### PR TITLE
Fix TUI expanded mode interactions

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -2,7 +2,7 @@
 
 import { basename } from "node:path";
 import { Box, type Key, render, Text, useApp, useInput, useStdout } from "ink";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatSessionName } from "../services/tmux";
 import { OpenModal, type OpenModalResult } from "./components/OpenModal";
 import { StatusBar } from "./components/StatusBar";
@@ -47,6 +47,44 @@ interface ResolveStatusBarPropsOptions {
   items: TreeItem[];
   selectedIndex: number;
 }
+
+interface ResolveExpandedRightArrowActionOptions {
+  repos: RepoInfo[];
+  items: TreeItem[];
+  selectedIndex: number;
+  expandedRepos: Set<string>;
+}
+
+interface ResolveRecoveredSelectionIndexOptions {
+  prevTree: TreeItem[];
+  treeItems: TreeItem[];
+  prevSelectionId: string | null;
+  selectedIndex: number;
+  repos: RepoInfo[];
+  skipIdentityRecovery?: boolean;
+}
+
+interface ResolveCloseSelectedWorktreeActionOptions {
+  mode: Mode;
+  repos: RepoInfo[];
+  items: TreeItem[];
+  selectedIndex: number;
+}
+
+type ExpandedRightArrowAction =
+  | { type: "noop" }
+  | { type: "expand-repo"; repoId: string }
+  | { type: "expand-worktree"; nextMode: Mode; nextSelectedIndex: number };
+
+type CloseSelectedWorktreeAction =
+  | { type: "noop" }
+  | {
+      type: "close-worktree";
+      worktreeIndex: number;
+      worktreeKey: string;
+      nextMode?: Mode;
+      nextSelectedIndex?: number;
+    };
 
 export interface ResolvedStatusBarProps {
   mode: Mode;
@@ -136,6 +174,186 @@ export function buildTreeItems({
     }
   }
   return items;
+}
+
+/**
+ * Compute a stable identity string for a tree item using repo id and branch,
+ * so selection can be recovered after background refreshes that shift indices.
+ */
+export function treeItemId(item: TreeItem, repos: RepoInfo[]): string | null {
+  const repo = repos[item.repoIndex];
+  if (!repo) return null;
+  if (item.type === "repo") return `repo:${repo.id}`;
+  const wt = repo.worktrees[item.worktreeIndex];
+  if (!wt) return null;
+  if (item.type === "worktree") return `wt:${repo.id}/${wt.branch}`;
+  const base = `detail:${repo.id}/${wt.branch}/${item.detailKind}`;
+  if (item.detailKind === "pane" && item.meta?.paneId)
+    return `${base}/${item.meta.paneId}`;
+  if (item.detailKind === "check") return `${base}/${item.label}`;
+  return base;
+}
+
+/**
+ * Compute the adjusted selectedIndex after all detail rows are removed from the
+ * tree (e.g. when exiting Expanded mode or switching expanded worktree).
+ *
+ * - If the cursor is on a detail row, snap to its parent worktree.
+ * - Otherwise subtract the number of detail rows before the cursor.
+ */
+export function adjustIndexForDetailCollapse(
+  items: TreeItem[],
+  selectedIndex: number,
+): number {
+  const current = items[selectedIndex];
+
+  if (current?.type === "detail") {
+    return findOwningWorktreeIndex(items, selectedIndex) ?? 0;
+  }
+
+  let detailsBefore = 0;
+  for (let i = 0; i < selectedIndex; i++) {
+    if (items[i]?.type === "detail") detailsBefore++;
+  }
+  return selectedIndex - detailsBefore;
+}
+
+export function resolveRecoveredSelectionIndex({
+  prevTree,
+  treeItems,
+  prevSelectionId,
+  selectedIndex,
+  repos,
+  skipIdentityRecovery = false,
+}: ResolveRecoveredSelectionIndexOptions): number | null {
+  if (prevTree === treeItems || !prevSelectionId || skipIdentityRecovery) {
+    return null;
+  }
+
+  const currentItem = treeItems[selectedIndex];
+  if (currentItem && treeItemId(currentItem, repos) === prevSelectionId) {
+    return null;
+  }
+
+  for (let i = 0; i < treeItems.length; i++) {
+    const candidate = treeItems[i];
+    if (candidate && treeItemId(candidate, repos) === prevSelectionId) {
+      return i;
+    }
+  }
+
+  if (treeItems.length === 0) {
+    return 0;
+  }
+
+  if (selectedIndex >= treeItems.length) {
+    return treeItems.length - 1;
+  }
+
+  return null;
+}
+
+export function resolveSelectedWorktreeIndex(
+  items: TreeItem[],
+  selectedIndex: number,
+): number | null {
+  const selected = items[selectedIndex];
+  if (!selected) {
+    return null;
+  }
+
+  if (selected.type === "worktree") {
+    return selectedIndex;
+  }
+
+  if (selected.type === "detail") {
+    return findOwningWorktreeIndex(items, selectedIndex);
+  }
+
+  return null;
+}
+
+export function resolveCloseSelectedWorktreeAction({
+  mode,
+  repos,
+  items,
+  selectedIndex,
+}: ResolveCloseSelectedWorktreeActionOptions): CloseSelectedWorktreeAction {
+  const worktreeIndex = resolveSelectedWorktreeIndex(items, selectedIndex);
+  if (worktreeIndex === null) {
+    return { type: "noop" };
+  }
+
+  const selectedWorktree = items[worktreeIndex];
+  if (!selectedWorktree || selectedWorktree.type !== "worktree") {
+    return { type: "noop" };
+  }
+
+  const repo = repos[selectedWorktree.repoIndex];
+  const worktree = repo?.worktrees[selectedWorktree.worktreeIndex];
+  if (!repo || !worktree) {
+    return { type: "noop" };
+  }
+
+  const worktreeKey = pendingKey(repo.project, worktree.branch);
+  if (
+    (mode.type === "Expanded" || mode.type === "ConfirmKill") &&
+    mode.worktreeKey === worktreeKey
+  ) {
+    return {
+      type: "close-worktree",
+      worktreeIndex,
+      worktreeKey,
+      nextMode: Mode.Navigate,
+      nextSelectedIndex: adjustIndexForDetailCollapse(items, selectedIndex),
+    };
+  }
+
+  return {
+    type: "close-worktree",
+    worktreeIndex,
+    worktreeKey,
+  };
+}
+
+export function resolveExpandedRightArrowAction({
+  repos,
+  items,
+  selectedIndex,
+  expandedRepos,
+}: ResolveExpandedRightArrowActionOptions): ExpandedRightArrowAction {
+  const current = items[selectedIndex];
+  if (!current) {
+    return { type: "noop" };
+  }
+
+  const repo = repos[current.repoIndex];
+  if (!repo) {
+    return { type: "noop" };
+  }
+
+  if (current.type === "repo") {
+    if (expandedRepos.has(repo.id)) {
+      return { type: "noop" };
+    }
+
+    return { type: "expand-repo", repoId: repo.id };
+  }
+
+  if (current.type !== "worktree") {
+    return { type: "noop" };
+  }
+
+  const worktree = repo.worktrees[current.worktreeIndex];
+  if (!worktree) {
+    return { type: "noop" };
+  }
+
+  return {
+    type: "expand-worktree",
+    nextMode: Mode.Expanded(pendingKey(repo.project, worktree.branch)),
+    nextSelectedIndex: adjustIndexForDetailCollapse(items, selectedIndex),
+  };
 }
 
 export function findOwningWorktreeIndex(
@@ -312,6 +530,45 @@ export function App() {
       jumpToPane,
     ],
   );
