### PR TITLE
Add Bun test coverage to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,13 @@ jobs:
       - name: Run linter
         run: bun run lint
 
-      - name: Run tests
-        run: bun test
+      - name: Run tests with coverage
+        run: bun run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
     "lint": "bunx biome check",
     "format": "bunx biome check --write",
     "build": "bun build src/index.ts --compile --outfile dist/wct",


### PR DESCRIPTION
## Summary
- add a test:coverage script using Bun coverage with text and lcov reporters
- run tests with coverage in the test GitHub Action workflow
- upload coverage/lcov.info as an artifact for CI inspection

## Validation
- bun run test:coverage
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test coverage reporting with artifact uploads to the CI/CD pipeline.

* **Chores**
  * Introduced new test coverage script for local development and automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->