### PR TITLE
[codex] TUI active styling and layout updates

### DIFF
--- a/docs/superpowers/plans/2026-04-08-tui-active-styling.md
+++ b/docs/superpowers/plans/2026-04-08-tui-active-styling.md
@@ -1,0 +1,310 @@
+# TUI Active Styling & Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace inverse-background selection with bold text, add ellipsis truncation for long branches, and move git stats to a second line shown only when selected/expanded.
+
+**Architecture:** All changes are in 4 TUI component files. A `truncateBranch` helper is added inline in `WorktreeItem.tsx`. Terminal width is threaded from `App.tsx` → `TreeView` → `WorktreeItem`.
+
+**Tech Stack:** React (Ink), TypeScript, Vitest
+
+---
+
+### Task 1: Remove inverse styling from RepoNode
+
+**Files:**
+- Modify: `src/tui/components/RepoNode.tsx:26-27`
+
+- [ ] **Step 1: Remove `inverse` from RepoNode**
+
+In `src/tui/components/RepoNode.tsx`, change the `<Text>` element that renders the project name:
+
+```tsx
+      <Text
+        color={isSelected ? "cyan" : "yellow"}
+        bold={isSelected}
+      >
+```
+
+Remove `inverse={isSelected}` — only `bold` and `color` remain.
+
+- [ ] **Step 2: Verify visually**
+
+Run: `bun run src/index.ts tui`
+
+Confirm that navigating to a repo node shows it in bold cyan text without a background highlight.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/components/RepoNode.tsx
+git commit -m "tui: replace inverse with bold for active repo node"
+```
+
+---
+
+### Task 2: Remove inverse styling and add truncation to WorktreeItem
+
+**Files:**
+- Modify: `src/tui/components/WorktreeItem.tsx`
+- Modify: `src/tui/components/TreeView.tsx`
+- Modify: `src/tui/App.tsx`
+
+- [ ] **Step 1: Add `maxWidth` prop to WorktreeItem and implement truncation**
+
+In `src/tui/components/WorktreeItem.tsx`, add `maxWidth` to the `Props` interface:
+
+```tsx
+interface Props {
+  branch: string;
+  hasSession: boolean;
+  isAttached: boolean;
+  sync: string;
+  changedFiles: number;
+  notifications: number;
+  isSelected: boolean;
+  pendingStatus?: "opening" | "closing" | "starting";
+  isExpanded?: boolean;
+  hasExpandableData?: boolean;
+  maxWidth: number;
+}
+```
+
+Add a truncation helper before the component function:
+
+```tsx
+function truncateBranch(branch: string, available: number): string {
+  if (branch.length <= available) return branch;
+  if (available <= 3) return branch.slice(0, Math.max(1, available));
+  return `${branch.slice(0, available - 3)}...`;
+}
+```
+
+- [ ] **Step 2: Apply truncation and remove inverse in the main return**
+
+Inside the `WorktreeItem` component, compute the truncated branch name and remove `inverse`:
+
+```tsx
+  // prefix=4, indicator=2, expandIcon=0or2, attached=0or2, margin=2
+  const overhead = 4 + 2 + (expandIcon ? 2 : 0) + (isAttached ? 2 : 0) + 2;
+  const available = Math.max(10, maxWidth - overhead);
+  const displayBranch = truncateBranch(branch, available);
+```
+
+Change the branch `<Text>` element (around line 75-82) — remove `inverse={isSelected}`:
+
+```tsx
+      <Text
+        color={isSelected ? "cyan" : undefined}
+        bold={isSelected}
+      >
+        {" "}
+        {displayBranch}
+      </Text>
+```
+
+Also apply `displayBranch` in the `pendingStatus === "opening"` and `pendingStatus === "closing"` return paths (replace `{branch}` with `{displayBranch}`). Note: the truncation values must be computed before the early returns, so move the overhead/available/displayBranch calculation to the top of the component body, right after the existing local variables.
+
+- [ ] **Step 3: Thread `maxWidth` through TreeView**
+
+In `src/tui/components/TreeView.tsx`, add `maxWidth: number` to the `Props` interface:
+
+```tsx
+interface Props {
+  repos: RepoInfo[];
+  sessions: Array<{ name: string; attached: boolean }>;
+  queueItems: QueueItem[];
+  expandedRepos: Set<string>;
+  selectedIndex: number;
+  items: TreeItem[];
+  pendingActions: Map<string, PendingAction>;
+  prData: Map<string, PRInfo>;
+  panes: Map<string, PaneInfo[]>;
+  expandedWorktreeKey: string | null;
+  maxWidth: number;
+}
+```
+
+Pass it to every `<WorktreeItem>` render (both the normal and phantom renders):
+
+```tsx
+        <WorktreeItem
+          ...existing props...
+          maxWidth={maxWidth}
+        />
+```
+
+There are 3 `<WorktreeItem>` renders in `TreeView.tsx` — add `maxWidth={maxWidth}` to all three.
+
+- [ ] **Step 4: Pass terminal columns from App.tsx to TreeView**
+
+In `src/tui/App.tsx`, the component already has `const { stdout } = useStdout();`. Add columns:
+
+```tsx
+  const termCols = stdout?.columns ?? 80;
+```
+
+Pass it to `<TreeView>`:
+
+```tsx
+        <TreeView
+          ...existing props...
+          maxWidth={termCols}
+        />
+```
+
+- [ ] **Step 5: Verify visually**
+
+Run: `bun run src/index.ts tui`
+
+Confirm:
+- Selected branches show bold cyan text, no background highlight
+- If you have a long branch name, it truncates with `...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/components/WorktreeItem.tsx src/tui/components/TreeView.tsx src/tui/App.tsx
+git commit -m "tui: replace inverse with bold, add branch name truncation"
+```
+
+---
+
+### Task 3: Move git stats to second line
+
+**Files:**
+- Modify: `src/tui/components/WorktreeItem.tsx`
+
+- [ ] **Step 1: Add `isExpanded` check and restructure layout**
+
+The component already receives `isExpanded` as a prop. Change the main return block to wrap everything in a `<Box flexDirection="column">` and conditionally render stats on a second line.
+
+Replace the main return (the final `return` statement, not the early returns for pending states) with:
+
+```tsx
+  const showStats = isSelected || isExpanded;
+  const hasStats =
+    (sync && sync !== "\u2713") || changedFiles > 0 || notifications > 0;
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+        {expandIcon ? <Text dimColor>{expandIcon}</Text> : null}
+        <Text color={indicatorColor}>
+          {indicator}
+          {pendingStatus === "starting" ? (
+            <Text dimColor> starting...</Text>
+          ) : null}
+        </Text>
+        <Text
+          color={isSelected ? "cyan" : undefined}
+          bold={isSelected}
+        >
+          {" "}
+          {displayBranch}
+        </Text>
+        <Text dimColor>{attached}</Text>
+      </Box>
+      {showStats && hasStats ? (
+        <Box>
+          <Text>{"        "}</Text>
+          {sync && sync !== "\u2713" ? <Text dimColor>{sync}</Text> : null}
+          {changedFiles > 0 ? (
+            <Text color="yellow">
+              {sync && sync !== "\u2713" ? " " : ""}~{changedFiles}
+            </Text>
+          ) : null}
+          {notifications > 0 ? (
+            <Text color="yellow">
+              {(sync && sync !== "\u2713") || changedFiles > 0 ? " " : ""}!
+              {notifications}
+            </Text>
+          ) : null}
+        </Box>
+      ) : null}
+    </Box>
+  );
+```
+
+This removes the inline stats from the branch line and renders them on a second line only when `showStats && hasStats`.
+
+- [ ] **Step 2: Verify visually**
+
+Run: `bun run src/index.ts tui`
+
+Confirm:
+- Unselected branches show only the branch name, no stats
+- Selected branches show stats on a second indented line
+- Expanded branches (right arrow) also show stats on second line
+- If a branch has no stats (no sync diff, no changes, no notifications), no second line appears
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/components/WorktreeItem.tsx
+git commit -m "tui: move git stats to second line, show only when active/expanded"
+```
+
+---
+
+### Task 4: Add tests for truncateBranch
+
+**Files:**
+- Create: `tests/tui/worktree-item.test.ts`
+- Modify: `src/tui/components/WorktreeItem.tsx` (export `truncateBranch`)
+
+- [ ] **Step 1: Export `truncateBranch` from WorktreeItem**
+
+In `src/tui/components/WorktreeItem.tsx`, change the function declaration to be exported:
+
+```tsx
+export function truncateBranch(branch: string, available: number): string {
+```
+
+- [ ] **Step 2: Write tests**
+
+Create `tests/tui/worktree-item.test.ts`:
+
+```typescript
+import { describe, expect, test } from "vitest";
+import { truncateBranch } from "../../src/tui/components/WorktreeItem";
+
+describe("truncateBranch", () => {
+  test("returns branch unchanged when it fits", () => {
+    expect(truncateBranch("feat/auth", 20)).toBe("feat/auth");
+  });
+
+  test("returns branch unchanged when exactly at limit", () => {
+    expect(truncateBranch("feat/auth", 9)).toBe("feat/auth");
+  });
+
+  test("truncates with ellipsis when too long", () => {
+    expect(truncateBranch("feature/very-long-branch-name", 15)).toBe(
+      "feature/very...",
+    );
+  });
+
+  test("handles very small available space", () => {
+    expect(truncateBranch("feature/branch", 3)).toBe("...");
+  });
+
+  test("handles available less than 3", () => {
+    const result = truncateBranch("feature/branch", 2);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `bun run test`
+
+Expected: All tests pass, including the new `truncateBranch` tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/components/WorktreeItem.tsx tests/tui/worktree-item.test.ts
+git commit -m "tui: add tests for truncateBranch helper"
+```