+
+  // Identity-based selection recovery: when the tree structure changes
+  // (background refresh, async worktree add/remove), find the previously-
+  // selected item by stable identity instead of blindly clamping by length.
+  const prevTreeRef = useRef(treeItems);
+  const prevSelectionIdRef = useRef<string | null>(null);
+  const prevSearchQueryRef = useRef(searchQuery);
+
+  useEffect(() => {
+    const prevTree = prevTreeRef.current;
+    const prevId = prevSelectionIdRef.current;
+    const prevSearchQuery = prevSearchQueryRef.current;
+    const searchQueryChanged = prevSearchQuery !== searchQuery;
+
+    // Snapshot current state for the next cycle before any mutations
+    prevTreeRef.current = treeItems;
+    prevSearchQueryRef.current = searchQuery;
+
+    if (searchQueryChanged) {
+      // Search transitions intentionally reset the cursor to the first match.
+      prevSelectionIdRef.current = null;
+      return;
+    }
+
+    const item = treeItems[selectedIndex];
+    prevSelectionIdRef.current = item ? treeItemId(item, filteredRepos) : null;
+
+    const recoveredIndex = resolveRecoveredSelectionIndex({
+      prevTree,
+      treeItems,
+      prevSelectionId: prevId,
+      selectedIndex,
+      repos: filteredRepos,
+    });
+    if (recoveredIndex !== null && recoveredIndex !== selectedIndex) {
+      setSelectedIndex(recoveredIndex);
+    }
+  }, [treeItems, selectedIndex, filteredRepos, searchQuery]);
+
   const statusBarProps = resolveStatusBarProps({
     mode,
     items: treeItems,
@@ -452,16 +709,14 @@ export function App() {
       return;
     }
 
-    // For other detail rows, resolve the parent worktree
-    const resolvedItem =
-      item.type === "detail"
-        ? {
-            type: "worktree" as const,
-            repoIndex: item.repoIndex,
-            worktreeIndex: item.worktreeIndex,
-          }
-        : item;
-    if (resolvedItem.type !== "worktree") return;
+    const worktreeIndex = resolveSelectedWorktreeIndex(
+      treeItems,
+      selectedIndex,
+    );
+    if (worktreeIndex === null) return;
+
+    const resolvedItem = treeItems[worktreeIndex];
+    if (!resolvedItem || resolvedItem.type !== "worktree") return;
     const repo = filteredRepos[resolvedItem.repoIndex];
     if (!repo) return;
     const wt = repo.worktrees[resolvedItem.worktreeIndex];
@@ -496,6 +751,75 @@ export function App() {
         });
       });
     }
