### PR TITLE
Fix close command completions to only show worktree branches

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -11,6 +11,7 @@ export interface CommandDef {
   description: string;
   args?: string;
   options?: CommandOption[];
+  completionType?: "branch" | "worktree";
 }
 
 export const COMMANDS: CommandDef[] = [
@@ -58,6 +59,7 @@ export const COMMANDS: CommandDef[] = [
     name: "close",
     description: "Kill tmux session and remove worktree",
     args: "<branch>",
+    completionType: "worktree",
     options: [
       {
         name: "yes",


### PR DESCRIPTION
## Summary
- `wct close` tab completion was suggesting all git branches; now it only suggests branches with active worktrees
- Added `completionType` field to `CommandDef` in the registry
- Added `__wct_worktree_branches` shell helpers for fish, bash, and zsh that parse `git worktree list --porcelain` output

## Test plan
- [ ] Run `wct completions fish | source` and verify `wct close <TAB>` only shows branches with worktrees
- [ ] Verify `wct open <TAB>` still shows all branches
- [ ] Run `bun test` — all 105 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)