### PR TITLE
Fix tmux session name collision from prefix matching

### DIFF
--- a/src/services/tmux.ts
+++ b/src/services/tmux.ts
@@ -35,7 +35,7 @@ export async function listSessions(): Promise<TmuxSession[]> {
 
 export async function sessionExists(name: string): Promise<boolean> {
 	try {
-		await $`tmux has-session -t ${`=${name}`}`.quiet();
+		await $`tmux has-session -t =${name}`.quiet();
 		return true;
 	} catch {
 		return false;
@@ -257,7 +257,7 @@ export interface KillSessionResult {
 
 export async function killSession(name: string): Promise<KillSessionResult> {
 	try {
-		await $`tmux kill-session -t ${`=${name}`}`.quiet();
+		await $`tmux kill-session -t =${name}`.quiet();
 		return { success: true, sessionName: name };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -288,7 +288,7 @@ export async function switchSession(
 	name: string,
 ): Promise<SwitchSessionResult> {
 	try {
-		await $`tmux switch-client -t ${`=${name}`}`.quiet();
+		await $`tmux switch-client -t =${name}`.quiet();
 		return { success: true, sessionName: name };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- tmux's `-t` flag does prefix matching by default, so `tmux has-session -t wct` matches `wct-feature-test`
- This caused `wct up` from the main repo to falsely report "session already exists" when only a worktree session was running
- Use tmux's `=` prefix for exact name matching in `sessionExists`, `killSession`, and `switchSession`

## Test plan
- [x] `bun test` — all 105 tests pass
- [x] Manual: `wct open feature/test` creates `testproj-feature-test`, then `wct up` from main repo correctly creates separate `testproj` session
- [x] Manual: `wct up` run twice correctly reports "already exists" on exact match
- [x] Manual: `wct down` only kills the exact session, leaves prefix-matching sessions intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)