+  }
+
+  function handleCloseSelectedWorktree() {
+    const action = resolveCloseSelectedWorktreeAction({
+      mode,
+      repos: filteredRepos,
+      items: treeItems,
+      selectedIndex,
+    });
+    if (action.type === "noop") {
+      return;
+    }
+
+    if (action.nextSelectedIndex !== undefined) {
+      setSelectedIndex(action.nextSelectedIndex);
+    }
+    if (action.nextMode) {
+      setMode(action.nextMode);
+    }
+
+    const currentItem = treeItems[action.worktreeIndex];
+    if (currentItem?.type !== "worktree") {
+      return;
+    }
+
+    const currentRepo = filteredRepos[currentItem.repoIndex];
+    if (!currentRepo) {
+      return;
+    }
+
+    const currentWorktree = currentRepo.worktrees[currentItem.worktreeIndex];
+    if (!currentWorktree) {
+      return;
+    }
+
+    const closingSession = formatSessionName(basename(currentWorktree.path));
+    if (client && client.session === closingSession) {
+      const other = sessions.find((s) => s.name !== closingSession);
+      if (other) {
+        switchSession(other.name);
+      }
+    }
+
+    const pendingActionKey = pendingKey(
+      currentRepo.project,
+      currentWorktree.branch,
+    );
+    setPendingActions((prev) =>
+      new Map(prev).set(pendingActionKey, {
+        type: "closing",
+        branch: currentWorktree.branch,
+        project: currentRepo.project,
+      }),
+    );
+
+    const proc = Bun.spawn(["wct", "close", currentWorktree.branch, "--yes"], {
+      cwd: currentRepo.repoPath,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    proc.exited.then(() => {
+      refreshAll().then(() => {
+        setPendingActions((prev) => {
+          const next = new Map(prev);
+          next.delete(pendingActionKey);
+          return next;
+        });
+      });
+    });
   }
 
   function handleNavigateInput(input: string, key: Key) {
@@ -561,43 +885,7 @@ export function App() {
     }
 
     if (input === "c" && currentItem.type === "worktree" && currentWorktree) {
-      const closingSession = formatSessionName(basename(currentWorktree.path));
-      if (client && client.session === closingSession) {
-        const other = sessions.find((s) => s.name !== closingSession);
-        if (other) {
-          switchSession(other.name);
-        }
-      }
-
-      const pendingActionKey = pendingKey(
-        currentRepo.project,
-        currentWorktree.branch,
-      );
-      setPendingActions((prev) =>
-        new Map(prev).set(pendingActionKey, {
-          type: "closing",
-          branch: currentWorktree.branch,
-          project: currentRepo.project,
-        }),
-      );
-
-      const proc = Bun.spawn(
-        ["wct", "close", currentWorktree.branch, "--yes"],
-        {
-          cwd: currentRepo.repoPath,
-          stdout: "ignore",
-          stderr: "ignore",
-        },
-      );
-      proc.exited.then(() => {
-        refreshAll().then(() => {
-          setPendingActions((prev) => {
-            const next = new Map(prev);
-            next.delete(pendingActionKey);
-            return next;
-          });
-        });
-      });
+      handleCloseSelectedWorktree();
       return;
     }
   }
@@ -617,10 +905,7 @@ export function App() {
 
   function handleExpandedInput(input: string, key: Key) {
     if (key.leftArrow || key.escape) {
-      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
-      if (parentIndex !== null) {
-        setSelectedIndex(parentIndex);
-      }
+      setSelectedIndex(adjustIndexForDetailCollapse(treeItems, selectedIndex));
       setMode(Mode.Navigate);
       return;
     }
@@ -636,14 +921,23 @@ export function App() {
     }
 
     if (key.rightArrow) {
-      const current = treeItems[selectedIndex];
-      if (current?.type === "worktree") {
-        const repo = filteredRepos[current.repoIndex];
-        const wt = repo?.worktrees[current.worktreeIndex];
-        if (repo && wt) {
-          setMode(Mode.Expanded(pendingKey(repo.project, wt.branch)));
-        }
+      const action = resolveExpandedRightArrowAction({
+        repos: filteredRepos,
+        items: treeItems,
+        selectedIndex,
+        expandedRepos,
+      });
+
+      if (action.type === "expand-repo") {
+        toggleExpanded(action.repoId);
+        return;
       }
+
+      if (action.type === "expand-worktree") {
+        setSelectedIndex(action.nextSelectedIndex);
+        setMode(action.nextMode);
+      }
+
       return;
     }
 
@@ -654,6 +948,11 @@ export function App() {
 
     if (input === "o") {
       prepareOpenModal();
+      return;
+    }
+
+    if (input === "c") {
+      handleCloseSelectedWorktree();
       return;
     }
 

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -27,7 +27,7 @@ function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
         ];
       }
       return [
-        "↑↓:navigate  ←:collapse  space:action  o:open",
+        "↑↓:navigate  ←:collapse  space:action  o:open  c:close",
         "/:search  q:quit",
       ];
     case "ConfirmKill":

--- a/tests/tui/adjust-index.test.ts
+++ b/tests/tui/adjust-index.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from "vitest";
+import {
+  adjustIndexForDetailCollapse,
+  resolveCloseSelectedWorktreeAction,
+  resolveExpandedRightArrowAction,
+  resolveRecoveredSelectionIndex,
+  resolveSelectedWorktreeIndex,
+  treeItemId,
+} from "../../src/tui/App";
+import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
+import { Mode, pendingKey, type TreeItem } from "../../src/tui/types";
+
+function repo(repoIndex: number): TreeItem {
+  return { type: "repo", repoIndex };
+}
+
+function worktree(repoIndex: number, worktreeIndex: number): TreeItem {
+  return { type: "worktree", repoIndex, worktreeIndex };
+}
+
+function detail(
+  repoIndex: number,
+  worktreeIndex: number,
+  kind: "pr" | "check" | "pane-header" = "pr",
+): TreeItem {
+  return {
+    type: "detail",
+    repoIndex,
+    worktreeIndex,
+    detailKind: kind,
+    label: `detail-${kind}`,
+  } as TreeItem;
+}
+
+function fakeRepo(id: string, branches: string[]): RepoInfo {
+  return {
+    id,
+    repoPath: `/tmp/${id}`,
+    project: id,
+    worktrees: branches.map((b) => ({
+      branch: b,
+      path: `/tmp/${id}/${b}`,
+      isMainWorktree: false,
+      changedFiles: 0,
+      sync: null,
+    })),
+    profileNames: [],
+  };
+}
+
+describe("adjustIndexForDetailCollapse", () => {
+  // [0] Repo A
+  // [1]   branch-1  (expanded)
+  // [2]     PR #42        (detail)
+  // [3]     Panes (1)     (detail)
+  // [4]     pane 0:0      (detail)
+  // [5]   branch-2
+  // [6] Repo B
+  // [7]   branch-3
+  const items: TreeItem[] = [
+    repo(0),
+    worktree(0, 0),
+    detail(0, 0, "pr"),
+    detail(0, 0, "pane-header"),
+    detail(0, 0, "pr"),
+    worktree(0, 1),
+    repo(1),
+    worktree(1, 0),
+  ];
+
+  test("cursor on detail row snaps to parent worktree", () => {
+    expect(adjustIndexForDetailCollapse(items, 2)).toBe(1);
+    expect(adjustIndexForDetailCollapse(items, 3)).toBe(1);
+    expect(adjustIndexForDetailCollapse(items, 4)).toBe(1);
+  });
+
+  test("cursor after details subtracts detail count", () => {
+    // branch-2 at index 5, 3 details before → 5 - 3 = 2
+    expect(adjustIndexForDetailCollapse(items, 5)).toBe(2);
+    // Repo B at index 6, 3 details before → 6 - 3 = 3
+    expect(adjustIndexForDetailCollapse(items, 6)).toBe(3);
+    // branch-3 at index 7, 3 details before → 7 - 3 = 4
+    expect(adjustIndexForDetailCollapse(items, 7)).toBe(4);
+  });
+
+  test("cursor before details stays unchanged", () => {
+    expect(adjustIndexForDetailCollapse(items, 0)).toBe(0);
+    expect(adjustIndexForDetailCollapse(items, 1)).toBe(1);
+  });
+
+  test("no detail rows returns same index", () => {
+    const simple: TreeItem[] = [repo(0), worktree(0, 0), worktree(0, 1)];
+    expect(adjustIndexForDetailCollapse(simple, 0)).toBe(0);
+    expect(adjustIndexForDetailCollapse(simple, 1)).toBe(1);
+    expect(adjustIndexForDetailCollapse(simple, 2)).toBe(2);
+  });
+
+  test("empty tree returns selected index unchanged", () => {
+    expect(adjustIndexForDetailCollapse([], 0)).toBe(0);
+  });
+});
+
+describe("treeItemId", () => {
+  const repos: RepoInfo[] = [
+    fakeRepo("repo-a", ["main", "feature-x"]),
+    fakeRepo("repo-b", ["main"]),
+  ];
+
+  test("returns stable id for repo items", () => {
+    expect(treeItemId(repo(0), repos)).toBe("repo:repo-a");
+    expect(treeItemId(repo(1), repos)).toBe("repo:repo-b");
+  });
+
+  test("returns stable id for worktree items", () => {
+    expect(treeItemId(worktree(0, 0), repos)).toBe("wt:repo-a/main");
+    expect(treeItemId(worktree(0, 1), repos)).toBe("wt:repo-a/feature-x");
+    expect(treeItemId(worktree(1, 0), repos)).toBe("wt:repo-b/main");
+  });
+
+  test("returns stable id for detail items", () => {
+    expect(treeItemId(detail(0, 0, "pr"), repos)).toBe("detail:repo-a/main/pr");
+  });
+
+  test("check details include label for uniqueness", () => {
+    const checkA = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "check",
+      label: "CI / build",
+    } as TreeItem;
+    const checkB = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "check",
+      label: "CI / lint",
+    } as TreeItem;
+    expect(treeItemId(checkA, repos)).toBe(
+      "detail:repo-a/main/check/CI / build",
+    );
+    expect(treeItemId(checkB, repos)).toBe(
+      "detail:repo-a/main/check/CI / lint",
+    );
+    expect(treeItemId(checkA, repos)).not.toBe(treeItemId(checkB, repos));
+  });
+
+  test("pane details include paneId for uniqueness", () => {
+    const paneA = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:0 bash",
+      meta: { paneId: "%1", zoomed: false, active: false },
+    } as TreeItem;
+    const paneB = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:1 bash",
+      meta: { paneId: "%2", zoomed: false, active: true },
+    } as TreeItem;
+    expect(treeItemId(paneA, repos)).toBe("detail:repo-a/main/pane/%1");
+    expect(treeItemId(paneB, repos)).toBe("detail:repo-a/main/pane/%2");
+    expect(treeItemId(paneA, repos)).not.toBe(treeItemId(paneB, repos));
+  });
+
+  test("returns null for out-of-range repo index", () => {
+    expect(treeItemId(repo(99), repos)).toBeNull();
+  });
+
+  test("returns null for out-of-range worktree index", () => {
+    expect(treeItemId(worktree(0, 99), repos)).toBeNull();
+  });
+
+  test("identity is independent of positional index in tree", () => {
+    // Same worktree at different tree positions should produce the same id
+    const item = worktree(0, 1);
+    expect(treeItemId(item, repos)).toBe(treeItemId(item, repos));
+  });
+});
+
+describe("identity-based recovery scenarios", () => {
+  // Simulate background refresh removing a worktree before the selected one
+  test("selected item shifts when earlier worktree is removed", () => {
+    const reposBefore: RepoInfo[] = [
+      fakeRepo("repo-a", ["main", "feat-1", "feat-2"]),
+    ];
+    const itemsBefore: TreeItem[] = [
+      repo(0),
+      worktree(0, 0), // main
+      worktree(0, 1), // feat-1
+      worktree(0, 2), // feat-2  ← selected at index 3
+    ];
+
+    const selectedIndex = 3;
+    const selectedItem = itemsBefore[selectedIndex];
+    if (!selectedItem) {
+      throw new Error("expected selected worktree item");
+    }
+    const selectedId = treeItemId(selectedItem, reposBefore);
+    expect(selectedId).toBe("wt:repo-a/feat-2");
+
+    // After refresh: feat-1 removed, feat-2 is now at worktreeIndex 1
+    const reposAfter: RepoInfo[] = [fakeRepo("repo-a", ["main", "feat-2"])];
+    const itemsAfter: TreeItem[] = [
+      repo(0),
+      worktree(0, 0), // main
+      worktree(0, 1), // feat-2  ← now at index 2
+    ];
+
+    // Old selectedIndex (3) is out of bounds — find by identity
+    const recovered = itemsAfter.findIndex(
+      (item) => treeItemId(item, reposAfter) === selectedId,
+    );
+    expect(recovered).toBe(2);
+  });
+
+  test("selected item gone returns -1 from identity search", () => {
+    const reposBefore: RepoInfo[] = [fakeRepo("repo-a", ["main", "feat-1"])];
+    const selectedId = treeItemId(worktree(0, 1), reposBefore);
+    expect(selectedId).toBe("wt:repo-a/feat-1");
+
+    // After refresh: feat-1 deleted entirely
+    const reposAfter: RepoInfo[] = [fakeRepo("repo-a", ["main"])];
+    const itemsAfter: TreeItem[] = [repo(0), worktree(0, 0)];
+
+    const recovered = itemsAfter.findIndex(
+      (item) => treeItemId(item, reposAfter) === selectedId,
+    );
+    expect(recovered).toBe(-1);
+  });
+
+  test("recovery with multiple panes targets the correct one", () => {
+    const repos: RepoInfo[] = [fakeRepo("repo-a", ["main"])];
+    const pane1 = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:0 bash",
+      meta: { paneId: "%1", zoomed: false, active: false },
+    } as TreeItem;
+    const pane2 = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pane",
+      label: "main:1 vim",
+      meta: { paneId: "%2", zoomed: false, active: true },
+    } as TreeItem;
+
+    const itemsBefore: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      pane1, // index 2
+      pane2, // index 3  ← selected
+    ];
+
+    // User selected pane2 (%2)
+    const selectedItem = itemsBefore[3];
+    if (!selectedItem) {
+      throw new Error("expected selected pane item");
+    }
+    const selectedId = treeItemId(selectedItem, repos);
+    expect(selectedId).toBe("detail:repo-a/main/pane/%2");
+
+    // After refresh: panes reordered (pane2 now comes first)
+    const itemsAfter: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      pane2, // index 2
+      pane1, // index 3
+    ];
+
+    const recovered = itemsAfter.findIndex(
+      (item) => treeItemId(item, repos) === selectedId,
+    );
+    // Should find pane2 at its new position, not pane1
+    expect(recovered).toBe(2);
+  });
+});
+
+describe("resolveRecoveredSelectionIndex", () => {
+  test("skips identity recovery when search query just changed", () => {
+    const repos: RepoInfo[] = [
+      fakeRepo("repo-a", ["main", "feat-1", "feat-2"]),
+    ];
+    const prevTree: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      worktree(0, 1),
+      worktree(0, 2),
+    ];
+    const nextTree: TreeItem[] = [repo(0), worktree(0, 1), worktree(0, 2)];
+
+    expect(
+      resolveRecoveredSelectionIndex({
+        prevTree,
+        treeItems: nextTree,
+        prevSelectionId: "wt:repo-a/feat-2",
+        selectedIndex: 2,
+        repos,
+        skipIdentityRecovery: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveSelectedWorktreeIndex", () => {
+  test("returns the same index for a selected worktree row", () => {
+    const items: TreeItem[] = [repo(0), worktree(0, 0)];
+    expect(resolveSelectedWorktreeIndex(items, 1)).toBe(1);
+  });
+
+  test("returns the parent worktree index for a selected detail row", () => {
+    const items: TreeItem[] = [repo(0), worktree(0, 0), detail(0, 0, "check")];
+    expect(resolveSelectedWorktreeIndex(items, 2)).toBe(1);
+  });
+
+  test("returns null for a selected repo row", () => {
+    const items: TreeItem[] = [repo(0), worktree(0, 0)];
+    expect(resolveSelectedWorktreeIndex(items, 0)).toBeNull();
+  });
+});
+
+describe("resolveCloseSelectedWorktreeAction", () => {
+  test("exits expanded mode when closing the active expanded worktree", () => {
+    const repos: RepoInfo[] = [fakeRepo("repo-a", ["main", "feat-1"])];
+    const items: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      detail(0, 0, "pr"),
+      worktree(0, 1),
+    ];
+
+    expect(
+      resolveCloseSelectedWorktreeAction({
+        mode: Mode.Expanded(pendingKey("repo-a", "main")),
+        repos,
+        items,
+        selectedIndex: 2,
+      }),
+    ).toEqual({
+      type: "close-worktree",
+      worktreeIndex: 1,
+      worktreeKey: "repo-a/main",
+      nextMode: Mode.Navigate,
+      nextSelectedIndex: 1,
+    });
+  });
+});
+
+describe("resolveExpandedRightArrowAction", () => {
+  test("expands a collapsed repo while another repo's worktree is expanded", () => {
+    const repos: RepoInfo[] = [
+      fakeRepo("repo-a", ["main"]),
+      fakeRepo("repo-b", ["feature-b"]),
+    ];
+    const items: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      detail(0, 0, "pr"),
+      repo(1),
+    ];
+
+    expect(
+      resolveExpandedRightArrowAction({
+        repos,
+        items,
+        selectedIndex: 3,
+        expandedRepos: new Set(["repo-a"]),
+      }),
+    ).toEqual({
+      type: "expand-repo",
+      repoId: "repo-b",
+    });
+  });
+
+  test("switches the expanded worktree using the collapsed tree index", () => {
+    const repos: RepoInfo[] = [fakeRepo("repo-a", ["main", "feature-b"])];
+    const items: TreeItem[] = [
+      repo(0),
+      worktree(0, 0),
+      detail(0, 0, "pr"),
+      detail(0, 0, "pane-header"),
+      worktree(0, 1),
+    ];
+
+    expect(
+      resolveExpandedRightArrowAction({
+        repos,
+        items,
+        selectedIndex: 4,
+        expandedRepos: new Set(["repo-a"]),
+      }),
+    ).toEqual({
+      type: "expand-worktree",
+      nextMode: Mode.Expanded(pendingKey("repo-a", "feature-b")),
+      nextSelectedIndex: 2,
+    });
+  });
+});

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -67,7 +67,7 @@ describe("StatusBar", () => {
     });
 
     expect(rendered.output).toContain(
-      "↑↓:navigate  ←:collapse  space:action  o:open",
+      "↑↓:navigate  ←:collapse  space:action  o:open  c:close",
     );
     expect(rendered.output).toContain("/:search  q:quit");
 


### PR DESCRIPTION
  Behavior Changes
  Most of the work is in src/tui/App.tsx. I pulled the tree-selection and mode-transition logic into small pure helpers so the TUI now behaves
  consistently when the tree changes underneath the cursor.

  The main user-visible fixes are:

  - Stable selection recovery after background refreshes, using item identity instead of raw index.
  - Search filtering no longer restores the old pre-filter selection; changing searchQuery now keeps the intended reset to the first filtered result.
  - Leaving expanded mode collapses detail rows consistently back onto the owning worktree row.
  - → in expanded mode can now expand a different repo even while another repo’s worktree details are open.
  - → on another worktree in expanded mode switches the expanded worktree while keeping the selection aligned with the collapsed tree.
  - c in expanded mode now works from detail rows like PR/check rows, not just exact worktree rows.
  - Closing the currently expanded worktree now exits Mode.Expanded first, so the app does not get stuck showing expanded-mode hints with no expanded
    details.
  - Shared “resolve selected worktree” logic is now used by both switch and close paths, so detail-row actions consistently target the parent worktree.

  UI And Tests
  In src/tui/components/StatusBar.tsx, the expanded-mode hint for non-pane rows now includes c:close, matching the restored shortcut. tests/tui/status-
  bar.test.tsx was updated to match that contract.

  I also added tests/tui/adjust-index.test.ts, which covers:

  - detail-collapse index adjustment
  - stable tree item IDs
  - identity-based recovery scenarios
  - skipping recovery during search transitions
  - resolving detail rows back to their owning worktree
  - expanded-mode right-arrow behavior
  - close behavior when the active expanded worktree is closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection recovery to preserve your position when the tree refreshes or changes unexpectedly.

* **Documentation**
  * Added "c:close" keyboard shortcut hint to the status bar in Expanded mode for better discoverability.

* **Tests**
  * Added comprehensive test suite to ensure selection handling and tree navigation work reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->