### PR TITLE
TUI: add pane zoom/kill actions with zoom indicator

### DIFF
--- a/docs/superpowers/plans/2026-04-10-tui-pane-actions.md
+++ b/docs/superpowers/plans/2026-04-10-tui-pane-actions.md
@@ -1,0 +1,737 @@
+# TUI Pane Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add zoom toggle, kill actions, and zoom indicator for tmux panes in the TUI expanded worktree view.
+
+**Architecture:** Extend `TmuxPaneInfo` with zoom state from tmux, add `zoomPane`/`killPane` operations to the service layer, wire new `z`/`x` keybindings in expanded mode with a confirmation modal for kill, and render a magnifying glass icon on zoomed panes.
+
+**Tech Stack:** Effect, React/Ink, tmux CLI, vitest
+
+---
+
+### Task 1: Add zoom state to TmuxPaneInfo and update parser
+
+**Files:**
+- Modify: `src/services/tmux.ts:14-25` (TmuxPaneInfo interface)
+- Modify: `src/services/tmux.ts:106-124` (parsePaneListOutput)
+- Modify: `src/services/tmux.ts:477-489` (listPanesImpl format string)
+- Test: `tests/tmux.test.ts`
+
+- [ ] **Step 1: Write failing tests for updated parsePaneListOutput**
+
+Add to `tests/tmux.test.ts` inside the existing `parsePaneListOutput` describe block:
+
+```typescript
+test("parses pane list output with zoom flag", () => {
+  const output = "%0\t0\tbash\tshell\t1\n%1\t1\tvim\teditor\t0";
+  const panes = parsePaneListOutput(output);
+  expect(panes).toHaveLength(2);
+  expect(panes[0]).toEqual({
+    paneId: "%0",
+    paneIndex: 0,
+    command: "bash",
+    window: "shell",
+    zoomed: true,
+  });
+  expect(panes[1]).toEqual({
+    paneId: "%1",
+    paneIndex: 1,
+    command: "vim",
+    window: "editor",
+    zoomed: false,
+  });
+});
+
+test("defaults zoomed to false when flag is missing", () => {
+  const output = "%0\t0\tbash\tshell";
+  const panes = parsePaneListOutput(output);
+  expect(panes[0]).toEqual({
+    paneId: "%0",
+    paneIndex: 0,
+    command: "bash",
+    window: "shell",
+    zoomed: false,
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test`
+Expected: FAIL — `zoomed` property missing from parsed output.
+
+- [ ] **Step 3: Update TmuxPaneInfo and parsePaneListOutput**
+
+In `src/services/tmux.ts`, add `zoomed` to the interface:
+
+```typescript
+export interface TmuxPaneInfo {
+  paneId: string;
+  paneIndex: number;
+  command: string;
+  window: string;
+  zoomed: boolean;
+}
+```
+
+Update `parsePaneListOutput` to parse the fifth column:
+
+```typescript
+export function parsePaneListOutput(output: string): TmuxPaneInfo[] {
+  if (!output) return [];
+  return output
+    .split("\n")
+    .filter(Boolean)
+    .flatMap((line) => {
+      const [pid, pIdx, cmd, win, zoom] = line.split("\t");
+      return pid
+        ? [
+            {
+              paneId: pid,
+              paneIndex: Number(pIdx),
+              command: cmd || "",
+              window: win || "",
+              zoomed: zoom === "1",
+            },
+          ]
+        : [];
+    });
+}
+```
+
+Update `listPanesImpl` format string to include zoom flag:
+
+```typescript
+function listPanesImpl(sessionName: string) {
+  return Effect.catch(
+    execProcess("tmux", [
+      "list-panes",
+      "-s",
+      "-t",
+      `=${sessionName}`,
+      "-F",
+      "#{pane_id}\t#{pane_index}\t#{pane_current_command}\t#{window_name}\t#{window_zoomed_flag}",
+    ]).pipe(Effect.map((result) => parsePaneListOutput(result.stdout.trim()))),
+    () => Effect.succeed([] as TmuxPaneInfo[]),
+  );
+}
+```
+
+- [ ] **Step 4: Fix the existing parsePaneListOutput tests**
+
+The existing test at line 70 uses 4-column output. Update it to include the zoom column:
+
+```typescript
+test("parses pane list output", () => {
+  const output = "%0\t0\tbash\tshell\t0\n%1\t1\tvim\teditor\t0";
+  const panes = parsePaneListOutput(output);
+  expect(panes).toHaveLength(2);
+  expect(panes[0]).toEqual({
+    paneId: "%0",
+    paneIndex: 0,
+    command: "bash",
+    window: "shell",
+    zoomed: false,
+  });
+  expect(panes[1]).toEqual({
+    paneId: "%1",
+    paneIndex: 1,
+    command: "vim",
+    window: "editor",
+    zoomed: false,
+  });
+});
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/tmux.ts tests/tmux.test.ts
+git commit -m "feat(tmux): add zoomed state to TmuxPaneInfo"
+```
+
+---
+
+### Task 2: Add zoomPane and killPane to TmuxService
+
+**Files:**
+- Modify: `src/services/tmux.ts:36-87` (TmuxService interface)
+- Modify: `src/services/tmux.ts:522-619` (liveTmuxService)
+
+- [ ] **Step 1: Add zoomPane and killPane to the TmuxService interface**
+
+Add two new methods to the `TmuxService` interface in `src/services/tmux.ts`:
+
+```typescript
+zoomPane: (
+  paneId: string,
+) => Effect.Effect<void, WctError, WctRuntimeServices>;
+killPane: (
+  paneId: string,
+) => Effect.Effect<void, WctError, WctRuntimeServices>;
+```
+
+- [ ] **Step 2: Add implementation functions**
+
+Add after `killSessionImpl` (around line 430):
+
+```typescript
+function zoomPaneImpl(paneId: string) {
+  return execProcess("tmux", ["resize-pane", "-Z", "-t", paneId]).pipe(
+    Effect.asVoid,
+  );
+}
+
+function killPaneImpl(paneId: string) {
+  return execProcess("tmux", ["kill-pane", "-t", paneId]).pipe(Effect.asVoid);
+}
+```
+
+- [ ] **Step 3: Wire into liveTmuxService**
+
+Add to the `liveTmuxService` object:
+
+```typescript
+zoomPane: (paneId) =>
+  Effect.mapError(zoomPaneImpl(paneId), (error) =>
+    commandError("tmux_error", `Failed to zoom pane '${paneId}'`, error),
+  ),
+killPane: (paneId) =>
+  Effect.mapError(killPaneImpl(paneId), (error) =>
+    commandError(
+      "tmux_error",
+      `Failed to kill pane '${paneId}': ${getProcessErrorMessage(error)}`,
+      error,
+    ),
+  ),
+```
+
+- [ ] **Step 4: Run tests to verify nothing is broken**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/tmux.ts
+git commit -m "feat(tmux): add zoomPane and killPane service methods"
+```
+
+---
+
+### Task 3: Expose zoomPane and killPane in useTmux hook
+
+**Files:**
+- Modify: `src/tui/hooks/useTmux.ts`
+- Test: `tests/tui/use-tmux.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the existing `useTmux hook` describe block in `tests/tui/use-tmux.test.ts`:
+
+```typescript
+test("zoomPane returns false when no active client exists", async () => {
+  mockRunPromise
+    .mockResolvedValueOnce([]) // listClients
+    .mockResolvedValueOnce(null); // listSessions
+
+  const harness = await renderUseTmux();
+  await flush(10);
+
+  const result = await harness.value.zoomPane("%0");
+  expect(result).toBe(false);
+
+  harness.unmount();
+});
+
+test("killPane returns false when no active client exists", async () => {
+  mockRunPromise
+    .mockResolvedValueOnce([]) // listClients
+    .mockResolvedValueOnce(null); // listSessions
+
+  const harness = await renderUseTmux();
+  await flush(10);
+
+  const result = await harness.value.killPane("%0");
+  expect(result).toBe(false);
+
+  harness.unmount();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun run test`
+Expected: FAIL — `zoomPane` and `killPane` not defined on hook return value.
+
+- [ ] **Step 3: Add zoomPane and killPane callbacks to useTmux**
+
+In `src/tui/hooks/useTmux.ts`, add after the `jumpToPane` callback:
+
+```typescript
+const zoomPane = useCallback(
+  async (paneId: string) => {
+    if (!client) return false;
+    try {
+      await tuiRuntime.runPromise(
+        TmuxService.use((service) => service.zoomPane(paneId)),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  [client],
+);
+
+const killPane = useCallback(
+  async (paneId: string) => {
+    if (!client) return false;
+    try {
+      await tuiRuntime.runPromise(
+        TmuxService.use((service) => service.killPane(paneId)),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  [client],
+);
+```
+
+Add `zoomPane` and `killPane` to the return object:
+
+```typescript
+return {
+  client,
+  sessions,
+  panes,
+  error,
+  switchSession,
+  jumpToPane,
+  zoomPane,
+  killPane,
+  refreshSessions,
+  discoverClient,
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/hooks/useTmux.ts tests/tui/use-tmux.test.ts
+git commit -m "feat(tui): expose zoomPane and killPane in useTmux hook"
+```
+
+---
+
+### Task 4: Add ConfirmKill mode to TUI types
+
+**Files:**
+- Modify: `src/tui/types.ts`
+- Test: `tests/tui/types.test.ts`
+
+- [ ] **Step 1: Update Mode type with ConfirmKill variant**
+
+In `src/tui/types.ts`, add the new mode variant to the `Mode` type:
+
+```typescript
+export type Mode =
+  | { type: "Navigate" }
+  | { type: "Search" }
+  | { type: "OpenModal" }
+  | { type: "Expanded"; worktreeKey: string }
+  | { type: "ConfirmKill"; paneId: string; label: string; worktreeKey: string };
+```
+
+Add the constructor to the `Mode` namespace object:
+
+```typescript
+export const Mode = {
+  Navigate: { type: "Navigate" } as Mode,
+  Search: { type: "Search" } as Mode,
+  OpenModal: { type: "OpenModal" } as Mode,
+  Expanded: (worktreeKey: string): Mode => ({
+    type: "Expanded",
+    worktreeKey,
+  }),
+  ConfirmKill: (paneId: string, label: string, worktreeKey: string): Mode => ({
+    type: "ConfirmKill",
+    paneId,
+    label,
+    worktreeKey,
+  }),
+};
+```
+
+- [ ] **Step 2: Run tests to verify nothing is broken**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/types.ts
+git commit -m "feat(tui): add ConfirmKill mode variant"
+```
+
+---
+
+### Task 5: Render zoom indicator in DetailRow
+
+**Files:**
+- Modify: `src/tui/components/DetailRow.tsx`
+- Modify: `src/tui/App.tsx` (buildTreeItems pane detail meta)
+
+- [ ] **Step 1: Pass zoomed state through buildTreeItems**
+
+In `src/tui/App.tsx`, update the pane detail item in `buildTreeItems` to include `zoomed` in meta:
+
+```typescript
+for (const pane of sessionPanes) {
+  items.push({
+    type: "detail",
+    repoIndex: ri,
+    worktreeIndex: wi,
+    detailKind: "pane",
+    label: `${pane.window}:${pane.paneIndex} ${pane.command}`,
+    meta: { zoomed: pane.zoomed },
+    action: () => jumpToPane(pane.paneId),
+  });
+}
+```
+
+- [ ] **Step 2: Update the meta type on TreeItem**
+
+In `src/tui/types.ts`, update the `meta` field type on the detail variant of `TreeItem`:
+
+```typescript
+meta?: { state?: string; paneRef?: string; zoomed?: boolean };
+```
+
+- [ ] **Step 3: Render zoom icon in DetailRow**
+
+In `src/tui/components/DetailRow.tsx`, update the `pane` case:
+
+```typescript
+case "pane": {
+  const zoomIcon = meta?.zoomed ? "🔍 " : "";
+  return (
+    <Box>
+      <Text>{indent}</Text>
+      <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
+        {prefix}
+        {zoomIcon}
+        {label}
+      </Text>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify nothing is broken**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/components/DetailRow.tsx src/tui/App.tsx src/tui/types.ts
+git commit -m "feat(tui): render magnifying glass icon on zoomed panes"
+```
+
+---
+
+### Task 6: Wire z/x keybindings and ConfirmKill mode in App
+
+**Files:**
+- Modify: `src/tui/App.tsx`
+
+- [ ] **Step 1: Destructure zoomPane and killPane from useTmux**
+
+In `src/tui/App.tsx`, update the `useTmux` destructure:
+
+```typescript
+const {
+  client,
+  sessions,
+  panes,
+  error: tmuxError,
+  switchSession,
+  jumpToPane,
+  zoomPane,
+  killPane,
+  refreshSessions,
+  discoverClient,
+} = useTmux();
+```
+
+- [ ] **Step 2: Add helper to resolve pane info from selected item**
+
+Add a helper function inside the `App` component, after `handleSpaceSwitch`:
+
+```typescript
+function getSelectedPaneInfo(): { paneId: string; label: string } | null {
+  const item = treeItems[selectedIndex];
+  if (!item || item.type !== "detail" || item.detailKind !== "pane") return null;
+  const repo = filteredRepos[item.repoIndex];
+  if (!repo) return null;
+  const wt = repo.worktrees[item.worktreeIndex];
+  if (!wt) return null;
+  const sessionName = formatSessionName(basename(wt.path));
+  const sessionPanes = panes.get(sessionName);
+  if (!sessionPanes) return null;
+  // Match pane by label
+  const labelParts = item.label.split(" ");
+  const windowPane = labelParts[0]; // "window:paneIndex"
+  if (!windowPane) return null;
+  const [window, paneIndexStr] = windowPane.split(":");
+  const paneIndex = Number(paneIndexStr);
+  const pane = sessionPanes.find(
+    (p) => p.window === window && p.paneIndex === paneIndex,
+  );
+  if (!pane) return null;
+  return { paneId: pane.paneId, label: item.label };
+}
+```
+
+- [ ] **Step 3: Add z and x handlers to handleExpandedInput**
+
+In `handleExpandedInput`, add before the existing `if (input === " ")` block:
+
+```typescript
+if (input === "z") {
+  const paneInfo = getSelectedPaneInfo();
+  if (!paneInfo) return;
+  zoomPane(paneInfo.paneId).then(() => refreshSessions());
+  return;
+}
+
+if (input === "x") {
+  const paneInfo = getSelectedPaneInfo();
+  if (!paneInfo) return;
+  if (mode.type !== "Expanded") return;
+  setMode(Mode.ConfirmKill(paneInfo.paneId, paneInfo.label, mode.worktreeKey));
+  return;
+}
+```
+
+- [ ] **Step 4: Add handleConfirmKillInput function**
+
+Add a new input handler in the `App` component:
+
+```typescript
+function handleConfirmKillInput(input: string, key: Key) {
+  if (mode.type !== "ConfirmKill") return;
+
+  if (key.escape) {
+    setMode(Mode.Expanded(mode.worktreeKey));
+    return;
+  }
+
+  if (key.return) {
+    const { paneId, worktreeKey } = mode;
+    setMode(Mode.Expanded(worktreeKey));
+    killPane(paneId).then(() => refreshSessions());
+    return;
+  }
+}
+```
+
+- [ ] **Step 5: Wire ConfirmKill into useInput switch**
+
+Update the `useInput` switch statement to handle the new mode:
+
+```typescript
+switch (mode.type) {
+  case "Navigate":
+    return handleNavigateInput(input, key);
+  case "Search":
+    return handleSearchInput(input, key);
+  case "OpenModal":
+    return;
+  case "Expanded":
+    return handleExpandedInput(input, key);
+  case "ConfirmKill":
+    return handleConfirmKillInput(input, key);
+}
+```
+
+Also update the global `q` guard to exclude `ConfirmKill`:
+
+```typescript
+if (input === "q" && mode.type !== "OpenModal" && mode.type !== "Search" && mode.type !== "ConfirmKill") {
+  exit();
+  return;
+}
+```
+
+- [ ] **Step 6: Run tests to verify nothing is broken**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tui/App.tsx
+git commit -m "feat(tui): wire z/x keybindings and ConfirmKill mode"
+```
+
+---
+
+### Task 7: Update StatusBar for pane hints and confirm kill prompt
+
+**Files:**
+- Modify: `src/tui/components/StatusBar.tsx`
+- Modify: `src/tui/App.tsx` (pass selectedPaneRow and mode to StatusBar)
+
+- [ ] **Step 1: Update StatusBar props and ConfirmKill rendering**
+
+In `src/tui/components/StatusBar.tsx`:
+
+```typescript
+import { Box, Text, useStdout } from "ink";
+import type { Mode } from "../types";
+
+interface Props {
+  mode: Mode;
+  searchQuery?: string;
+  selectedPaneRow?: boolean;
+}
+
+function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
+  switch (mode.type) {
+    case "Navigate":
+      return [
+        "↑↓:navigate  ←→:expand/collapse  space:switch  o:open",
+        "c:close  /:search  q:quit",
+      ];
+    case "Search":
+      return ["type to filter", "esc:cancel  enter:done"];
+    case "OpenModal":
+      return ["", ""];
+    case "Expanded":
+      return [
+        selectedPaneRow
+          ? "↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill"
+          : "↑↓:navigate  ←:collapse  space:action  o:open",
+        "/:search  q:quit",
+      ];
+    case "ConfirmKill":
+      return ["", ""];
+  }
+}
+
+export function StatusBar({ mode, searchQuery, selectedPaneRow }: Props) {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 50;
+  const divider = "─".repeat(Math.max(1, cols));
+
+  if (mode.type === "Search") {
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>{divider}</Text>
+        <Text color="cyan">/{searchQuery}</Text>
+        <Text dimColor>{getHints(mode)[1]}</Text>
+      </Box>
+    );
+  }
+
+  if (mode.type === "ConfirmKill") {
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>{divider}</Text>
+        <Text color="red" bold>
+          Kill pane {mode.label}?
+        </Text>
+        <Text dimColor>enter:confirm  esc:cancel</Text>
+      </Box>
+    );
+  }
+
+  const [line1, line2] = getHints(mode, selectedPaneRow);
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{divider}</Text>
+      <Text dimColor>{line1}</Text>
+      <Text dimColor>{line2}</Text>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 2: Pass selectedPaneRow to StatusBar from App**
+
+In `src/tui/App.tsx`, compute `selectedPaneRow` and pass it to `StatusBar`:
+
+```typescript
+const selectedItem = treeItems[selectedIndex];
+const selectedPaneRow =
+  selectedItem?.type === "detail" && selectedItem.detailKind === "pane";
+```
+
+Update the StatusBar JSX:
+
+```typescript
+<StatusBar
+  mode={mode}
+  searchQuery={searchQuery}
+  selectedPaneRow={selectedPaneRow}
+/>
+```
+
+- [ ] **Step 3: Run tests to verify nothing is broken**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/components/StatusBar.tsx src/tui/App.tsx
+git commit -m "feat(tui): update StatusBar with pane hints and confirm kill prompt"
+```
+
+---
+
+### Task 8: Manual testing and final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bun run test`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Manual test zoom toggle**
+
+Run `bun run src/index.ts tui`, navigate to a worktree with a multi-pane session, expand it with right arrow, select a pane row, press `z`. Verify:
+- The tmux pane zooms in the other terminal
+- After refresh, the 🔍 icon appears on pane rows in the zoomed window
+- Pressing `z` again unzooms and the icon disappears
+
+- [ ] **Step 3: Manual test kill pane**
+
+Select a pane row, press `x`. Verify:
+- The StatusBar shows the red confirmation prompt with the pane label
+- Pressing `esc` cancels and returns to expanded mode
+- Pressing `enter` kills the pane and refreshes the pane list
+- If it was the last pane in a window, the window is removed by tmux
+
+- [ ] **Step 4: Commit any fixes**
+
+If any issues were found and fixed, commit them.

--- a/docs/superpowers/specs/2026-04-10-tui-pane-actions-design.md
+++ b/docs/superpowers/specs/2026-04-10-tui-pane-actions-design.md
@@ -1,0 +1,72 @@
+# TUI Pane Actions: Zoom & Kill
+
+## Summary
+
+Add zoom toggle and kill actions for individual tmux panes in the TUI's expanded worktree view, plus a visual indicator for zoomed panes.
+
+## Data Layer
+
+Add `zoomed: boolean` to `TmuxPaneInfo` by extending the `list-panes` format string with `#{window_zoomed_flag}`. Update `parsePaneListOutput` to parse the new column.
+
+All panes in a zoomed window report `zoomed: true` (tmux exposes zoom at the window level). This is acceptable — the icon on any pane in the window signals that zoom mode is active.
+
+## TmuxService
+
+Two new methods:
+
+- **`zoomPane(paneId: string)`** — executes `tmux resize-pane -Z -t <paneId>`. Toggles zoom on/off.
+- **`killPane(paneId: string)`** — executes `tmux kill-pane -t <paneId>`. When the last pane in a window is killed, tmux removes the window automatically.
+
+## useTmux Hook
+
+Expose `zoomPane(paneId)` and `killPane(paneId)` callbacks matching the existing `jumpToPane` pattern — call through to `TmuxService`, swallow errors.
+
+## TUI Interaction
+
+### Keybindings (Expanded mode only, pane row selected)
+
+- **`z`** — toggle zoom on the selected pane. Calls `zoomPane`, then `refreshSessions` to update indicators. No confirmation.
+- **`x`** — kill the selected pane. Opens `ConfirmKill` mode for confirmation before executing.
+
+### ConfirmKill Mode
+
+New mode in `types.ts`:
+
+```typescript
+| { type: "ConfirmKill"; paneId: string; label: string; worktreeKey: string }
+```
+
+Replaces the StatusBar content with an inline confirmation prompt:
+
+```
+Kill pane editor:0 zsh?  enter:confirm  esc:cancel
+```
+
+- **Enter** — calls `killPane(paneId)`, refreshes sessions, returns to `Expanded` mode (preserving `worktreeKey`).
+- **Escape** — returns to `Expanded` mode without action.
+
+### StatusBar Updates
+
+Expanded mode hints update to show `z:zoom  x:kill` when a pane detail row is selected. This requires passing the selected item type to StatusBar, or conditionally appending the hints.
+
+## Visual: Zoom Indicator
+
+When a pane has `zoomed: true`, prepend a magnifying glass icon in `DetailRow`:
+
+```
+        ▸ 🔍 editor:0 zsh
+              editor:1 node
+```
+
+Implementation: add `zoomed?: boolean` to the `meta` field on `TreeItem` detail rows. `buildTreeItems` passes the value from `PaneInfo`. `DetailRow` renders the icon in yellow when `meta.zoomed` is truthy.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/services/tmux.ts` | Add `zoomed` to `TmuxPaneInfo`, add `zoomPane`/`killPane` to service, update format string and parser |
+| `src/tui/hooks/useTmux.ts` | Expose `zoomPane` and `killPane` callbacks |
+| `src/tui/types.ts` | Add `ConfirmKill` mode variant, update `meta` type with `zoomed` |
+| `src/tui/App.tsx` | Handle `z`/`x` keys in expanded mode, add `ConfirmKill` input handler, pass zoomed to tree items |
+| `src/tui/components/DetailRow.tsx` | Render zoom icon for zoomed panes |
+| `src/tui/components/StatusBar.tsx` | Show pane-specific hints in expanded mode, render confirm kill prompt |

--- a/src/services/tmux.ts
+++ b/src/services/tmux.ts
@@ -22,6 +22,7 @@ export interface TmuxPaneInfo {
   paneIndex: number;
   command: string;
   window: string;
+  zoomed: boolean;
 }
 
 export interface TmuxClient {
@@ -109,7 +110,7 @@ export function parsePaneListOutput(output: string): TmuxPaneInfo[] {
     .split("\n")
     .filter(Boolean)
     .flatMap((line) => {
-      const [pid, pIdx, cmd, win] = line.split("\t");
+      const [pid, pIdx, cmd, win, zoom] = line.split("\t");
       return pid
         ? [
             {
@@ -117,6 +118,7 @@ export function parsePaneListOutput(output: string): TmuxPaneInfo[] {
               paneIndex: Number(pIdx),
               command: cmd || "",
               window: win || "",
+              zoomed: zoom === "1",
             },
           ]
         : [];
@@ -482,7 +484,7 @@ function listPanesImpl(sessionName: string) {
       "-t",
       `=${sessionName}`,
       "-F",
-      "#{pane_id}\t#{pane_index}\t#{pane_current_command}\t#{window_name}",
+      "#{pane_id}\t#{pane_index}\t#{pane_current_command}\t#{window_name}\t#{window_zoomed_flag}",
     ]).pipe(Effect.map((result) => parsePaneListOutput(result.stdout.trim()))),
     () => Effect.succeed([] as TmuxPaneInfo[]),
   );

--- a/src/services/tmux.ts
+++ b/src/services/tmux.ts
@@ -85,7 +85,7 @@ export interface TmuxService {
   selectPane: (
     pane: string,
   ) => Effect.Effect<void, WctError, WctRuntimeServices>;
-  zoomPane: (
+  togglePaneZoom: (
     paneId: string,
   ) => Effect.Effect<void, WctError, WctRuntimeServices>;
   killPane: (
@@ -443,7 +443,7 @@ function killSessionImpl(name: string) {
   );
 }
 
-function zoomPaneImpl(paneId: string) {
+function togglePaneZoomImpl(paneId: string) {
   return execProcess("tmux", ["resize-pane", "-Z", "-t", paneId]).pipe(
     Effect.asVoid,
   );
@@ -632,9 +632,13 @@ export const liveTmuxService: TmuxService = TmuxService.of({
     Effect.mapError(selectPaneImpl(pane), (error) =>
       commandError("tmux_error", `Failed to select pane '${pane}'`, error),
     ),
-  zoomPane: (paneId) =>
-    Effect.mapError(zoomPaneImpl(paneId), (error) =>
-      commandError("tmux_error", `Failed to zoom pane '${paneId}'`, error),
+  togglePaneZoom: (paneId) =>
+    Effect.mapError(togglePaneZoomImpl(paneId), (error) =>
+      commandError(
+        "tmux_error",
+        `Failed to toggle zoom for pane '${paneId}': ${getProcessErrorMessage(error)}`,
+        error,
+      ),
     ),
   killPane: (paneId) =>
     Effect.mapError(killPaneImpl(paneId), (error) =>

--- a/src/services/tmux.ts
+++ b/src/services/tmux.ts
@@ -85,6 +85,12 @@ export interface TmuxService {
   selectPane: (
     pane: string,
   ) => Effect.Effect<void, WctError, WctRuntimeServices>;
+  zoomPane: (
+    paneId: string,
+  ) => Effect.Effect<void, WctError, WctRuntimeServices>;
+  killPane: (
+    paneId: string,
+  ) => Effect.Effect<void, WctError, WctRuntimeServices>;
   refreshClient: () => Effect.Effect<void, WctError, WctRuntimeServices>;
 }
 
@@ -437,6 +443,16 @@ function killSessionImpl(name: string) {
   );
 }
 
+function zoomPaneImpl(paneId: string) {
+  return execProcess("tmux", ["resize-pane", "-Z", "-t", paneId]).pipe(
+    Effect.asVoid,
+  );
+}
+
+function killPaneImpl(paneId: string) {
+  return execProcess("tmux", ["kill-pane", "-t", paneId]).pipe(Effect.asVoid);
+}
+
 function getCurrentSessionImpl() {
   if (!process.env.TMUX) {
     return Effect.succeed(null);
@@ -615,6 +631,18 @@ export const liveTmuxService: TmuxService = TmuxService.of({
   selectPane: (pane) =>
     Effect.mapError(selectPaneImpl(pane), (error) =>
       commandError("tmux_error", `Failed to select pane '${pane}'`, error),
+    ),
+  zoomPane: (paneId) =>
+    Effect.mapError(zoomPaneImpl(paneId), (error) =>
+      commandError("tmux_error", `Failed to zoom pane '${paneId}'`, error),
+    ),
+  killPane: (paneId) =>
+    Effect.mapError(killPaneImpl(paneId), (error) =>
+      commandError(
+        "tmux_error",
+        `Failed to kill pane '${paneId}': ${getProcessErrorMessage(error)}`,
+        error,
+      ),
     ),
   refreshClient: () =>
     Effect.mapError(refreshClientImpl(), (error) =>

--- a/src/services/tmux.ts
+++ b/src/services/tmux.ts
@@ -23,6 +23,7 @@ export interface TmuxPaneInfo {
   command: string;
   window: string;
   zoomed: boolean;
+  active: boolean;
 }
 
 export interface TmuxClient {
@@ -110,7 +111,7 @@ export function parsePaneListOutput(output: string): TmuxPaneInfo[] {
     .split("\n")
     .filter(Boolean)
     .flatMap((line) => {
-      const [pid, pIdx, cmd, win, zoom] = line.split("\t");
+      const [pid, pIdx, cmd, win, zoom, active] = line.split("\t");
       return pid
         ? [
             {
@@ -119,6 +120,7 @@ export function parsePaneListOutput(output: string): TmuxPaneInfo[] {
               command: cmd || "",
               window: win || "",
               zoomed: zoom === "1",
+              active: active === "1",
             },
           ]
         : [];
@@ -484,7 +486,7 @@ function listPanesImpl(sessionName: string) {
       "-t",
       `=${sessionName}`,
       "-F",
-      "#{pane_id}\t#{pane_index}\t#{pane_current_command}\t#{window_name}\t#{window_zoomed_flag}",
+      "#{pane_id}\t#{pane_index}\t#{pane_current_command}\t#{window_name}\t#{window_zoomed_flag}\t#{pane_active}",
     ]).pipe(Effect.map((result) => parsePaneListOutput(result.stdout.trim()))),
     () => Effect.succeed([] as TmuxPaneInfo[]),
   );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -42,6 +42,17 @@ interface SelectedPaneResolution {
   worktreeKey: string;
 }
 
+interface ResolveStatusBarPropsOptions {
+  mode: Mode;
+  items: TreeItem[];
+  selectedIndex: number;
+}
+
+export interface ResolvedStatusBarProps {
+  mode: Mode;
+  selectedPaneRow?: boolean;
+}
+
 export function buildTreeItems({
   repos,
   expandedRepos,
@@ -199,6 +210,19 @@ export function resolveSelectedPane({
   };
 }
 
+export function resolveStatusBarProps({
+  mode,
+  items,
+  selectedIndex,
+}: ResolveStatusBarPropsOptions): ResolvedStatusBarProps {
+  return {
+    mode,
+    selectedPaneRow:
+      items[selectedIndex]?.type === "detail" &&
+      items[selectedIndex]?.detailKind === "pane",
+  };
+}
+
 export function App() {
   const { exit } = useApp();
   const { stdout } = useStdout();
@@ -288,9 +312,11 @@ export function App() {
       jumpToPane,
     ],
   );
-  const selectedPaneRow =
-    treeItems[selectedIndex]?.type === "detail" &&
-    treeItems[selectedIndex]?.detailKind === "pane";
+  const statusBarProps = resolveStatusBarProps({
+    mode,
+    items: treeItems,
+    selectedIndex,
+  });
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
@@ -768,9 +794,8 @@ export function App() {
         />
       ) : (
         <StatusBar
-          mode={mode}
+          {...statusBarProps}
           searchQuery={searchQuery}
-          selectedPaneRow={selectedPaneRow}
         />
       )}
     </Box>

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -112,7 +112,11 @@ export function buildTreeItems({
               worktreeIndex: wi,
               detailKind: "pane",
               label: `${pane.window}:${pane.paneIndex} ${pane.command}`,
-              meta: { zoomed: pane.zoomed, active: pane.active },
+              meta: {
+                paneId: pane.paneId,
+                zoomed: pane.zoomed,
+                active: pane.active,
+              },
               action: () => jumpToPane(pane.paneId),
             });
           }
@@ -121,6 +125,33 @@ export function buildTreeItems({
     }
   }
   return items;
+}
+
+export function findOwningWorktreeIndex(
+  items: TreeItem[],
+  selectedIndex: number,
+): number | null {
+  const selected = items[selectedIndex];
+  if (!selected) {
+    return null;
+  }
+
+  if (selected.type === "worktree") {
+    return selectedIndex;
+  }
+
+  if (selected.type !== "detail") {
+    return null;
+  }
+
+  for (let i = selectedIndex - 1; i >= 0; i--) {
+    const candidate = items[i];
+    if (candidate?.type === "worktree") {
+      return i;
+    }
+  }
+
+  return null;
 }
 
 export function resolveSelectedPane({
@@ -150,21 +181,12 @@ export function resolveSelectedPane({
     return null;
   }
 
-  const labelMatch = selected.label.match(/^(.*):(\d+)\s/);
-  if (!labelMatch) {
+  const paneId = selected.meta?.paneId;
+  if (!paneId) {
     return null;
   }
 
-  const [, window, paneIndexText] = labelMatch;
-  const paneIndex = Number(paneIndexText);
-  if (Number.isNaN(paneIndex)) {
-    return null;
-  }
-
-  const pane = sessionPanes.find(
-    (candidate) =>
-      candidate.window === window && candidate.paneIndex === paneIndex,
-  );
+  const pane = sessionPanes.find((candidate) => candidate.paneId === paneId);
 
   if (!pane) {
     return null;
@@ -568,17 +590,9 @@ export function App() {
 
   function handleExpandedInput(input: string, key: Key) {
     if (key.leftArrow || key.escape) {
-      // Move selection back to parent worktree so selectedIndex
-      // doesn't point past the end after detail rows are removed.
-      const current = treeItems[selectedIndex];
-      if (current && current.type === "detail") {
-        for (let i = selectedIndex - 1; i >= 0; i--) {
-          const candidate = treeItems[i];
-          if (candidate?.type === "worktree") {
-            setSelectedIndex(i);
-            break;
-          }
-        }
+      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
+      if (parentIndex !== null) {
+        setSelectedIndex(parentIndex);
       }
       setMode(Mode.Navigate);
       return;
@@ -668,6 +682,10 @@ export function App() {
 
     if (key.return) {
       const { paneId, worktreeKey } = mode;
+      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
+      if (parentIndex !== null) {
+        setSelectedIndex(parentIndex);
+      }
       setMode(Mode.Expanded(worktreeKey));
       killPane(paneId).then(() => refreshSessions());
     }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -793,10 +793,7 @@ export function App() {
           onCancel={() => setMode(Mode.Navigate)}
         />
       ) : (
-        <StatusBar
-          {...statusBarProps}
-          searchQuery={searchQuery}
-        />
+        <StatusBar {...statusBarProps} searchQuery={searchQuery} />
       )}
     </Box>
   );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -99,6 +99,7 @@ function buildTreeItems({
               worktreeIndex: wi,
               detailKind: "pane",
               label: `${pane.window}:${pane.paneIndex} ${pane.command}`,
+              meta: { zoomed: pane.zoomed, active: pane.active },
               action: () => jumpToPane(pane.paneId),
             });
           }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -29,7 +29,7 @@ interface BuildTreeOptions {
   jumpToPane: (paneId: string) => void;
 }
 
-function buildTreeItems({
+export function buildTreeItems({
   repos,
   expandedRepos,
   expandedWorktreeKey,

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -29,6 +29,19 @@ interface BuildTreeOptions {
   jumpToPane: (paneId: string) => void;
 }
 
+interface ResolveSelectedPaneOptions {
+  repos: RepoInfo[];
+  items: TreeItem[];
+  panes: Map<string, PaneInfo[]>;
+  selectedIndex: number;
+}
+
+interface SelectedPaneResolution {
+  pane: PaneInfo;
+  label: string;
+  worktreeKey: string;
+}
+
 export function buildTreeItems({
   repos,
   expandedRepos,
@@ -110,6 +123,60 @@ export function buildTreeItems({
   return items;
 }
 
+export function resolveSelectedPane({
+  repos,
+  items,
+  panes,
+  selectedIndex,
+}: ResolveSelectedPaneOptions): SelectedPaneResolution | null {
+  const selected = items[selectedIndex];
+  if (
+    !selected ||
+    selected.type !== "detail" ||
+    selected.detailKind !== "pane"
+  ) {
+    return null;
+  }
+
+  const repo = repos[selected.repoIndex];
+  const worktree = repo?.worktrees[selected.worktreeIndex];
+  if (!repo || !worktree) {
+    return null;
+  }
+
+  const sessionName = formatSessionName(basename(worktree.path));
+  const sessionPanes = panes.get(sessionName);
+  if (!sessionPanes) {
+    return null;
+  }
+
+  const labelMatch = selected.label.match(/^(.*):(\d+)\s/);
+  if (!labelMatch) {
+    return null;
+  }
+
+  const [, window, paneIndexText] = labelMatch;
+  const paneIndex = Number(paneIndexText);
+  if (Number.isNaN(paneIndex)) {
+    return null;
+  }
+
+  const pane = sessionPanes.find(
+    (candidate) =>
+      candidate.window === window && candidate.paneIndex === paneIndex,
+  );
+
+  if (!pane) {
+    return null;
+  }
+
+  return {
+    pane,
+    label: selected.label,
+    worktreeKey: pendingKey(repo.project, worktree.branch),
+  };
+}
+
 export function App() {
   const { exit } = useApp();
   const { stdout } = useStdout();
@@ -124,6 +191,8 @@ export function App() {
     error: tmuxError,
     switchSession,
     jumpToPane,
+    zoomPane,
+    killPane,
     refreshSessions,
     discoverClient,
   } = useTmux();
@@ -140,6 +209,8 @@ export function App() {
   const [pendingActions, setPendingActions] = useState<
     Map<string, PendingAction>
   >(new Map());
+  const statusMode =
+    mode.type === "ConfirmKill" ? Mode.Expanded(mode.worktreeKey) : mode;
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -174,7 +245,9 @@ export function App() {
   }, [repos, searchQuery]);
 
   const expandedWorktreeKey =
-    mode.type === "Expanded" ? mode.worktreeKey : null;
+    mode.type === "Expanded" || mode.type === "ConfirmKill"
+      ? mode.worktreeKey
+      : null;
 
   const treeItems = useMemo(
     () =>
@@ -548,11 +621,66 @@ export function App() {
       setSearchQuery("");
       return;
     }
+
+    if (input === "z") {
+      const selectedPane = resolveSelectedPane({
+        repos: filteredRepos,
+        items: treeItems,
+        panes,
+        selectedIndex,
+      });
+      if (!selectedPane) {
+        return;
+      }
+      zoomPane(selectedPane.pane.paneId).then(() => refreshSessions());
+      return;
+    }
+
+    if (input === "x") {
+      const selectedPane = resolveSelectedPane({
+        repos: filteredRepos,
+        items: treeItems,
+        panes,
+        selectedIndex,
+      });
+      if (!selectedPane) {
+        return;
+      }
+      setMode(
+        Mode.ConfirmKill(
+          selectedPane.pane.paneId,
+          selectedPane.label,
+          selectedPane.worktreeKey,
+        ),
+      );
+    }
+  }
+
+  function handleConfirmKillInput(_input: string, key: Key) {
+    if (mode.type !== "ConfirmKill") {
+      return;
+    }
+
+    if (key.escape) {
+      setMode(Mode.Expanded(mode.worktreeKey));
+      return;
+    }
+
+    if (key.return) {
+      const { paneId, worktreeKey } = mode;
+      setMode(Mode.Expanded(worktreeKey));
+      killPane(paneId).then(() => refreshSessions());
+    }
   }
 
   useInput((input, key) => {
     // Global keys (work in any mode)
-    if (input === "q" && mode.type !== "OpenModal" && mode.type !== "Search") {
+    if (
+      input === "q" &&
+      mode.type !== "OpenModal" &&
+      mode.type !== "Search" &&
+      mode.type !== "ConfirmKill"
+    ) {
       exit();
       return;
     }
@@ -567,6 +695,8 @@ export function App() {
         return;
       case "Expanded":
         return handleExpandedInput(input, key);
+      case "ConfirmKill":
+        return handleConfirmKillInput(input, key);
     }
   });
 
@@ -618,7 +748,7 @@ export function App() {
           onCancel={() => setMode(Mode.Navigate)}
         />
       ) : (
-        <StatusBar mode={mode} searchQuery={searchQuery} />
+        <StatusBar mode={statusMode} searchQuery={searchQuery} />
       )}
     </Box>
   );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -231,8 +231,6 @@ export function App() {
   const [pendingActions, setPendingActions] = useState<
     Map<string, PendingAction>
   >(new Map());
-  const statusMode =
-    mode.type === "ConfirmKill" ? Mode.Expanded(mode.worktreeKey) : mode;
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -290,6 +288,9 @@ export function App() {
       jumpToPane,
     ],
   );
+  const selectedPaneRow =
+    treeItems[selectedIndex]?.type === "detail" &&
+    treeItems[selectedIndex]?.detailKind === "pane";
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
@@ -766,7 +767,11 @@ export function App() {
           onCancel={() => setMode(Mode.Navigate)}
         />
       ) : (
-        <StatusBar mode={statusMode} searchQuery={searchQuery} />
+        <StatusBar
+          mode={mode}
+          searchQuery={searchQuery}
+          selectedPaneRow={selectedPaneRow}
+        />
       )}
     </Box>
   );

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "ink";
-import type { DetailKind } from "../types";
+import type { DetailKind, DetailMeta } from "../types";
 import { checkColor, checkIcon } from "../types";
 
 interface Props {
@@ -7,7 +7,7 @@ interface Props {
   label: string;
   isSelected: boolean;
   /** Extra data for rendering (e.g., check state) */
-  meta?: { state?: string; paneRef?: string };
+  meta?: DetailMeta;
 }
 
 export function DetailRow({ kind, label, isSelected, meta }: Props) {
@@ -68,6 +68,7 @@ export function DetailRow({ kind, label, isSelected, meta }: Props) {
           <Text>{indent}</Text>
           <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
             {prefix}
+            {meta?.zoomed && meta?.active ? "🔍 " : ""}
             {label}
           </Text>
         </Box>

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -1,23 +1,21 @@
 import { Box, Text } from "ink";
-import type { DetailKind, DetailMeta } from "../types";
+import type { TreeItem } from "../types";
 import { checkColor, checkIcon } from "../types";
 
 interface Props {
-  kind: DetailKind;
-  label: string;
+  item: Extract<TreeItem, { type: "detail" }>;
   isSelected: boolean;
-  /** Extra data for rendering (e.g., check state) */
-  meta?: DetailMeta;
 }
 
-export function DetailRow({ kind, label, isSelected, meta }: Props) {
+export function DetailRow({ item, isSelected }: Props) {
+  const { detailKind, label, meta } = item;
   const prefix = isSelected ? "▸ " : "  ";
   const indent =
-    kind === "pr" || kind === "pane-header"
+    detailKind === "pr" || detailKind === "pane-header"
       ? "      " // section header: 6 spaces
       : "        "; // section item: 8 spaces
 
-  switch (kind) {
+  switch (detailKind) {
     case "pane-header":
       return (
         <Box>

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -5,9 +5,10 @@ import type { Mode } from "../types";
 interface Props {
   mode: Mode;
   searchQuery?: string;
+  selectedPaneRow?: boolean;
 }
 
-function getHints(mode: Mode): [string, string] {
+function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
   switch (mode.type) {
     case "Navigate":
       return [
@@ -19,17 +20,38 @@ function getHints(mode: Mode): [string, string] {
     case "OpenModal":
       return ["", ""];
     case "Expanded":
+      if (selectedPaneRow) {
+        return [
+          "↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill",
+          "/:search  q:quit",
+        ];
+      }
       return [
         "↑↓:navigate  ←:collapse  space:action  o:open",
         "/:search  q:quit",
       ];
+    case "ConfirmKill":
+      return ["Kill pane " + mode.label + "?", "enter:confirm  esc:cancel"];
   }
 }
 
-export function StatusBar({ mode, searchQuery }: Props) {
+export function StatusBar({ mode, searchQuery, selectedPaneRow }: Props) {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 50;
   const divider = "─".repeat(Math.max(1, cols));
+
+  if (mode.type === "ConfirmKill") {
+    const [line1, line2] = getHints(mode, selectedPaneRow);
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>{divider}</Text>
+        <Text color="red" bold>
+          {line1}
+        </Text>
+        <Text dimColor>{line2}</Text>
+      </Box>
+    );
+  }
 
   if (mode.type === "Search") {
     return (
@@ -41,7 +63,7 @@ export function StatusBar({ mode, searchQuery }: Props) {
     );
   }
 
-  const [line1, line2] = getHints(mode);
+  const [line1, line2] = getHints(mode, selectedPaneRow);
   return (
     <Box flexDirection="column">
       <Text dimColor>{divider}</Text>

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -28,6 +28,17 @@ interface Props {
   maxWidth: number;
 }
 
+export function getDetailRowKey(
+  repoId: string,
+  item: Extract<TreeItem, { type: "detail" }>,
+): string {
+  const base = `detail-${repoId}-${item.worktreeIndex}-${item.detailKind}`;
+  if (item.detailKind === "pane") {
+    return `${base}-${item.meta?.paneId ?? item.label}`;
+  }
+  return `${base}-${item.label}`;
+}
+
 export function TreeView({
   repos,
   sessions,
@@ -96,7 +107,7 @@ export function TreeView({
     if (item.type === "detail") {
       elements.push(
         <DetailRow
-          key={`detail-${repo.id}-${item.worktreeIndex}-${item.detailKind}-${item.label}`}
+          key={getDetailRowKey(repo.id, item)}
           item={item}
           isSelected={idx === selectedIndex}
         />,

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -97,10 +97,8 @@ export function TreeView({
       elements.push(
         <DetailRow
           key={`detail-${repo.id}-${item.worktreeIndex}-${item.detailKind}-${item.label}`}
-          kind={item.detailKind}
-          label={item.label}
+          item={item}
           isSelected={idx === selectedIndex}
-          meta={item.meta}
         />,
       );
       continue;

--- a/src/tui/hooks/useTmux.ts
+++ b/src/tui/hooks/useTmux.ts
@@ -129,6 +129,36 @@ export function useTmux() {
     [client],
   );
 
+  const zoomPane = useCallback(
+    async (paneId: string) => {
+      if (!client) return false;
+      try {
+        await tuiRuntime.runPromise(
+          TmuxService.use((service) => service.togglePaneZoom(paneId)),
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [client],
+  );
+
+  const killPane = useCallback(
+    async (paneId: string) => {
+      if (!client) return false;
+      try {
+        await tuiRuntime.runPromise(
+          TmuxService.use((service) => service.killPane(paneId)),
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [client],
+  );
+
   useEffect(() => {
     const controller = new AbortController();
     discoverClient(controller.signal);
@@ -143,6 +173,8 @@ export function useTmux() {
     error,
     switchSession,
     jumpToPane,
+    zoomPane,
+    killPane,
     refreshSessions,
     discoverClient,
   };

--- a/src/tui/hooks/useTmux.ts
+++ b/src/tui/hooks/useTmux.ts
@@ -13,6 +13,17 @@ export interface TmuxSessionInfo {
   attached: boolean;
 }
 
+async function runPaneAction(
+  effect: Parameters<typeof tuiRuntime.runPromise>[0],
+) {
+  try {
+    await tuiRuntime.runPromise(effect);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function useTmux() {
   const [client, setClient] = useState<TmuxClient | null>(null);
   const [sessions, setSessions] = useState<TmuxSessionInfo[]>([]);
@@ -129,27 +140,19 @@ export function useTmux() {
     [client],
   );
 
-  const zoomPane = useCallback(async (paneId: string) => {
-    try {
-      await tuiRuntime.runPromise(
+  const zoomPane = useCallback(
+    async (paneId: string) =>
+      runPaneAction(
         TmuxService.use((service) => service.togglePaneZoom(paneId)),
-      );
-      return true;
-    } catch {
-      return false;
-    }
-  }, []);
+      ),
+    [],
+  );
 
-  const killPane = useCallback(async (paneId: string) => {
-    try {
-      await tuiRuntime.runPromise(
-        TmuxService.use((service) => service.killPane(paneId)),
-      );
-      return true;
-    } catch {
-      return false;
-    }
-  }, []);
+  const killPane = useCallback(
+    async (paneId: string) =>
+      runPaneAction(TmuxService.use((service) => service.killPane(paneId))),
+    [],
+  );
 
   useEffect(() => {
     const controller = new AbortController();

--- a/src/tui/hooks/useTmux.ts
+++ b/src/tui/hooks/useTmux.ts
@@ -129,35 +129,27 @@ export function useTmux() {
     [client],
   );
 
-  const zoomPane = useCallback(
-    async (paneId: string) => {
-      if (!client) return false;
-      try {
-        await tuiRuntime.runPromise(
-          TmuxService.use((service) => service.togglePaneZoom(paneId)),
-        );
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    [client],
-  );
+  const zoomPane = useCallback(async (paneId: string) => {
+    try {
+      await tuiRuntime.runPromise(
+        TmuxService.use((service) => service.togglePaneZoom(paneId)),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
-  const killPane = useCallback(
-    async (paneId: string) => {
-      if (!client) return false;
-      try {
-        await tuiRuntime.runPromise(
-          TmuxService.use((service) => service.killPane(paneId)),
-        );
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    [client],
-  );
+  const killPane = useCallback(async (paneId: string) => {
+    try {
+      await tuiRuntime.runPromise(
+        TmuxService.use((service) => service.killPane(paneId)),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -23,11 +23,7 @@ export const Mode = {
     type: "Expanded",
     worktreeKey,
   }),
-  ConfirmKill: (
-    paneId: string,
-    label: string,
-    worktreeKey: string,
-  ): Mode => ({
+  ConfirmKill: (paneId: string, label: string, worktreeKey: string): Mode => ({
     type: "ConfirmKill",
     paneId,
     label,
@@ -36,6 +32,13 @@ export const Mode = {
 };
 
 /** Items in the flat tree list */
+export interface DetailMeta {
+  state?: string;
+  paneRef?: string;
+  zoomed?: boolean;
+  active?: boolean;
+}
+
 export type TreeItem =
   | { type: "repo"; repoIndex: number }
   | { type: "worktree"; repoIndex: number; worktreeIndex: number }
@@ -46,7 +49,7 @@ export type TreeItem =
       detailKind: DetailKind;
       label: string;
       action?: () => void;
-      meta?: { state?: string; paneRef?: string };
+      meta?: DetailMeta;
     };
 
 export type DetailKind = "pr" | "check" | "pane-header" | "pane";

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -31,27 +31,37 @@ export const Mode = {
   }),
 };
 
-/** Items in the flat tree list */
-export interface DetailMeta {
-  state?: string;
-  zoomed?: boolean;
-  active?: boolean;
-}
-
 export type TreeItem =
   | { type: "repo"; repoIndex: number }
   | { type: "worktree"; repoIndex: number; worktreeIndex: number }
-  | {
+  | DetailItem<"pr">
+  | DetailItem<"check", { state?: string }>
+  | DetailItem<"pane-header">
+  | DetailItem<"pane", { zoomed?: boolean; active?: boolean }>;
+
+export type DetailKind = "pr" | "check" | "pane-header" | "pane";
+
+type DetailItem<
+  TKind extends DetailKind,
+  TMeta = undefined,
+> = TMeta extends undefined
+  ? {
       type: "detail";
       repoIndex: number;
       worktreeIndex: number;
-      detailKind: DetailKind;
+      detailKind: TKind;
       label: string;
       action?: () => void;
-      meta?: DetailMeta;
+    }
+  : {
+      type: "detail";
+      repoIndex: number;
+      worktreeIndex: number;
+      detailKind: TKind;
+      label: string;
+      action?: () => void;
+      meta?: TMeta;
     };
-
-export type DetailKind = "pr" | "check" | "pane-header" | "pane";
 
 /** Pending action for optimistic UI */
 export interface PendingAction {

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -37,10 +37,7 @@ export type TreeItem =
   | DetailItem<"pr">
   | DetailItem<"check", { state?: string }>
   | DetailItem<"pane-header">
-  | DetailItem<
-      "pane",
-      { paneId: string; zoomed?: boolean; active?: boolean }
-    >;
+  | DetailItem<"pane", { paneId: string; zoomed?: boolean; active?: boolean }>;
 
 export type DetailKind = "pr" | "check" | "pane-header" | "pane";
 

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -34,7 +34,6 @@ export const Mode = {
 /** Items in the flat tree list */
 export interface DetailMeta {
   state?: string;
-  paneRef?: string;
   zoomed?: boolean;
   active?: boolean;
 }

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -7,7 +7,13 @@ export type Mode =
   | { type: "Navigate" }
   | { type: "Search" }
   | { type: "OpenModal" }
-  | { type: "Expanded"; worktreeKey: string };
+  | { type: "Expanded"; worktreeKey: string }
+  | {
+      type: "ConfirmKill";
+      paneId: string;
+      label: string;
+      worktreeKey: string;
+    };
 
 export const Mode = {
   Navigate: { type: "Navigate" } as Mode,
@@ -15,6 +21,16 @@ export const Mode = {
   OpenModal: { type: "OpenModal" } as Mode,
   Expanded: (worktreeKey: string): Mode => ({
     type: "Expanded",
+    worktreeKey,
+  }),
+  ConfirmKill: (
+    paneId: string,
+    label: string,
+    worktreeKey: string,
+  ): Mode => ({
+    type: "ConfirmKill",
+    paneId,
+    label,
     worktreeKey,
   }),
 };

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -37,7 +37,10 @@ export type TreeItem =
   | DetailItem<"pr">
   | DetailItem<"check", { state?: string }>
   | DetailItem<"pane-header">
-  | DetailItem<"pane", { zoomed?: boolean; active?: boolean }>;
+  | DetailItem<
+      "pane",
+      { paneId: string; zoomed?: boolean; active?: boolean }
+    >;
 
 export type DetailKind = "pr" | "check" | "pane-header" | "pane";
 

--- a/tests/tmux.test.ts
+++ b/tests/tmux.test.ts
@@ -76,6 +76,7 @@ describe("parsePaneListOutput", () => {
       command: "bash",
       window: "shell",
       zoomed: false,
+      active: false,
     });
     expect(panes[1]).toEqual({
       paneId: "%1",
@@ -83,6 +84,7 @@ describe("parsePaneListOutput", () => {
       command: "vim",
       window: "editor",
       zoomed: false,
+      active: false,
     });
   });
 
@@ -96,6 +98,7 @@ describe("parsePaneListOutput", () => {
       command: "bash",
       window: "shell",
       zoomed: true,
+      active: false,
     });
     expect(panes[1]).toEqual({
       paneId: "%1",
@@ -103,6 +106,7 @@ describe("parsePaneListOutput", () => {
       command: "vim",
       window: "editor",
       zoomed: false,
+      active: false,
     });
   });
 
@@ -116,6 +120,29 @@ describe("parsePaneListOutput", () => {
       command: "bash",
       window: "shell",
       zoomed: false,
+      active: false,
+    });
+  });
+
+  test("parses pane activity and keeps zoomed state on all panes in a zoomed window", () => {
+    const output = "%0\t0\tbash\tshell\t1\t0\n%1\t1\tvim\teditor\t1\t1";
+    const panes = parsePaneListOutput(output);
+    expect(panes).toHaveLength(2);
+    expect(panes[0]).toEqual({
+      paneId: "%0",
+      paneIndex: 0,
+      command: "bash",
+      window: "shell",
+      zoomed: true,
+      active: false,
+    });
+    expect(panes[1]).toEqual({
+      paneId: "%1",
+      paneIndex: 1,
+      command: "vim",
+      window: "editor",
+      zoomed: true,
+      active: true,
     });
   });
 

--- a/tests/tmux.test.ts
+++ b/tests/tmux.test.ts
@@ -67,7 +67,7 @@ myapp-fix-login:0:1`;
 
 describe("parsePaneListOutput", () => {
   test("parses pane list output", () => {
-    const output = "%0\t0\tbash\tshell\n%1\t1\tvim\teditor";
+    const output = "%0\t0\tbash\tshell\t0\n%1\t1\tvim\teditor\t0";
     const panes = parsePaneListOutput(output);
     expect(panes).toHaveLength(2);
     expect(panes[0]).toEqual({
@@ -75,12 +75,47 @@ describe("parsePaneListOutput", () => {
       paneIndex: 0,
       command: "bash",
       window: "shell",
+      zoomed: false,
     });
     expect(panes[1]).toEqual({
       paneId: "%1",
       paneIndex: 1,
       command: "vim",
       window: "editor",
+      zoomed: false,
+    });
+  });
+
+  test("parses pane list output with zoom flag", () => {
+    const output = "%0\t0\tbash\tshell\t1\n%1\t1\tvim\teditor\t0";
+    const panes = parsePaneListOutput(output);
+    expect(panes).toHaveLength(2);
+    expect(panes[0]).toEqual({
+      paneId: "%0",
+      paneIndex: 0,
+      command: "bash",
+      window: "shell",
+      zoomed: true,
+    });
+    expect(panes[1]).toEqual({
+      paneId: "%1",
+      paneIndex: 1,
+      command: "vim",
+      window: "editor",
+      zoomed: false,
+    });
+  });
+
+  test("defaults zoomed to false when flag is missing", () => {
+    const output = "%0\t0\tbash\tshell";
+    const panes = parsePaneListOutput(output);
+    expect(panes).toHaveLength(1);
+    expect(panes[0]).toEqual({
+      paneId: "%0",
+      paneIndex: 0,
+      command: "bash",
+      window: "shell",
+      zoomed: false,
     });
   });
 

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -1,8 +1,12 @@
 import { basename } from "node:path";
 import { describe, expect, test } from "vitest";
 import { formatSessionName } from "../../src/services/tmux";
-import { buildTreeItems, resolveSelectedPane } from "../../src/tui/App";
-import { type PaneInfo, pendingKey } from "../../src/tui/types";
+import {
+  buildTreeItems,
+  findOwningWorktreeIndex,
+  resolveSelectedPane,
+} from "../../src/tui/App";
+import { type PaneInfo, pendingKey, type TreeItem } from "../../src/tui/types";
 
 describe("buildTreeItems", () => {
   test("passes zoomed and active pane metadata into pane detail rows", () => {
@@ -49,10 +53,14 @@ describe("buildTreeItems", () => {
       (item) => item.type === "detail" && item.detailKind === "pane",
     );
 
-    expect(paneItem?.meta).toEqual({ zoomed: true, active: true });
+    expect(paneItem?.meta).toEqual({
+      paneId: "%1",
+      zoomed: true,
+      active: true,
+    });
   });
 
-  test("resolves the selected pane from session/window/pane index data", () => {
+  test("resolves the selected pane from stable pane identity", () => {
     const branch = "feature/pane-actions";
     const repoPath = "/tmp/example-repo";
     const worktreePath = "/tmp/worktree-pane-actions";
@@ -105,7 +113,7 @@ describe("buildTreeItems", () => {
       (item) =>
         item.type === "detail" &&
         item.detailKind === "pane" &&
-        item.label === "editor:1 git status",
+        item.meta?.paneId === "%2",
     );
 
     const resolved = resolveSelectedPane({
@@ -132,7 +140,12 @@ describe("buildTreeItems", () => {
           sessionName,
           [
             { ...sessionPanes[0], paneId: "%9", zoomed: true, active: true },
-            { ...sessionPanes[1], command: "htop" },
+            {
+              ...sessionPanes[1],
+              command: "htop",
+              window: "renamed-window",
+              paneIndex: 4,
+            },
           ],
         ],
       ]),
@@ -140,9 +153,110 @@ describe("buildTreeItems", () => {
     });
 
     expect(resolved).toEqual({
-      pane: { ...sessionPanes[1], command: "htop" },
+      pane: {
+        ...sessionPanes[1],
+        command: "htop",
+        window: "renamed-window",
+        paneIndex: 4,
+      },
       label: "editor:1 git status",
       worktreeKey: pendingKey("example", branch),
     });
+  });
+
+  test("resolves the correct pane when multiple pane rows share the same label", () => {
+    const items: TreeItem[] = [
+      { type: "repo", repoIndex: 0 },
+      { type: "worktree", repoIndex: 0, worktreeIndex: 0 },
+      {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "shared label",
+        meta: { paneId: "%1", zoomed: false, active: false },
+      },
+      {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "shared label",
+        meta: { paneId: "%2", zoomed: true, active: true },
+      },
+    ];
+
+    const resolved = resolveSelectedPane({
+      repos: [
+        {
+          id: "repo-1",
+          repoPath: "/tmp/example-repo",
+          project: "example",
+          worktrees: [
+            {
+              branch: "feature/duplicate-labels",
+              path: "/tmp/worktree-duplicate-labels",
+              isMainWorktree: false,
+              changedFiles: 0,
+              sync: null,
+            },
+          ],
+          profileNames: [],
+        },
+      ],
+      items,
+      panes: new Map([
+        [
+          formatSessionName(basename("/tmp/worktree-duplicate-labels")),
+          [
+            {
+              paneId: "%1",
+              paneIndex: 0,
+              command: "bash",
+              window: "main",
+              zoomed: false,
+              active: false,
+            },
+            {
+              paneId: "%2",
+              paneIndex: 1,
+              command: "top",
+              window: "main",
+              zoomed: true,
+              active: true,
+            },
+          ],
+        ],
+      ]),
+      selectedIndex: 3,
+    });
+
+    expect(resolved?.pane.paneId).toBe("%2");
+  });
+
+  test("finds the owning worktree row for a selected detail row", () => {
+    const items: TreeItem[] = [
+      { type: "repo", repoIndex: 0 },
+      { type: "worktree", repoIndex: 0, worktreeIndex: 0 },
+      {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane-header",
+        label: "Panes (1)",
+      },
+      {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "editor:0 bash",
+        meta: { paneId: "%1", zoomed: false, active: true },
+      },
+    ];
+
+    expect(findOwningWorktreeIndex(items, 3)).toBe(1);
+    expect(findOwningWorktreeIndex(items, 1)).toBe(1);
+    expect(findOwningWorktreeIndex(items, 0)).toBeNull();
   });
 });

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -2,7 +2,7 @@ import { basename } from "node:path";
 import { describe, expect, test } from "vitest";
 import { formatSessionName } from "../../src/services/tmux";
 import { buildTreeItems } from "../../src/tui/App";
-import { pendingKey, type PaneInfo } from "../../src/tui/types";
+import { type PaneInfo, pendingKey } from "../../src/tui/types";
 
 describe("buildTreeItems", () => {
   test("passes zoomed and active pane metadata into pane detail rows", () => {

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -1,0 +1,54 @@
+import { basename } from "node:path";
+import { describe, expect, test } from "vitest";
+import { formatSessionName } from "../../src/services/tmux";
+import { buildTreeItems } from "../../src/tui/App";
+import { pendingKey, type PaneInfo } from "../../src/tui/types";
+
+describe("buildTreeItems", () => {
+  test("passes zoomed and active pane metadata into pane detail rows", () => {
+    const repoPath = "/tmp/example-repo";
+    const branch = "feature/zoomed-pane";
+    const sessionName = formatSessionName(basename("/tmp/worktree-one"));
+    const panes: PaneInfo[] = [
+      {
+        paneId: "%1",
+        paneIndex: 0,
+        command: "bun run dev",
+        window: "main",
+        zoomed: true,
+        active: true,
+      },
+    ];
+
+    const items = buildTreeItems({
+      repos: [
+        {
+          id: "repo-1",
+          repoPath,
+          project: "example",
+          worktrees: [
+            {
+              branch,
+              path: "/tmp/worktree-one",
+              isMainWorktree: true,
+              changedFiles: 0,
+              sync: null,
+            },
+          ],
+          profileNames: [],
+        },
+      ],
+      expandedRepos: new Set(["repo-1"]),
+      expandedWorktreeKey: pendingKey("example", branch),
+      prData: new Map(),
+      panes: new Map([[sessionName, panes]]),
+      jumpToPane: () => undefined,
+    });
+
+    const paneItem = items.find(
+      (item) => item.type === "detail" && item.detailKind === "pane",
+    );
+
+    expect(paneItem?.meta).toEqual({ zoomed: true, active: true });
+  });
+});

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -1,7 +1,7 @@
 import { basename } from "node:path";
 import { describe, expect, test } from "vitest";
 import { formatSessionName } from "../../src/services/tmux";
-import { buildTreeItems } from "../../src/tui/App";
+import { buildTreeItems, resolveSelectedPane } from "../../src/tui/App";
 import { type PaneInfo, pendingKey } from "../../src/tui/types";
 
 describe("buildTreeItems", () => {
@@ -50,5 +50,99 @@ describe("buildTreeItems", () => {
     );
 
     expect(paneItem?.meta).toEqual({ zoomed: true, active: true });
+  });
+
+  test("resolves the selected pane from session/window/pane index data", () => {
+    const branch = "feature/pane-actions";
+    const repoPath = "/tmp/example-repo";
+    const worktreePath = "/tmp/worktree-pane-actions";
+    const sessionName = formatSessionName(basename(worktreePath));
+    const sessionPanes: PaneInfo[] = [
+      {
+        paneId: "%1",
+        paneIndex: 0,
+        command: "bun run dev",
+        window: "editor",
+        zoomed: false,
+        active: false,
+      },
+      {
+        paneId: "%2",
+        paneIndex: 1,
+        command: "git status",
+        window: "editor",
+        zoomed: true,
+        active: true,
+      },
+    ];
+
+    const items = buildTreeItems({
+      repos: [
+        {
+          id: "repo-1",
+          repoPath,
+          project: "example",
+          worktrees: [
+            {
+              branch,
+              path: worktreePath,
+              isMainWorktree: false,
+              changedFiles: 0,
+              sync: null,
+            },
+          ],
+          profileNames: [],
+        },
+      ],
+      expandedRepos: new Set(["repo-1"]),
+      expandedWorktreeKey: pendingKey("example", branch),
+      prData: new Map(),
+      panes: new Map([[sessionName, sessionPanes]]),
+      jumpToPane: () => undefined,
+    });
+
+    const selectedIndex = items.findIndex(
+      (item) =>
+        item.type === "detail" &&
+        item.detailKind === "pane" &&
+        item.label === "editor:1 git status",
+    );
+
+    const resolved = resolveSelectedPane({
+      repos: [
+        {
+          id: "repo-1",
+          repoPath,
+          project: "example",
+          worktrees: [
+            {
+              branch,
+              path: worktreePath,
+              isMainWorktree: false,
+              changedFiles: 0,
+              sync: null,
+            },
+          ],
+          profileNames: [],
+        },
+      ],
+      items,
+      panes: new Map([
+        [
+          sessionName,
+          [
+            { ...sessionPanes[0], paneId: "%9", zoomed: true, active: true },
+            { ...sessionPanes[1], command: "htop" },
+          ],
+        ],
+      ]),
+      selectedIndex,
+    });
+
+    expect(resolved).toEqual({
+      pane: { ...sessionPanes[1], command: "htop" },
+      label: "editor:1 git status",
+      worktreeKey: pendingKey("example", branch),
+    });
   });
 });

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -1,0 +1,77 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { describe, expect, test } from "vitest";
+import { DetailRow } from "../../src/tui/components/DetailRow";
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+};
+
+function createStdoutStdin() {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 80;
+  stdout.rows = 24;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = false;
+  stdin.setRawMode = () => stdin;
+  return { stdout, stdin };
+}
+
+async function renderDetailRow(
+  props: React.ComponentProps<typeof DetailRow>,
+) {
+  const { stdout, stdin } = createStdoutStdin();
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+  const { render } = await import("ink");
+  const instance = render(React.createElement(DetailRow, props), {
+    stdout,
+    stdin,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return {
+    output: chunks.join(""),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+describe("DetailRow", () => {
+  test("renders a zoom indicator only for the active zoomed pane", async () => {
+    const zoomedActive = await renderDetailRow({
+      kind: "pane",
+      label: "main:0 bash",
+      isSelected: false,
+      meta: { zoomed: true, active: true },
+    });
+    const zoomedInactive = await renderDetailRow({
+      kind: "pane",
+      label: "main:1 node",
+      isSelected: false,
+      meta: { zoomed: true, active: false },
+    });
+    const unzoomedActive = await renderDetailRow({
+      kind: "pane",
+      label: "main:2 zsh",
+      isSelected: false,
+      meta: { zoomed: false, active: true },
+    });
+
+    expect(zoomedActive.output).toContain("🔍");
+    expect(zoomedInactive.output).not.toContain("🔍");
+    expect(unzoomedActive.output).not.toContain("🔍");
+
+    zoomedActive.unmount();
+    zoomedInactive.unmount();
+    unzoomedActive.unmount();
+  });
+});

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -20,6 +20,17 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
+async function waitForOutput(chunks: string[], attempts = 20) {
+  for (let i = 0; i < attempts; i++) {
+    if (chunks.length > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
@@ -34,7 +45,7 @@ async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
     exitOnCtrlC: false,
   });
 
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await waitForOutput(chunks);
 
   return {
     output: chunks.join(""),

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -19,9 +19,7 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function renderDetailRow(
-  props: React.ComponentProps<typeof DetailRow>,
-) {
+async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
   stdout.on("data", (chunk) => {

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -20,13 +20,6 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function waitForOutput(chunks: string[], attempts = 50) {
-  for (let i = 0; i < attempts; i++) {
-    if (chunks.length > 0) return;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-}
-
 async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
@@ -37,11 +30,12 @@ async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
   const instance = render(React.createElement(DetailRow, props), {
     stdout,
     stdin,
+    debug: true,
     patchConsole: false,
     exitOnCtrlC: false,
   });
 
-  await waitForOutput(chunks);
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
   return {
     output: chunks.join(""),

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -20,14 +20,10 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function waitForOutput(chunks: string[], attempts = 20) {
+async function waitForOutput(chunks: string[], attempts = 50) {
   for (let i = 0; i < attempts; i++) {
-    if (chunks.length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (chunks.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
 

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -2,6 +2,7 @@ import { PassThrough } from "node:stream";
 import React from "react";
 import { describe, expect, test } from "vitest";
 import { DetailRow } from "../../src/tui/components/DetailRow";
+import type { TreeItem } from "../../src/tui/types";
 
 type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
 type TestStdin = NodeJS.ReadStream & {
@@ -46,22 +47,37 @@ async function renderDetailRow(props: React.ComponentProps<typeof DetailRow>) {
 describe("DetailRow", () => {
   test("renders a zoom indicator only for the active zoomed pane", async () => {
     const zoomedActive = await renderDetailRow({
-      kind: "pane",
-      label: "main:0 bash",
+      item: {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "main:0 bash",
+        meta: { zoomed: true, active: true },
+      } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>,
       isSelected: false,
-      meta: { zoomed: true, active: true },
     });
     const zoomedInactive = await renderDetailRow({
-      kind: "pane",
-      label: "main:1 node",
+      item: {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "main:1 node",
+        meta: { zoomed: true, active: false },
+      } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>,
       isSelected: false,
-      meta: { zoomed: true, active: false },
     });
     const unzoomedActive = await renderDetailRow({
-      kind: "pane",
-      label: "main:2 zsh",
+      item: {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "main:2 zsh",
+        meta: { zoomed: false, active: true },
+      } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>,
       isSelected: false,
-      meta: { zoomed: false, active: true },
     });
 
     expect(zoomedActive.output).toContain("🔍");

--- a/tests/tui/status-bar-wiring.test.ts
+++ b/tests/tui/status-bar-wiring.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { resolveStatusBarProps } from "../../src/tui/App";
+import { Mode, type TreeItem } from "../../src/tui/types";
+
+describe("resolveStatusBarProps", () => {
+  test("marks a selected pane detail row", () => {
+    const items: TreeItem[] = [
+      { type: "repo", repoIndex: 0 },
+      {
+        type: "detail",
+        repoIndex: 0,
+        worktreeIndex: 0,
+        detailKind: "pane",
+        label: "main:0 bash",
+        meta: { paneId: "%1", zoomed: false, active: true },
+      },
+    ];
+
+    expect(
+      resolveStatusBarProps({
+        mode: Mode.Expanded("proj/branch"),
+        items,
+        selectedIndex: 1,
+      }),
+    ).toEqual({
+      mode: Mode.Expanded("proj/branch"),
+      selectedPaneRow: true,
+    });
+  });
+
+  test("does not mark a non-pane selected row", () => {
+    const items: TreeItem[] = [
+      { type: "repo", repoIndex: 0 },
+      { type: "worktree", repoIndex: 0, worktreeIndex: 0 },
+    ];
+
+    expect(
+      resolveStatusBarProps({
+        mode: Mode.Expanded("proj/branch"),
+        items,
+        selectedIndex: 1,
+      }),
+    ).toEqual({
+      mode: Mode.Expanded("proj/branch"),
+      selectedPaneRow: false,
+    });
+  });
+
+  test("passes ConfirmKill mode through unchanged", () => {
+    const confirmKill = Mode.ConfirmKill("%1", "shell:1 vim", "proj/branch");
+
+    expect(
+      resolveStatusBarProps({
+        mode: confirmKill,
+        items: [
+          { type: "repo", repoIndex: 0 },
+          {
+            type: "detail",
+            repoIndex: 0,
+            worktreeIndex: 0,
+            detailKind: "pane",
+            label: "main:0 bash",
+            meta: { paneId: "%1", zoomed: false, active: true },
+          },
+        ],
+        selectedIndex: 1,
+      }),
+    ).toEqual({
+      mode: confirmKill,
+      selectedPaneRow: true,
+    });
+  });
+});

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -20,6 +20,17 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
+async function waitForOutput(chunks: string[], attempts = 20) {
+  for (let i = 0; i < attempts; i++) {
+    if (chunks.length > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
@@ -34,7 +45,7 @@ async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
     exitOnCtrlC: false,
   });
 
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await waitForOutput(chunks);
 
   return {
     output: chunks.join(""),

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -51,7 +51,9 @@ describe("StatusBar", () => {
       selectedPaneRow: true,
     });
 
-    expect(rendered.output).toContain("↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill");
+    expect(rendered.output).toContain(
+      "↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill",
+    );
     expect(rendered.output).toContain("/:search  q:quit");
 
     rendered.unmount();

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -20,14 +20,10 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function waitForOutput(chunks: string[], attempts = 20) {
+async function waitForOutput(chunks: string[], attempts = 50) {
   for (let i = 0; i < attempts; i++) {
-    if (chunks.length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (chunks.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
 

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -1,0 +1,84 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { describe, expect, test } from "vitest";
+import { StatusBar } from "../../src/tui/components/StatusBar";
+import { Mode } from "../../src/tui/types";
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+};
+
+function createStdoutStdin() {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 80;
+  stdout.rows = 24;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = false;
+  stdin.setRawMode = () => stdin;
+  return { stdout, stdin };
+}
+
+async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
+  const { stdout, stdin } = createStdoutStdin();
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+  const { render } = await import("ink");
+  const instance = render(React.createElement(StatusBar, props), {
+    stdout,
+    stdin,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return {
+    output: chunks.join(""),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+describe("StatusBar", () => {
+  test("shows pane hints for expanded pane rows", async () => {
+    const rendered = await renderStatusBar({
+      mode: Mode.Expanded("proj/branch"),
+      selectedPaneRow: true,
+    });
+
+    expect(rendered.output).toContain("↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill");
+    expect(rendered.output).toContain("/:search  q:quit");
+
+    rendered.unmount();
+  });
+
+  test("shows generic expanded hints for non-pane rows", async () => {
+    const rendered = await renderStatusBar({
+      mode: Mode.Expanded("proj/branch"),
+      selectedPaneRow: false,
+    });
+
+    expect(rendered.output).toContain(
+      "↑↓:navigate  ←:collapse  space:action  o:open",
+    );
+    expect(rendered.output).toContain("/:search  q:quit");
+
+    rendered.unmount();
+  });
+
+  test("shows the kill confirmation prompt", async () => {
+    const rendered = await renderStatusBar({
+      mode: Mode.ConfirmKill("%1", "shell:1 vim", "proj/branch"),
+    });
+
+    expect(rendered.output).toContain("Kill pane shell:1 vim?");
+    expect(rendered.output).toContain("enter:confirm  esc:cancel");
+
+    rendered.unmount();
+  });
+});

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -20,13 +20,6 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function waitForOutput(chunks: string[], attempts = 50) {
-  for (let i = 0; i < attempts; i++) {
-    if (chunks.length > 0) return;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-}
-
 async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
@@ -37,11 +30,12 @@ async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
   const instance = render(React.createElement(StatusBar, props), {
     stdout,
     stdin,
+    debug: true,
     patchConsole: false,
     exitOnCtrlC: false,
   });
 
-  await waitForOutput(chunks);
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
   return {
     output: chunks.join(""),

--- a/tests/tui/tree-view-keys.test.ts
+++ b/tests/tui/tree-view-keys.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { getDetailRowKey } from "../../src/tui/components/TreeView";
+import type { TreeItem } from "../../src/tui/types";
+
+describe("getDetailRowKey", () => {
+  test("uses pane identity instead of label so duplicate pane labels do not collide", () => {
+    const paneA = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:0 bash",
+      meta: { paneId: "%1", zoomed: false, active: false },
+    } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>;
+    const paneB = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:0 bash",
+      meta: { paneId: "%2", zoomed: true, active: true },
+    } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>;
+
+    expect(getDetailRowKey("repo-1", paneA)).toBe(
+      "detail-repo-1-0-pane-%1",
+    );
+    expect(getDetailRowKey("repo-1", paneB)).toBe(
+      "detail-repo-1-0-pane-%2",
+    );
+    expect(getDetailRowKey("repo-1", paneA)).not.toBe(
+      getDetailRowKey("repo-1", paneB),
+    );
+  });
+
+  test("keeps non-pane detail keys stable and label-based", () => {
+    const prItem = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 2,
+      detailKind: "pr",
+      label: "PR #42",
+    } as Extract<TreeItem, { type: "detail"; detailKind: "pr" }>;
+
+    expect(getDetailRowKey("repo-1", prItem)).toBe(
+      "detail-repo-1-2-pr-PR #42",
+    );
+  });
+});

--- a/tests/tui/tree-view-keys.test.ts
+++ b/tests/tui/tree-view-keys.test.ts
@@ -21,12 +21,8 @@ describe("getDetailRowKey", () => {
       meta: { paneId: "%2", zoomed: true, active: true },
     } as Extract<TreeItem, { type: "detail"; detailKind: "pane" }>;
 
-    expect(getDetailRowKey("repo-1", paneA)).toBe(
-      "detail-repo-1-0-pane-%1",
-    );
-    expect(getDetailRowKey("repo-1", paneB)).toBe(
-      "detail-repo-1-0-pane-%2",
-    );
+    expect(getDetailRowKey("repo-1", paneA)).toBe("detail-repo-1-0-pane-%1");
+    expect(getDetailRowKey("repo-1", paneB)).toBe("detail-repo-1-0-pane-%2");
     expect(getDetailRowKey("repo-1", paneA)).not.toBe(
       getDetailRowKey("repo-1", paneB),
     );
@@ -41,8 +37,6 @@ describe("getDetailRowKey", () => {
       label: "PR #42",
     } as Extract<TreeItem, { type: "detail"; detailKind: "pr" }>;
 
-    expect(getDetailRowKey("repo-1", prItem)).toBe(
-      "detail-repo-1-2-pr-PR #42",
-    );
+    expect(getDetailRowKey("repo-1", prItem)).toBe("detail-repo-1-2-pr-PR #42");
   });
 });

--- a/tests/tui/types.test.ts
+++ b/tests/tui/types.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, test } from "vitest";
-import { checkColor, checkIcon, pendingKey } from "../../src/tui/types";
+import { Mode, checkColor, checkIcon, pendingKey } from "../../src/tui/types";
 
 describe("pendingKey", () => {
   test("formats project/branch", () => {
     expect(pendingKey("wct", "feat/tui")).toBe("wct/feat/tui");
+  });
+});
+
+describe("Mode", () => {
+  test("constructs ConfirmKill mode", () => {
+    expect(Mode.ConfirmKill("%1", "shell:1 vim", "proj/branch")).toEqual({
+      type: "ConfirmKill",
+      paneId: "%1",
+      label: "shell:1 vim",
+      worktreeKey: "proj/branch",
+    });
   });
 });
 

--- a/tests/tui/types.test.ts
+++ b/tests/tui/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { Mode, checkColor, checkIcon, pendingKey } from "../../src/tui/types";
+import { checkColor, checkIcon, Mode, pendingKey } from "../../src/tui/types";
 
 describe("pendingKey", () => {
   test("formats project/branch", () => {

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -21,9 +21,9 @@ vi.mock("../../src/tui/runtime", () => ({
 }));
 
 vi.mock("../../src/services/tmux", async () => {
-  const actual = await vi.importActual<typeof import("../../src/services/tmux")>(
-    "../../src/services/tmux",
-  );
+  const actual = await vi.importActual<
+    typeof import("../../src/services/tmux")
+  >("../../src/services/tmux");
 
   return {
     ...actual,

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -62,6 +62,19 @@ async function flush(n = 5) {
   }
 }
 
+async function renderWithSingleClient() {
+  const singleClient = { tty: "/dev/ttys001", session: "main" };
+  mockRunPromise
+    .mockResolvedValueOnce([singleClient]) // listClients
+    .mockResolvedValueOnce(null); // listSessions
+
+  const harness = await renderUseTmux();
+  await flush(10);
+
+  expect(harness.value.client).toEqual(singleClient);
+  return harness;
+}
+
 describe("useTmux hook", () => {
   beforeEach(() => {
     mockRunPromise.mockReset();
@@ -142,17 +155,7 @@ describe("useTmux hook", () => {
   });
 
   test("jumpToPane returns false when runtime navigation fails", async () => {
-    const singleClient = { tty: "/dev/ttys001", session: "main" };
-
-    // Mount with one client so client is set
-    mockRunPromise
-      .mockResolvedValueOnce([singleClient]) // listClients
-      .mockResolvedValueOnce(null); // listSessions
-
-    const harness = await renderUseTmux();
-    await flush(10);
-
-    expect(harness.value.client).toEqual(singleClient);
+    const harness = await renderWithSingleClient();
 
     // Make the next runPromise call reject (switchClientToPane failure)
     mockRunPromise.mockRejectedValueOnce(new Error("tmux switch failed"));
@@ -179,6 +182,28 @@ describe("useTmux hook", () => {
     harness.unmount();
   });
 
+  test("zoomPane returns true when the runtime call succeeds", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockResolvedValueOnce(undefined);
+
+    const result = await harness.value.zoomPane("pane-id");
+    expect(result).toBe(true);
+
+    harness.unmount();
+  });
+
+  test("zoomPane returns false when the runtime call rejects", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockRejectedValueOnce(new Error("tmux zoom failed"));
+
+    const result = await harness.value.zoomPane("pane-id");
+    expect(result).toBe(false);
+
+    harness.unmount();
+  });
+
   test("killPane returns false when no active client exists", async () => {
     mockRunPromise
       .mockResolvedValueOnce([]) // listClients
@@ -188,6 +213,28 @@ describe("useTmux hook", () => {
     await flush(10);
 
     expect(harness.value.client).toBeNull();
+
+    const result = await harness.value.killPane("pane-id");
+    expect(result).toBe(false);
+
+    harness.unmount();
+  });
+
+  test("killPane returns true when the runtime call succeeds", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockResolvedValueOnce(undefined);
+
+    const result = await harness.value.killPane("pane-id");
+    expect(result).toBe(true);
+
+    harness.unmount();
+  });
+
+  test("killPane returns false when the runtime call rejects", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockRejectedValueOnce(new Error("tmux kill failed"));
 
     const result = await harness.value.killPane("pane-id");
     expect(result).toBe(false);

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -192,10 +192,11 @@ describe("useTmux hook", () => {
     harness.unmount();
   });
 
-  test("zoomPane returns false when no active client exists", async () => {
+  test("zoomPane still runs when no active client exists", async () => {
     mockRunPromise
       .mockResolvedValueOnce([]) // listClients
-      .mockResolvedValueOnce(null); // listSessions
+      .mockResolvedValueOnce(null) // listSessions
+      .mockResolvedValueOnce(undefined); // togglePaneZoom
 
     const harness = await renderUseTmux();
     await flush(10);
@@ -203,7 +204,8 @@ describe("useTmux hook", () => {
     expect(harness.value.client).toBeNull();
 
     const result = await harness.value.zoomPane("pane-id");
-    expect(result).toBe(false);
+    expect(result).toBe(true);
+    expect(tmuxServiceMock.togglePaneZoom).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });
@@ -232,10 +234,11 @@ describe("useTmux hook", () => {
     harness.unmount();
   });
 
-  test("killPane returns false when no active client exists", async () => {
+  test("killPane still runs when no active client exists", async () => {
     mockRunPromise
       .mockResolvedValueOnce([]) // listClients
-      .mockResolvedValueOnce(null); // listSessions
+      .mockResolvedValueOnce(null) // listSessions
+      .mockResolvedValueOnce(undefined); // killPane
 
     const harness = await renderUseTmux();
     await flush(10);
@@ -243,7 +246,8 @@ describe("useTmux hook", () => {
     expect(harness.value.client).toBeNull();
 
     const result = await harness.value.killPane("pane-id");
-    expect(result).toBe(false);
+    expect(result).toBe(true);
+    expect(tmuxServiceMock.killPane).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -162,4 +162,36 @@ describe("useTmux hook", () => {
 
     harness.unmount();
   });
+
+  test("zoomPane returns false when no active client exists", async () => {
+    mockRunPromise
+      .mockResolvedValueOnce([]) // listClients
+      .mockResolvedValueOnce(null); // listSessions
+
+    const harness = await renderUseTmux();
+    await flush(10);
+
+    expect(harness.value.client).toBeNull();
+
+    const result = await harness.value.zoomPane("pane-id");
+    expect(result).toBe(false);
+
+    harness.unmount();
+  });
+
+  test("killPane returns false when no active client exists", async () => {
+    mockRunPromise
+      .mockResolvedValueOnce([]) // listClients
+      .mockResolvedValueOnce(null); // listSessions
+
+    const harness = await renderUseTmux();
+    await flush(10);
+
+    expect(harness.value.client).toBeNull();
+
+    const result = await harness.value.killPane("pane-id");
+    expect(result).toBe(false);
+
+    harness.unmount();
+  });
 });

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -2,12 +2,37 @@ import { PassThrough } from "node:stream";
 import React, { type FC } from "react";
 import { beforeEach, describe, expect, type Mock, test, vi } from "vitest";
 
+const tmuxServiceMock = vi.hoisted(() => ({
+  listClients: vi.fn(),
+  listSessions: vi.fn(),
+  listPanes: vi.fn(),
+  switchClientToPane: vi.fn(),
+  togglePaneZoom: vi.fn(),
+  killPane: vi.fn(),
+  selectPane: vi.fn(),
+  refreshClient: vi.fn(),
+}));
+
 // Mock tuiRuntime before importing the hook
 vi.mock("../../src/tui/runtime", () => ({
   tuiRuntime: {
     runPromise: vi.fn(),
   },
 }));
+
+vi.mock("../../src/services/tmux", async () => {
+  const actual = await vi.importActual<typeof import("../../src/services/tmux")>(
+    "../../src/services/tmux",
+  );
+
+  return {
+    ...actual,
+    TmuxService: {
+      use: (selector: (service: typeof tmuxServiceMock) => unknown) =>
+        selector(tmuxServiceMock),
+    },
+  };
+});
 
 // Lazy imports so the mock is in place
 const { tuiRuntime } = await import("../../src/tui/runtime");
@@ -77,6 +102,7 @@ async function renderWithSingleClient() {
 
 describe("useTmux hook", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockRunPromise.mockReset();
   });
 
@@ -189,6 +215,7 @@ describe("useTmux hook", () => {
 
     const result = await harness.value.zoomPane("pane-id");
     expect(result).toBe(true);
+    expect(tmuxServiceMock.togglePaneZoom).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });
@@ -200,6 +227,7 @@ describe("useTmux hook", () => {
 
     const result = await harness.value.zoomPane("pane-id");
     expect(result).toBe(false);
+    expect(tmuxServiceMock.togglePaneZoom).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });
@@ -227,6 +255,7 @@ describe("useTmux hook", () => {
 
     const result = await harness.value.killPane("pane-id");
     expect(result).toBe(true);
+    expect(tmuxServiceMock.killPane).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });
@@ -238,6 +267,7 @@ describe("useTmux hook", () => {
 
     const result = await harness.value.killPane("pane-id");
     expect(result).toBe(false);
+    expect(tmuxServiceMock.killPane).toHaveBeenCalledWith("pane-id");
 
     harness.unmount();
   });


### PR DESCRIPTION
## Summary
- Add zoom toggle (`z`) and kill (`x`) keybindings for tmux panes in TUI expanded worktree view
- Show 🔍 icon on zoomed panes for visual indication
- Kill pane shows inline confirmation prompt (enter/esc) before executing
- Extended `TmuxPaneInfo` with zoom and active state from tmux
- Added `togglePaneZoom` and `killPane` to TmuxService

## Test plan
- [x] Verify zoom toggle works on a multi-pane tmux session (press `z` on pane row)
- [x] Verify 🔍 icon appears on zoomed pane rows and disappears on unzoom
- [x] Verify kill confirmation prompt appears on `x`, cancels with `esc`, executes with `enter`
- [x] Verify killing last pane in a window removes the window
- [x] Verify StatusBar shows `z:zoom x:kill` hints when pane row is selected
- [x] Run `bun run test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded view: press `z` to toggle pane zoom; press `x` to prompt pane kill (Enter to confirm, Esc to cancel)
  * Zoomed+active panes show a magnifying-glass indicator; status bar shows `z:zoom`/`x:kill` hints and a red kill confirmation prompt

* **Tests**
  * Added/updated unit and UI tests covering pane-list parsing, tree wiring, hook actions, detail-row rendering, status bar prompts, and key handling

* **Documentation**
  * Added design and implementation plan for TUI pane actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->