### PR TITLE
Add `wct up` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Git worktree workflow automation CLI. Quickly create isolated development environments for different branches with pre-configured tooling, tmux sessions, and IDE integration.
 
+## Usage
+
+```bash
+wct open <branch>       # Create worktree, run setup, start tmux session, open IDE
+wct up                  # Start tmux session and open IDE in current directory
+wct close <branch>      # Kill tmux session and remove worktree
+wct list                # Show active worktrees with tmux session status
+wct init                # Generate a starter .wct.yaml config file
+```
+
 ## Installation
 
 ### Quick Install (Recommended)

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,0 +1,83 @@
+import { loadConfig } from "../config/loader";
+import { openIDE } from "../services/ide";
+import type { SetupEnv } from "../services/setup";
+import { createSession, formatSessionName } from "../services/tmux";
+import {
+	getCurrentBranch,
+	getMainWorktreePath,
+	isGitRepo,
+} from "../services/worktree";
+import * as logger from "../utils/logger";
+
+export async function upCommand(): Promise<void> {
+	if (!(await isGitRepo())) {
+		logger.error("Not a git repository");
+		process.exit(1);
+	}
+
+	const cwd = process.cwd();
+
+	const mainWorktreePath = await getMainWorktreePath();
+	if (!mainWorktreePath) {
+		logger.error("Could not determine main repository path");
+		process.exit(1);
+	}
+
+	const { config, errors } = await loadConfig(mainWorktreePath);
+	if (!config) {
+		for (const err of errors) {
+			logger.error(err);
+		}
+		process.exit(1);
+	}
+
+	const branch = await getCurrentBranch();
+	if (!branch) {
+		logger.error(
+			"Could not determine current branch (detached HEAD is not supported)",
+		);
+		process.exit(1);
+	}
+
+	const sessionName = formatSessionName(config.project_name, branch);
+
+	const env: SetupEnv = {
+		WCT_WORKTREE_DIR: cwd,
+		WCT_MAIN_DIR: mainWorktreePath,
+		WCT_BRANCH: branch,
+		WCT_PROJECT: config.project_name,
+	};
+
+	if (config.tmux) {
+		logger.info("Creating tmux session...");
+		const tmuxResult = await createSession(sessionName, cwd, config.tmux);
+
+		if (tmuxResult.success) {
+			if (tmuxResult.alreadyExists) {
+				logger.info(`Tmux session '${sessionName}' already exists`);
+			} else {
+				logger.success(`Created tmux session '${sessionName}'`);
+			}
+		} else {
+			logger.warn(`Failed to create tmux session: ${tmuxResult.error}`);
+		}
+	}
+
+	if (config.ide?.command) {
+		logger.info("Opening IDE...");
+		const ideResult = await openIDE(config.ide.command, env);
+
+		if (ideResult.success) {
+			logger.success("IDE opened");
+		} else {
+			logger.warn(`Failed to open IDE: ${ideResult.error}`);
+		}
+	}
+
+	logger.success(`Environment ready for '${branch}'`);
+	if (config.tmux) {
+		console.log(
+			`\nAttach to tmux session: ${logger.bold(`tmux attach -t ${sessionName}`)}`,
+		);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { closeCommand } from "./commands/close";
 import { initCommand } from "./commands/init";
 import { listCommand } from "./commands/list";
 import { openCommand } from "./commands/open";
+import { upCommand } from "./commands/up";
 import * as logger from "./utils/logger";
 
 const VERSION = "0.1.0";
@@ -15,6 +16,7 @@ Usage:
 
 Commands:
   open <branch>     Create worktree, run setup, start tmux session, open IDE
+  up                Start tmux session and open IDE in current directory
   close <branch>    Kill tmux session and remove worktree
   list              Show active worktrees with tmux session status
   init              Generate a starter .wct.yaml config file
@@ -30,6 +32,7 @@ Options:
 Examples:
   wct init                         Create a new .wct.yaml config file
   wct open feature-auth            Create new worktree and branch from HEAD
+  wct up                           Start tmux + IDE in current directory
   wct open feature-auth -e         Use existing branch
   wct open feature-auth -b main    Create new branch based on 'main'
   wct close feature-auth           Close worktree (with confirmation)
@@ -66,6 +69,10 @@ async function main(): Promise<void> {
 	switch (command) {
 		case "init":
 			await initCommand();
+			break;
+
+		case "up":
+			await upCommand();
 			break;
 
 		case "list":

--- a/src/services/worktree.ts
+++ b/src/services/worktree.ts
@@ -44,6 +44,27 @@ export async function getMainRepoPath(): Promise<string | null> {
 	}
 }
 
+export async function getCurrentBranch(): Promise<string | null> {
+	try {
+		const result = await $`git rev-parse --abbrev-ref HEAD`.quiet();
+		const branch = result.text().trim();
+		if (!branch || branch === "HEAD") {
+			return null;
+		}
+		return branch;
+	} catch {
+		return null;
+	}
+}
+
+export async function getMainWorktreePath(): Promise<string | null> {
+	const worktrees = await listWorktrees();
+	if (worktrees.length === 0) {
+		return null;
+	}
+	return worktrees[0].path;
+}
+
 export async function isGitRepo(): Promise<boolean> {
 	try {
 		await $`git rev-parse --git-dir`.quiet();

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import { upCommand } from "../src/commands/up";
+import {
+	getCurrentBranch,
+	getMainWorktreePath,
+} from "../src/services/worktree";
+
+describe("getCurrentBranch", () => {
+	test("returns current branch name in a git repo", async () => {
+		const branch = await getCurrentBranch();
+		expect(branch).not.toBeNull();
+		expect(typeof branch).toBe("string");
+		expect(branch?.length).toBeGreaterThan(0);
+	});
+
+	test("returns null on detached HEAD", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "wct-test-detached-"));
+		const originalDir = process.cwd();
+
+		try {
+			await $`git init -b main`.quiet().cwd(tempDir);
+			await $`git config user.email "test@test.com"`.quiet().cwd(tempDir);
+			await $`git config user.name "Test"`.quiet().cwd(tempDir);
+			await $`git config commit.gpgSign false`.quiet().cwd(tempDir);
+			await $`git commit --allow-empty -m "initial"`.quiet().cwd(tempDir);
+			const sha = await $`git rev-parse HEAD`.quiet().cwd(tempDir).text();
+			await $`git checkout ${sha.trim()}`.quiet().cwd(tempDir);
+
+			process.chdir(tempDir);
+			const branch = await getCurrentBranch();
+			expect(branch).toBeNull();
+		} finally {
+			process.chdir(originalDir);
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("getMainWorktreePath", () => {
+	let repoDir: string;
+	let worktreeDir: string;
+	const originalDir = process.cwd();
+
+	beforeAll(async () => {
+		repoDir = await realpath(
+			await mkdtemp(join(tmpdir(), "wct-test-main-wt-")),
+		);
+		worktreeDir = await realpath(await mkdtemp(join(tmpdir(), "wct-test-wt-")));
+
+		await $`git init -b main`.quiet().cwd(repoDir);
+		await $`git config user.email "test@test.com"`.quiet().cwd(repoDir);
+		await $`git config user.name "Test"`.quiet().cwd(repoDir);
+		await $`git config commit.gpgSign false`.quiet().cwd(repoDir);
+		await $`git commit --allow-empty -m "initial"`.quiet().cwd(repoDir);
+
+		const wtPath = join(worktreeDir, "feature-branch");
+		await $`git worktree add -b feature-branch ${wtPath}`.quiet().cwd(repoDir);
+	});
+
+	afterAll(async () => {
+		process.chdir(originalDir);
+		await $`git worktree remove ${join(worktreeDir, "feature-branch")}`
+			.quiet()
+			.cwd(repoDir)
+			.nothrow();
+		await rm(repoDir, { recursive: true, force: true });
+		await rm(worktreeDir, { recursive: true, force: true });
+	});
+
+	test("returns main repo path when run from main repo", async () => {
+		process.chdir(repoDir);
+		const result = await getMainWorktreePath();
+		expect(result).toBe(repoDir);
+	});
+
+	test("returns main repo path when run from a worktree", async () => {
+		const wtPath = join(worktreeDir, "feature-branch");
+		process.chdir(wtPath);
+		const result = await getMainWorktreePath();
+		expect(result).toBe(repoDir);
+	});
+});
+
+describe("upCommand", () => {
+	test("is exported as a function", () => {
+		expect(typeof upCommand).toBe("function");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `wct up` command that starts tmux session and opens IDE in the current directory — no worktree creation, copy, or setup steps
- Add `getCurrentBranch()` and `getMainWorktreePath()` helpers to resolve the current branch and the true main worktree path (works correctly from any worktree, not just the main repo)
- Handle detached HEAD gracefully (returns clear error instead of creating a session named `project-HEAD`)

## Test plan
- [x] `bun test` — 96 tests pass (6 new: detached HEAD, main worktree path from repo, main worktree path from worktree, getCurrentBranch happy path, upCommand export, plus existing)
- [x] `bunx biome check` — lint/format clean
- [x] Manual: `bun run index.ts up` from repo root
- [ ] Manual: `bun run index.ts up` from a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)