### PR TITLE
feat: work without .wct.yaml using sensible defaults

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,6 +5,12 @@ import { resolveConfig, validateConfig } from "./validator";
 
 const CONFIG_FILENAME = ".wct.yaml";
 
+const DEFAULT_CONFIG: WctConfig = {
+  worktree_dir: "..",
+  ide: { command: "code $WCT_WORKTREE_DIR" },
+  tmux: { windows: [{ name: "main" }] },
+};
+
 export function expandTilde(path: string): string {
   if (path.startsWith("~/")) {
     return join(homedir(), path.slice(2));
@@ -78,16 +84,10 @@ export async function loadConfig(
   const hasProjectConfig = projectConfig !== null;
   const hasGlobalConfig = globalConfig !== null;
 
-  if (!hasProjectConfig && !hasGlobalConfig) {
-    return {
-      config: null,
-      errors: ["No config file found. Run 'wct init' to create one."],
-      hasProjectConfig,
-      hasGlobalConfig,
-    };
-  }
-
-  const merged = mergeConfigs(globalConfig, projectConfig);
+  const merged =
+    hasProjectConfig || hasGlobalConfig
+      ? mergeConfigs(globalConfig, projectConfig)
+      : DEFAULT_CONFIG;
   const validation = validateConfig(merged);
 
   if (!validation.valid) {
@@ -125,4 +125,4 @@ export function resolveWorktreePath(
   );
 }
 
-export { CONFIG_FILENAME };
+export { CONFIG_FILENAME, DEFAULT_CONFIG };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_CONFIG,
   expandTilde,
   resolveWorktreePath,
   slugifyBranch,
@@ -363,6 +364,22 @@ describe("slugifyBranch", () => {
 
   test("handles nested slashes", () => {
     expect(slugifyBranch("feature/auth/login")).toBe("feature-auth-login");
+  });
+});
+
+describe("DEFAULT_CONFIG", () => {
+  test("uses parent directory as worktree_dir", () => {
+    expect(DEFAULT_CONFIG.worktree_dir).toBe("..");
+  });
+
+  test("opens VS Code with worktree path as default IDE", () => {
+    expect(DEFAULT_CONFIG.ide?.command).toBe("code $WCT_WORKTREE_DIR");
+  });
+
+  test("creates a single empty tmux window by default", () => {
+    expect(DEFAULT_CONFIG.tmux?.windows).toHaveLength(1);
+    expect(DEFAULT_CONFIG.tmux?.windows?.[0].name).toBe("main");
+    expect(DEFAULT_CONFIG.tmux?.windows?.[0].command).toBeUndefined();
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   DEFAULT_CONFIG,
   expandTilde,
+  loadConfig,
   resolveWorktreePath,
   slugifyBranch,
 } from "../src/config/loader";
@@ -380,6 +381,28 @@ describe("DEFAULT_CONFIG", () => {
     expect(DEFAULT_CONFIG.tmux?.windows).toHaveLength(1);
     expect(DEFAULT_CONFIG.tmux?.windows?.[0].name).toBe("main");
     expect(DEFAULT_CONFIG.tmux?.windows?.[0].command).toBeUndefined();
+  });
+
+  test("loadConfig returns default config when no config files are present", async () => {
+    const noConfigFile = { exists: async () => false } as ReturnType<
+      typeof Bun.file
+    >;
+    const spy = spyOn(Bun, "file").mockImplementation(() => noConfigFile);
+
+    try {
+      const result = await loadConfig("/tmp/wct-test-no-config");
+
+      expect(result.config).not.toBeNull();
+      expect(result.config?.worktree_dir).toBe(DEFAULT_CONFIG.worktree_dir);
+      expect(result.config?.ide?.command).toBe(DEFAULT_CONFIG.ide?.command);
+      expect(result.config?.tmux?.windows).toHaveLength(1);
+      expect(result.config?.tmux?.windows?.[0].name).toBe(
+        DEFAULT_CONFIG.tmux?.windows?.[0].name,
+      );
+      expect(result.config?.tmux?.windows?.[0].command).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
When no config file exists (neither project nor global), wct now falls
back to built-in defaults instead of exiting with an error:

- worktree_dir: ".." (worktrees placed as siblings of the main repo)
- ide: "code $WCT_WORKTREE_DIR" (open VS Code at the worktree path)
- tmux: single window named "main" with no command

Existing configs are unaffected; defaults only apply when no config
file is found at all.

https://claude.ai/code/session_01CxmUK3FGsJbNCvgj6JCGQK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration system now falls back to sensible defaults when no project or global configuration files are found, instead of returning an error.

* **New Features**
  * Default configuration object is now publicly available for consumers.

* **Tests**
  * Added tests validating default configuration values for workspace directory, IDE command, and tmux window setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->