--- a/docs/superpowers/specs/2026-04-08-tui-active-styling-design.md
+++ b/docs/superpowers/specs/2026-04-08-tui-active-styling-design.md
@@ -1,0 +1,66 @@
+# TUI Active Styling & Layout Improvements
+
+## Summary
+
+Three changes to the TUI tree view:
+
+1. **Bold instead of inverse** for active/selected items
+2. **Ellipsis truncation** for long branch names that exceed terminal width
+3. **Git stats on second line**, only visible when branch is selected or expanded
+
+## Changes
+
+### 1. Active Styling
+
+Remove `inverse={isSelected}` from `WorktreeItem` and `RepoNode`. Keep `bold={isSelected}` and `color={isSelected ? "cyan" : ...}`.
+
+**Files:** `src/tui/components/WorktreeItem.tsx`, `src/tui/components/RepoNode.tsx`
+
+### 2. Branch Name Truncation
+
+`WorktreeItem` receives a `maxWidth` prop (terminal columns from `stdout.columns`).
+
+Available space for the branch name is calculated by subtracting fixed-width elements:
+- Prefix: 4 chars (`"❯   "` or `"    "`)
+- Expand icon: 2 chars (when present)
+- Indicator: 2 chars (`"● "` or `"○ "`)
+- Attached marker: 2 chars (when present)
+- Right margin buffer: 2 chars
+
+If `branch.length` exceeds the available space, slice to `(available - 3)` and append `...`.
+
+**Prop threading:** `App.tsx` reads `stdout.columns` (already has `useStdout()`), passes through `TreeView` props to `WorktreeItem`.
+
+**Files:** `src/tui/App.tsx`, `src/tui/components/TreeView.tsx`, `src/tui/components/WorktreeItem.tsx`
+
+### 3. Git Stats on Second Line
+
+When `isSelected || isExpanded`, render sync status, changed files count, and notification count on a second `<Box>` row. When neither condition is true, hide stats entirely.
+
+Second line layout:
+```
+❯   ● feature/my-branch *
+        ↑2 ~3 !1
+```
+
+Indentation: 8 spaces (aligns past `"❯   ● "`).
+
+Stats elements (only rendered when non-empty):
+- Sync status (e.g., `↑2`)
+- Changed files (e.g., `~3`)
+- Notifications (e.g., `!1`)
+
+If all stats are empty, no second line is rendered even when selected/expanded.
+
+The `WorktreeItem` component changes from returning a single `<Box>` to returning a `<Box flexDirection="column">` wrapper containing the branch line and the optional stats line.
+
+**Files:** `src/tui/components/WorktreeItem.tsx`
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/tui/components/WorktreeItem.tsx` | Remove inverse, add truncation, add stats second line |
+| `src/tui/components/RepoNode.tsx` | Remove inverse |
+| `src/tui/components/TreeView.tsx` | Pass `maxWidth` to `WorktreeItem` |
+| `src/tui/App.tsx` | Read `stdout.columns`, pass to `TreeView` |

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -140,6 +140,7 @@ function buildTreeItems({
 export function App() {
   const { exit } = useApp();
   const { stdout } = useStdout();
+  const termCols = stdout?.columns ?? 80;
   const termRows = stdout?.rows ?? 24;
   const { repos, loading, refresh: refreshRegistry } = useRegistry();
   const { items: queueItems, refresh: refreshQueue } = useQueue();
@@ -658,6 +659,7 @@ export function App() {
           prData={prData}
           panes={panes}
           expandedWorktreeKey={expandedWorktreeKey}
+          maxWidth={termCols}
         />
       </Box>
       {mode.type === "OpenModal" ? (

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function DetailRow({ kind, label, isSelected, meta }: Props) {
-  const prefix = isSelected ? "❯ " : "  ";
+  const prefix = isSelected ? "▸ " : "  ";
   const indent =
     kind === "notification-header" || kind === "pr" || kind === "pane-header"
       ? "      " // section header: 6 spaces
@@ -38,7 +38,7 @@ export function DetailRow({ kind, label, isSelected, meta }: Props) {
       return (
         <Box>
           <Text>{indent}</Text>
-          <Text color={isSelected ? "cyan" : "red"}>
+          <Text color={isSelected ? "cyan" : "red"} bold={isSelected}>
             {prefix}! {label}
           </Text>
           {meta?.paneRef && <Text dimColor> (pane {meta.paneRef})</Text>}
@@ -62,9 +62,14 @@ export function DetailRow({ kind, label, isSelected, meta }: Props) {
       return (
         <Box>
           <Text>{indent}</Text>
-          <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+          <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+            {prefix}
+          </Text>
           <Text color={color}>{icon}</Text>
-          <Text color={isSelected ? "cyan" : "dim"}> {label}</Text>
+          <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
+            {" "}
+            {label}
+          </Text>
         </Box>
       );
     }
@@ -73,7 +78,7 @@ export function DetailRow({ kind, label, isSelected, meta }: Props) {
       return (
         <Box>
           <Text>{indent}</Text>
-          <Text color={isSelected ? "cyan" : "dim"}>
+          <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
             {prefix}
             {label}
           </Text>

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -62,7 +62,7 @@ export function DetailRow({ kind, label, isSelected, meta }: Props) {
       return (
         <Box>
           <Text>{indent}</Text>
-          <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+          <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
             {prefix}
           </Text>
           <Text color={color}>{icon}</Text>

--- a/src/tui/components/RepoNode.tsx
+++ b/src/tui/components/RepoNode.tsx
@@ -21,11 +21,7 @@ export function RepoNode({
   return (
     <Box>
       <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
-      <Text
-        color={isSelected ? "cyan" : "yellow"}
-        bold={isSelected}
-        inverse={isSelected}
-      >
+      <Text color={isSelected ? "cyan" : "yellow"} bold={isSelected}>
         {arrow} {project}
       </Text>
       <Text dimColor>{suffix}</Text>

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -27,6 +27,7 @@ interface Props {
   prData: Map<string, PRInfo>;
   panes: Map<string, PaneInfo[]>;
   expandedWorktreeKey: string | null;
+  maxWidth: number;
 }
 
 export function TreeView({
@@ -40,6 +41,7 @@ export function TreeView({
   prData,
   panes,
   expandedWorktreeKey,
+  maxWidth,
 }: Props) {
   const sessionMap = useMemo(
     () => new Map(sessions.map((s) => [s.name, s])),
@@ -138,6 +140,7 @@ export function TreeView({
         pendingStatus={pending?.type}
         isExpanded={expandedWorktreeKey === wtKey}
         hasExpandableData={!!hasExpandableData}
+        maxWidth={maxWidth}
       />,
     );
 
@@ -162,6 +165,7 @@ export function TreeView({
               notifications={0}
               isSelected={false}
               pendingStatus="opening"
+              maxWidth={maxWidth}
             />,
           );
         }
@@ -187,6 +191,7 @@ export function TreeView({
           notifications={0}
           isSelected={false}
           pendingStatus="opening"
+          maxWidth={maxWidth}
         />,
       );
     }

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -14,9 +14,9 @@ interface Props {
   maxWidth: number;
 }
 
-function truncateBranch(branch: string, available: number): string {
+export function truncateBranch(branch: string, available: number): string {
   if (branch.length <= available) return branch;
-  if (available <= 3) return branch.slice(0, Math.max(1, available));
+  if (available <= 3) return ".".repeat(Math.max(0, available));
   return `${branch.slice(0, available - 3)}...`;
 }
 

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -21,7 +21,7 @@ export function truncateBranch(branch: string, available: number): string {
 }
 
 function branchBudget(maxWidth: number, overhead: number): number {
-  return Math.max(10, maxWidth - overhead);
+  return Math.max(0, maxWidth - overhead);
 }
 
 export function WorktreeItem({

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -11,6 +11,13 @@ interface Props {
   pendingStatus?: "opening" | "closing" | "starting";
   isExpanded?: boolean;
   hasExpandableData?: boolean;
+  maxWidth: number;
+}
+
+function truncateBranch(branch: string, available: number): string {
+  if (branch.length <= available) return branch;
+  if (available <= 3) return branch.slice(0, Math.max(1, available));
+  return `${branch.slice(0, available - 3)}...`;
 }
 
 export function WorktreeItem({
@@ -24,6 +31,7 @@ export function WorktreeItem({
   pendingStatus,
   isExpanded,
   hasExpandableData,
+  maxWidth,
 }: Props) {
   const indicator = hasSession ? "\u25CF" : "\u25CB";
   const indicatorColor = hasSession ? "green" : "gray";
@@ -37,6 +45,10 @@ export function WorktreeItem({
       : "";
 
   const prefix = isSelected ? "❯   " : "    ";
+  // prefix=4, indicator=2, expandIcon=0or2, attached=0or2, margin=2
+  const overhead = 4 + 2 + (expandIcon ? 2 : 0) + (isAttached ? 2 : 0) + 2;
+  const available = Math.max(10, maxWidth - overhead);
+  const displayBranch = truncateBranch(branch, available);
 
   if (pendingStatus === "opening") {
     return (
@@ -44,7 +56,7 @@ export function WorktreeItem({
         <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
         <Text color="yellow">
           <Text italic>
-            {"\u25CB"} {branch} opening...
+            {"\u25CB"} {displayBranch} opening...
           </Text>
         </Text>
       </Box>
@@ -56,7 +68,7 @@ export function WorktreeItem({
       <Box>
         <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
         <Text dimColor>
-          {indicator} {branch} closing...
+          {indicator} {displayBranch} closing...
         </Text>
       </Box>
     );
@@ -72,13 +84,9 @@ export function WorktreeItem({
           <Text dimColor> starting...</Text>
         ) : null}
       </Text>
-      <Text
-        color={isSelected ? "cyan" : undefined}
-        bold={isSelected}
-        inverse={isSelected}
-      >
+      <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
         {" "}
-        {branch}
+        {displayBranch}
       </Text>
       <Text dimColor>{attached}</Text>
       {sync && sync !== "\u2713" ? <Text dimColor> {sync}</Text> : null}

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -40,8 +40,6 @@ export function WorktreeItem({
   const indicator = hasSession ? "\u25CF" : "\u25CB";
   const indicatorColor = hasSession ? "green" : "gray";
   const attached = isAttached ? " *" : "";
-  const notifText = notifications > 0 ? ` !${notifications}` : "";
-  const changesText = changedFiles > 0 ? ` ~${changedFiles}` : "";
   const expandIcon = isExpanded
     ? "\u25BC "
     : hasExpandableData
@@ -64,11 +62,7 @@ export function WorktreeItem({
     ),
   );
   const mainSuffix =
-    attached +
-    (sync && sync !== "\u2713" ? ` ${sync}` : "") +
-    changesText +
-    notifText +
-    (pendingStatus === "starting" ? " starting..." : "");
+    attached + (pendingStatus === "starting" ? " starting..." : "");
   const mainDisplayBranch = truncateBranch(
     branch,
     branchBudget(

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -20,6 +20,10 @@ function truncateBranch(branch: string, available: number): string {
   return `${branch.slice(0, available - 3)}...`;
 }
 
+function branchBudget(maxWidth: number, overhead: number): number {
+  return Math.max(10, maxWidth - overhead);
+}
+
 export function WorktreeItem({
   branch,
   hasSession,
@@ -45,10 +49,37 @@ export function WorktreeItem({
       : "";
 
   const prefix = isSelected ? "❯   " : "    ";
-  // prefix=4, indicator=2, expandIcon=0or2, attached=0or2, margin=2
-  const overhead = 4 + 2 + (expandIcon ? 2 : 0) + (isAttached ? 2 : 0) + 2;
-  const available = Math.max(10, maxWidth - overhead);
-  const displayBranch = truncateBranch(branch, available);
+  const openingDisplayBranch = truncateBranch(
+    branch,
+    branchBudget(
+      maxWidth,
+      prefix.length + "\u25CB ".length + " opening...".length,
+    ),
+  );
+  const closingDisplayBranch = truncateBranch(
+    branch,
+    branchBudget(
+      maxWidth,
+      prefix.length + `${indicator} `.length + " closing...".length,
+    ),
+  );
+  const mainSuffix =
+    attached +
+    (sync && sync !== "\u2713" ? ` ${sync}` : "") +
+    changesText +
+    notifText +
+    (pendingStatus === "starting" ? " starting..." : "");
+  const mainDisplayBranch = truncateBranch(
+    branch,
+    branchBudget(
+      maxWidth,
+      prefix.length +
+        expandIcon.length +
+        indicator.length +
+        1 +
+        mainSuffix.length,
+    ),
+  );
 
   if (pendingStatus === "opening") {
     return (
@@ -56,7 +87,7 @@ export function WorktreeItem({
         <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
         <Text color="yellow">
           <Text italic>
-            {"\u25CB"} {displayBranch} opening...
+            {"\u25CB"} {openingDisplayBranch} opening...
           </Text>
         </Text>
       </Box>
@@ -68,7 +99,7 @@ export function WorktreeItem({
       <Box>
         <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
         <Text dimColor>
-          {indicator} {displayBranch} closing...
+          {indicator} {closingDisplayBranch} closing...
         </Text>
       </Box>
     );
@@ -86,7 +117,7 @@ export function WorktreeItem({
       </Text>
       <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
         {" "}
-        {displayBranch}
+        {mainDisplayBranch}
       </Text>
       <Text dimColor>{attached}</Text>
       {sync && sync !== "\u2713" ? <Text dimColor> {sync}</Text> : null}

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -80,6 +80,9 @@ export function WorktreeItem({
         mainSuffix.length,
     ),
   );
+  const showStats = isSelected || isExpanded;
+  const hasStats =
+    (sync && sync !== "\u2713") || changedFiles > 0 || notifications > 0;
 
   if (pendingStatus === "opening") {
     return (
@@ -106,23 +109,39 @@ export function WorktreeItem({
   }
 
   return (
-    <Box>
-      <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
-      {expandIcon ? <Text dimColor>{expandIcon}</Text> : null}
-      <Text color={indicatorColor}>
-        {indicator}
-        {pendingStatus === "starting" ? (
-          <Text dimColor> starting...</Text>
-        ) : null}
-      </Text>
-      <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
-        {" "}
-        {mainDisplayBranch}
-      </Text>
-      <Text dimColor>{attached}</Text>
-      {sync && sync !== "\u2713" ? <Text dimColor> {sync}</Text> : null}
-      {changesText ? <Text color="yellow">{changesText}</Text> : null}
-      {notifText ? <Text color="yellow">{notifText}</Text> : null}
+    <Box flexDirection="column">
+      <Box>
+        <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+        {expandIcon ? <Text dimColor>{expandIcon}</Text> : null}
+        <Text color={indicatorColor}>
+          {indicator}
+          {pendingStatus === "starting" ? (
+            <Text dimColor> starting...</Text>
+          ) : null}
+        </Text>
+        <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+          {" "}
+          {mainDisplayBranch}
+        </Text>
+        <Text dimColor>{attached}</Text>
+      </Box>
+      {showStats && hasStats ? (
+        <Box>
+          <Text>{"        "}</Text>
+          {sync && sync !== "\u2713" ? <Text dimColor>{sync}</Text> : null}
+          {changedFiles > 0 ? (
+            <Text color="yellow">
+              {sync && sync !== "\u2713" ? " " : ""}~{changedFiles}
+            </Text>
+          ) : null}
+          {notifications > 0 ? (
+            <Text color="yellow">
+              {(sync && sync !== "\u2713") || changedFiles > 0 ? " " : ""}!
+              {notifications}
+            </Text>
+          ) : null}
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/tests/tui/worktree-item.test.ts
+++ b/tests/tui/worktree-item.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { truncateBranch } from "../../src/tui/components/WorktreeItem";
+
+describe("truncateBranch", () => {
+  test("returns branch unchanged when it fits", () => {
+    expect(truncateBranch("feat/auth", 20)).toBe("feat/auth");
+  });
+
+  test("returns branch unchanged when exactly at limit", () => {
+    expect(truncateBranch("feat/auth", 9)).toBe("feat/auth");
+  });
+
+  test("truncates with ellipsis when too long", () => {
+    expect(truncateBranch("feature/very-long-branch-name", 15)).toBe(
+      "feature/very...",
+    );
+  });
+
+  test("handles very small available space", () => {
+    expect(truncateBranch("feature/branch", 3)).toBe("...");
+  });
+
+  test("handles available less than 3", () => {
+    const result = truncateBranch("feature/branch", 2);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/tui/worktree-item.test.ts
+++ b/tests/tui/worktree-item.test.ts
@@ -21,7 +21,7 @@ describe("truncateBranch", () => {
   });
 
   test("handles available less than 3", () => {
-    const result = truncateBranch("feature/branch", 2);
-    expect(result.length).toBeLessThanOrEqual(2);
+    expect(truncateBranch("feature/branch", 2)).toBe("..");
+    expect(truncateBranch("feature/branch", 1)).toBe(".");
   });
 });

--- a/tests/tui/worktree-item.test.ts
+++ b/tests/tui/worktree-item.test.ts
@@ -24,4 +24,8 @@ describe("truncateBranch", () => {
     expect(truncateBranch("feature/branch", 2)).toBe("..");
     expect(truncateBranch("feature/branch", 1)).toBe(".");
   });
+
+  test("returns empty string when no space is available", () => {
+    expect(truncateBranch("feature/branch", 0)).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary
- replace inverse selection styling with bold cyan active styling in the TUI
- truncate long worktree branch names based on terminal width and handle narrow widths
- move worktree git stats to a second line for selected or expanded rows and add truncateBranch tests

## Validation
- manual test and lint runs were not executed here because AGENTS.md forbids running them manually
- added unit coverage for truncateBranch edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch names automatically truncate with ellipsis to fit terminal width
  * Git stats now display on a separate indented line when items are selected or expanded

* **Style**
  * Selected/active items use bold + color emphasis instead of inverse background
  * Selection prefix marker updated for clearer focus indication

* **Tests**
  * Added tests covering branch truncation across boundary and small-width cases

* **Documentation**
  * Added TUI active-styling design and implementation plan documents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->