### PR TITLE
Restyle open modal with lazygit-inspired titled boxes

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1083,6 +1083,7 @@ export function App() {
       {mode.type === "OpenModal" ? (
         <OpenModal
           visible
+          width={Math.min(termCols, 60)}
           defaultBase={openModalBase ?? ""}
           profileNames={openModalProfiles}
           repoProject={openModalRepoProject}

--- a/src/tui/components/Modal.tsx
+++ b/src/tui/components/Modal.tsx
@@ -1,28 +1,19 @@
-import { Box, Text } from "ink";
 import type { ReactNode } from "react";
+import { TitledBox } from "./TitledBox";
 
 interface Props {
   title: string;
   children: ReactNode;
   visible: boolean;
+  width?: number;
 }
 
-export function Modal({ title, children, visible }: Props) {
+export function Modal({ title, children, visible, width }: Props) {
   if (!visible) return null;
 
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor="cyan"
-      paddingX={1}
-    >
-      <Text bold color="cyan">
-        {title}
-      </Text>
-      <Box flexDirection="column" marginTop={1}>
-        {children}
-      </Box>
-    </Box>
+    <TitledBox title={title} isFocused={true} width={width}>
+      {children}
+    </TitledBox>
   );
 }

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -679,7 +679,7 @@ export function OpenModal({
     fromPR: "Open Worktree — From PR",
     existingBranch: "Open Worktree — Existing Branch",
   };
-  const innerWidth = width === undefined ? undefined : Math.max(width - 4, 0);
+  const innerWidth = width === undefined ? undefined : Math.max(width - 2, 0);
 
   return (
     <Modal title={titleMap[step]} visible={visible} width={width}>

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -6,6 +6,7 @@ import { tuiRuntime } from "../runtime";
 import type { PRInfo } from "../types";
 import { Modal } from "./Modal";
 import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
+import { TitledBox } from "./TitledBox";
 
 export interface OpenModalResult {
   branch: string;
@@ -99,17 +100,12 @@ function BracketInput({
   );
 
   return (
-    <Box flexDirection="column">
-      <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
-        {label}
+    <TitledBox title={label} isFocused={isFocused}>
+      <Text color={isFocused ? undefined : "dim"}>
+        {value}
+        {isFocused && cursorVisible ? "▎" : ""}
       </Text>
-      <Text color={isFocused ? "cyan" : "dim"}>
-        {"[ "}
-        <Text color={isFocused ? undefined : "dim"}>{value}</Text>
-        {isFocused && cursorVisible ? "▎" : " "}
-        {" ]"}
-      </Text>
-    </Box>
+    </TitledBox>
   );
 }
 

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -23,6 +23,7 @@ type ModalStep = "selector" | "newBranch" | "fromPR" | "existingBranch";
 
 export interface OpenModalProps {
   visible: boolean;
+  width?: number;
   onSubmit: (result: OpenModalResult) => void;
   onCancel: () => void;
   defaultBase: string;
@@ -630,6 +631,7 @@ function ExistingBranchForm({
 
 export function OpenModal({
   visible,
+  width,
   onSubmit,
   onCancel,
   defaultBase,
@@ -654,7 +656,7 @@ export function OpenModal({
   };
 
   return (
-    <Modal title={titleMap[step]} visible={visible}>
+    <Modal title={titleMap[step]} visible={visible} width={width}>
       {step === "selector" && (
         <ModeSelector onSelect={setStep} onCancel={onCancel} />
       )}

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -109,7 +109,7 @@ function BracketInput({
     <TitledBox title={label} isFocused={isFocused} width={width}>
       <Text color={isFocused ? undefined : "dim"}>
         {displayValue}
-        {isFocused && cursorVisible ? "▎" : ""}
+        {isFocused ? (cursorVisible ? "▎" : " ") : ""}
       </Text>
     </TitledBox>
   );

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -135,17 +135,12 @@ function PromptArea({
   );
 
   return (
-    <Box flexDirection="column">
-      <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
-        Prompt
-      </Text>
-      <Text dimColor>───────────────────────────────</Text>
+    <TitledBox title="Prompt" isFocused={isFocused}>
       <Text color={isFocused ? undefined : "dim"}>
         {value || (isFocused ? "" : "optional")}
         {isFocused ? (cursorVisible ? "▎" : " ") : ""}
       </Text>
-      <Text dimColor>───────────────────────────────</Text>
-    </Box>
+    </TitledBox>
   );
 }
 

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -428,19 +428,15 @@ function FromPRForm({
     <Box flexDirection="column" gap={0}>
       <Text dimColor>Open from PR</Text>
       <Box height={1} />
-      <Text
-        color={currentField === "prList" ? "cyan" : "dim"}
-        bold={currentField === "prList"}
-      >
-        Select PR
-      </Text>
-      <ScrollableList
-        items={prItems}
-        selectedIndex={selectedPRIndex}
-        filterQuery={filterQuery}
-        maxVisible={8}
-        isFocused={currentField === "prList"}
-      />
+      <TitledBox title="Select PR" isFocused={currentField === "prList"}>
+        <ScrollableList
+          items={prItems}
+          selectedIndex={selectedPRIndex}
+          filterQuery={filterQuery}
+          maxVisible={8}
+          isFocused={currentField === "prList"}
+        />
+      </TitledBox>
       {profileNames.length > 0 && (
         <BracketInput
           label="Profile"
@@ -596,19 +592,18 @@ function ExistingBranchForm({
     <Box flexDirection="column" gap={0}>
       <Text dimColor>Existing Branch</Text>
       <Box height={1} />
-      <Text
-        color={currentField === "branchList" ? "cyan" : "dim"}
-        bold={currentField === "branchList"}
-      >
-        Select Branch
-      </Text>
-      <ScrollableList
-        items={branchItems}
-        selectedIndex={selectedBranchIndex}
-        filterQuery={filterQuery}
-        maxVisible={10}
+      <TitledBox
+        title="Select Branch"
         isFocused={currentField === "branchList"}
-      />
+      >
+        <ScrollableList
+          items={branchItems}
+          selectedIndex={selectedBranchIndex}
+          filterQuery={filterQuery}
+          maxVisible={10}
+          isFocused={currentField === "branchList"}
+        />
+      </TitledBox>
       <PromptArea
         value={prompt}
         isFocused={currentField === "prompt"}

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -38,9 +38,11 @@ export interface OpenModalProps {
 function ModeSelector({
   onSelect,
   onCancel,
+  width,
 }: {
   onSelect: (step: ModalStep) => void;
   onCancel: () => void;
+  width?: number;
 }) {
   const [selected, setSelected] = useState(0);
   const options: { label: string; step: ModalStep }[] = [
@@ -61,7 +63,7 @@ function ModeSelector({
   );
 
   return (
-    <TitledBox title="Select mode" isFocused={true}>
+    <TitledBox title="Select mode" isFocused={true} width={width}>
       {options.map((opt, i) => {
         const isSel = i === selected;
         return (
@@ -80,13 +82,16 @@ function BracketInput({
   value,
   isFocused,
   onChange,
+  width,
 }: {
   label: string;
   value: string;
   isFocused: boolean;
   onChange: (v: string) => void;
+  width?: number;
 }) {
   const cursorVisible = useBlink();
+  const displayValue = value || (!isFocused || !cursorVisible ? " " : "");
 
   useInput(
     (input, key) => {
@@ -101,9 +106,9 @@ function BracketInput({
   );
 
   return (
-    <TitledBox title={label} isFocused={isFocused}>
+    <TitledBox title={label} isFocused={isFocused} width={width}>
       <Text color={isFocused ? undefined : "dim"}>
-        {value}
+        {displayValue}
         {isFocused && cursorVisible ? "▎" : ""}
       </Text>
     </TitledBox>
@@ -114,10 +119,12 @@ function PromptArea({
   value,
   isFocused,
   onChange,
+  width,
 }: {
   value: string;
   isFocused: boolean;
   onChange: (v: string) => void;
+  width?: number;
 }) {
   const cursorVisible = useBlink();
 
@@ -136,7 +143,7 @@ function PromptArea({
   );
 
   return (
-    <TitledBox title="Prompt" isFocused={isFocused}>
+    <TitledBox title="Prompt" isFocused={isFocused} width={width}>
       <Text color={isFocused ? undefined : "dim"}>
         {value || (isFocused ? "" : "optional")}
         {isFocused ? (cursorVisible ? "▎" : " ") : ""}
@@ -209,11 +216,13 @@ function NewBranchForm({
   profileNames,
   onSubmit,
   onBack,
+  width,
 }: {
   defaultBase: string;
   profileNames: string[];
   onSubmit: (result: OpenModalResult) => void;
   onBack: () => void;
+  width?: number;
 }) {
   const [branch, setBranch] = useState("");
   const [base, setBase] = useState(defaultBase);
@@ -275,12 +284,14 @@ function NewBranchForm({
         value={branch}
         isFocused={currentField === "branch"}
         onChange={setBranch}
+        width={width}
       />
       <BracketInput
         label="Base"
         value={base}
         isFocused={currentField === "base"}
         onChange={setBase}
+        width={width}
       />
       {profileNames.length > 0 && (
         <BracketInput
@@ -288,12 +299,14 @@ function NewBranchForm({
           value={profile}
           isFocused={currentField === "profile"}
           onChange={setProfile}
+          width={width}
         />
       )}
       <PromptArea
         value={prompt}
         isFocused={currentField === "prompt"}
         onChange={setPrompt}
+        width={width}
       />
       <ToggleRow
         label="No IDE"
@@ -327,11 +340,13 @@ function FromPRForm({
   profileNames,
   onSubmit,
   onBack,
+  width,
 }: {
   prList: PRInfo[];
   profileNames: string[];
   onSubmit: (result: OpenModalResult) => void;
   onBack: () => void;
+  width?: number;
 }) {
   const [selectedPRIndex, setSelectedPRIndex] = useState(0);
   const [filterQuery, setFilterQuery] = useState("");
@@ -429,7 +444,11 @@ function FromPRForm({
     <Box flexDirection="column" gap={0}>
       <Text dimColor>Open from PR</Text>
       <Box height={1} />
-      <TitledBox title="Select PR" isFocused={currentField === "prList"}>
+      <TitledBox
+        title="Select PR"
+        isFocused={currentField === "prList"}
+        width={width}
+      >
         <ScrollableList
           items={prItems}
           selectedIndex={selectedPRIndex}
@@ -444,12 +463,14 @@ function FromPRForm({
           value={profile}
           isFocused={currentField === "profile"}
           onChange={setProfile}
+          width={width}
         />
       )}
       <PromptArea
         value={prompt}
         isFocused={currentField === "prompt"}
         onChange={setPrompt}
+        width={width}
       />
       <ToggleRow
         label="No IDE"
@@ -481,10 +502,12 @@ function ExistingBranchForm({
   repoPath,
   onSubmit,
   onBack,
+  width,
 }: {
   repoPath: string;
   onSubmit: (result: OpenModalResult) => void;
   onBack: () => void;
+  width?: number;
 }) {
   const [branches, setBranches] = useState<string[]>([]);
   const [selectedBranchIndex, setSelectedBranchIndex] = useState(0);
@@ -596,6 +619,7 @@ function ExistingBranchForm({
       <TitledBox
         title="Select Branch"
         isFocused={currentField === "branchList"}
+        width={width}
       >
         <ScrollableList
           items={branchItems}
@@ -609,6 +633,7 @@ function ExistingBranchForm({
         value={prompt}
         isFocused={currentField === "prompt"}
         onChange={setPrompt}
+        width={width}
       />
       <ToggleRow
         label="No IDE"
@@ -654,11 +679,16 @@ export function OpenModal({
     fromPR: "Open Worktree — From PR",
     existingBranch: "Open Worktree — Existing Branch",
   };
+  const innerWidth = width === undefined ? undefined : Math.max(width - 4, 0);
 
   return (
     <Modal title={titleMap[step]} visible={visible} width={width}>
       {step === "selector" && (
-        <ModeSelector onSelect={setStep} onCancel={onCancel} />
+        <ModeSelector
+          onSelect={setStep}
+          onCancel={onCancel}
+          width={innerWidth}
+        />
       )}
       {step === "newBranch" && (
         <NewBranchForm
@@ -666,6 +696,7 @@ export function OpenModal({
           profileNames={profileNames}
           onSubmit={onSubmit}
           onBack={() => setStep("selector")}
+          width={innerWidth}
         />
       )}
       {step === "fromPR" && (
@@ -674,6 +705,7 @@ export function OpenModal({
           profileNames={profileNames}
           onSubmit={onSubmit}
           onBack={() => setStep("selector")}
+          width={innerWidth}
         />
       )}
       {step === "existingBranch" && (
@@ -681,6 +713,7 @@ export function OpenModal({
           repoPath={repoPath}
           onSubmit={onSubmit}
           onBack={() => setStep("selector")}
+          width={innerWidth}
         />
       )}
       <Box marginTop={1}>

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -60,7 +60,7 @@ function ModeSelector({
   );
 
   return (
-    <Box flexDirection="column">
+    <TitledBox title="Select mode" isFocused={true}>
       {options.map((opt, i) => {
         const isSel = i === selected;
         return (
@@ -70,7 +70,7 @@ function ModeSelector({
           </Text>
         );
       })}
-    </Box>
+    </TitledBox>
   );
 }
 

--- a/src/tui/components/ScrollableList.tsx
+++ b/src/tui/components/ScrollableList.tsx
@@ -77,11 +77,7 @@ export function ScrollableList({
             <Text color={isSelected && isFocused ? "cyan" : undefined}>
               {isSelected ? "▸ " : "  "}
             </Text>
-            <Text
-              bold={isSelected}
-              color={isSelected ? undefined : "dim"}
-              wrap="truncate"
-            >
+            <Text bold={isSelected} dimColor={!isSelected} wrap="truncate">
               {item.label}
             </Text>
             {item.description && (

--- a/src/tui/components/ScrollableList.tsx
+++ b/src/tui/components/ScrollableList.tsx
@@ -77,10 +77,19 @@ export function ScrollableList({
             <Text color={isSelected && isFocused ? "cyan" : undefined}>
               {isSelected ? "▸ " : "  "}
             </Text>
-            <Text bold={isSelected} color={isSelected ? undefined : "dim"}>
+            <Text
+              bold={isSelected}
+              color={isSelected ? undefined : "dim"}
+              wrap="truncate"
+            >
               {item.label}
             </Text>
-            {item.description && <Text dimColor> {item.description}</Text>}
+            {item.description && (
+              <Text dimColor wrap="truncate">
+                {" "}
+                {item.description}
+              </Text>
+            )}
           </Box>
         );
       })}

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -1,0 +1,84 @@
+import { Box, Text } from "ink";
+import { Children, type ReactNode } from "react";
+
+interface Props {
+  title: string;
+  isFocused: boolean;
+  width?: number;
+  children: ReactNode;
+}
+
+function visibleLength(value: string) {
+  return Array.from(value).length;
+}
+
+function truncateTitle(title: string, width: number) {
+  if (width <= 0) return "";
+
+  const chars = Array.from(title);
+  if (chars.length <= width) return title;
+
+  if (width === 1) return "…";
+
+  return `${chars.slice(0, width - 1).join("")}…`;
+}
+
+function topBorder(width: number, title: string) {
+  if (width <= 0) return "";
+  if (width === 1) return "╭";
+  if (width === 2) return "╭╮";
+  if (width === 3) return "╭─╮";
+
+  const titleWidth = width - 4;
+  const visibleTitle = truncateTitle(title, titleWidth);
+  const dashCount = Math.max(titleWidth - visibleLength(visibleTitle), 0);
+
+  return `╭ ${visibleTitle} ${"─".repeat(dashCount)}╮`;
+}
+
+function bottomBorder(width: number) {
+  if (width <= 0) return "";
+  if (width === 1) return "╰";
+  if (width === 2) return "╰╯";
+  if (width === 3) return "╰─╯";
+
+  return `╰${"─".repeat(width - 2)}╯`;
+}
+
+export function TitledBox({ title, isFocused, width, children }: Props) {
+  const boxWidth = Math.max(width ?? visibleLength(title) + 4, 0);
+  const contentWidth = Math.max(boxWidth - 2, 0);
+  const normalizedChildren = Children.map(children, (child) =>
+    typeof child === "string" || typeof child === "number" ? (
+      <Text dimColor={!isFocused}>{child}</Text>
+    ) : (
+      child
+    ),
+  );
+  const lineProps = {
+    color: isFocused ? "cyan" : undefined,
+    bold: isFocused,
+    dimColor: !isFocused,
+  } as const;
+
+  return (
+    <Box flexDirection="column">
+      <Text {...lineProps}>{topBorder(boxWidth, title)}</Text>
+      <Box
+        width={contentWidth}
+        flexDirection="column"
+        borderStyle="round"
+        borderTop={false}
+        borderBottom={false}
+        borderColor={isFocused ? "cyan" : undefined}
+        borderLeftColor={isFocused ? "cyan" : undefined}
+        borderRightColor={isFocused ? "cyan" : undefined}
+        borderLeftDimColor={!isFocused}
+        borderRightDimColor={!isFocused}
+      >
+        {normalizedChildren}
+      </Box>
+      <Text {...lineProps}>{bottomBorder(boxWidth)}</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -47,7 +47,6 @@ function bottomBorder(width: number) {
 
 export function TitledBox({ title, isFocused, width, children }: Props) {
   const boxWidth = Math.max(width ?? 40, 0);
-  const contentWidth = Math.max(boxWidth - 2, 0);
   const normalizedChildren = Children.map(children, (child) =>
     typeof child === "string" || typeof child === "number" ? (
       <Text dimColor={!isFocused}>{child}</Text>
@@ -65,7 +64,7 @@ export function TitledBox({ title, isFocused, width, children }: Props) {
     <Box flexDirection="column">
       <Text {...lineProps}>{topBorder(boxWidth, title)}</Text>
       <Box
-        width={contentWidth}
+        width={boxWidth}
         flexDirection="column"
         borderStyle="round"
         borderTop={false}

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -8,19 +8,27 @@ interface Props {
   children: ReactNode;
 }
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function getGraphemes(value: string) {
+  return Array.from(graphemeSegmenter.segment(value), ({ segment }) => segment);
+}
+
 function visibleLength(value: string) {
-  return Array.from(value).length;
+  return getGraphemes(value).length;
 }
 
 function truncateTitle(title: string, width: number) {
   if (width <= 0) return "";
 
-  const chars = Array.from(title);
-  if (chars.length <= width) return title;
+  const graphemes = getGraphemes(title);
+  if (graphemes.length <= width) return title;
 
   if (width === 1) return "…";
 
-  return `${chars.slice(0, width - 1).join("")}…`;
+  return `${graphemes.slice(0, width - 1).join("")}…`;
 }
 
 function topBorder(width: number, title: string) {

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -46,7 +46,7 @@ function bottomBorder(width: number) {
 }
 
 export function TitledBox({ title, isFocused, width, children }: Props) {
-  const boxWidth = Math.max(width ?? visibleLength(title) + 4, 0);
+  const boxWidth = Math.max(width ?? 40, 0);
   const contentWidth = Math.max(boxWidth - 2, 0);
   const normalizedChildren = Children.map(children, (child) =>
     typeof child === "string" || typeof child === "number" ? (

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -95,131 +95,155 @@ async function renderTitledBox(props: React.ComponentProps<typeof TitledBox>) {
 
 describe("TitledBox", () => {
   test("renders the top border with an embedded title and a bottom border", async () => {
-    const rendered = await renderTitledBox({
-      title: "Open Worktrees",
-      isFocused: true,
-      width: 28,
-      children: "content",
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "Open Worktrees",
+        isFocused: true,
+        width: 28,
+        children: "content",
+      });
 
-    expect(lines[0].startsWith("╭ Open Worktrees ")).toBe(true);
-    expect(lines[0].endsWith("╮")).toBe(true);
-    expect(lines[0].length).toBe(28);
-    expect(lines[1]).toContain("content");
-    expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
-    expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
-    expect(lines[lines.length - 1].length).toBe(28);
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    rendered.unmount();
+      expect(lines[0].startsWith("╭ Open Worktrees ")).toBe(true);
+      expect(lines[0].endsWith("╮")).toBe(true);
+      expect(lines[0].length).toBe(28);
+      expect(lines[1]).toContain("content");
+      expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
+      expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
+      expect(lines[lines.length - 1].length).toBe(28);
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("truncates the title with an ellipsis when the box is too narrow", async () => {
-    const rendered = await renderTitledBox({
-      title: "A very long title that will not fit",
-      isFocused: false,
-      width: 18,
-      children: "x",
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "A very long title that will not fit",
+        isFocused: false,
+        width: 18,
+        children: "x",
+      });
 
-    expect(lines[0].startsWith("╭ ")).toBe(true);
-    expect(lines[0]).toContain("…");
-    expect(lines[0].length).toBe(18);
-    expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
-    expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
-    expect(lines[lines.length - 1].length).toBe(18);
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    rendered.unmount();
+      expect(lines[0].startsWith("╭ ")).toBe(true);
+      expect(lines[0]).toContain("…");
+      expect(lines[0].length).toBe(18);
+      expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
+      expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
+      expect(lines[lines.length - 1].length).toBe(18);
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("keeps all rendered border lines within the requested width", async () => {
     const width = 26;
-    const rendered = await renderTitledBox({
-      title: "Status",
-      isFocused: true,
-      width,
-      children: "alpha\nbeta",
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "Status",
+        isFocused: true,
+        width,
+        children: "alpha\nbeta",
+      });
 
-    expect(lines.every((line) => line.length <= width)).toBe(true);
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    rendered.unmount();
+      expect(lines.every((line) => line.length <= width)).toBe(true);
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("truncates emoji titles without splitting grapheme clusters", async () => {
     const width = 6;
-    const rendered = await renderTitledBox({
-      title: "👨‍👩‍👧‍👦abc",
-      isFocused: false,
-      width,
-      children: "x",
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "👨‍👩‍👧‍👦abc",
+        isFocused: false,
+        width,
+        children: "x",
+      });
 
-    expect(lines[0]).toContain("👨‍👩‍👧‍👦…");
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    rendered.unmount();
+      expect(lines[0]).toContain("👨‍👩‍👧‍👦…");
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("keeps content lines aligned to the requested width", async () => {
     const width = 24;
-    const rendered = await renderTitledBox({
-      title: "Branch",
-      isFocused: true,
-      width,
-      children: "my-feature",
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "Branch",
+        isFocused: true,
+        width,
+        children: "my-feature",
+      });
 
-    expect(lines.every((line) => line.length === width)).toBe(true);
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    rendered.unmount();
+      expect(lines.every((line) => line.length === width)).toBe(true);
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("renders side borders for every line of multiline content", async () => {
-    const rendered = await renderTitledBox({
-      title: "Logs",
-      isFocused: false,
-      width: 20,
-      children: <Text>{`line one\nline two`}</Text>,
-    });
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 
-    const lines = rendered.output
-      .split("\n")
-      .map((line) => line.replace(/\s+$/, ""))
-      .filter((line) => line.length > 0);
+    try {
+      rendered = await renderTitledBox({
+        title: "Logs",
+        isFocused: false,
+        width: 20,
+        children: <Text>{`line one\nline two`}</Text>,
+      });
 
-    const contentLines = lines.filter(
-      (line) => line.includes("line one") || line.includes("line two"),
-    );
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
 
-    expect(contentLines).toHaveLength(2);
-    expect(contentLines.every((line) => line.startsWith("│"))).toBe(true);
-    expect(contentLines.every((line) => line.endsWith("│"))).toBe(true);
+      const contentLines = lines.filter(
+        (line) => line.includes("line one") || line.includes("line two"),
+      );
 
-    rendered.unmount();
+      expect(contentLines).toHaveLength(2);
+      expect(contentLines.every((line) => line.startsWith("│"))).toBe(true);
+      expect(contentLines.every((line) => line.endsWith("│"))).toBe(true);
+    } finally {
+      rendered?.unmount();
+    }
   });
 
   test("applies focused cyan bold styling and unfocused dim styling", async () => {

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -1,0 +1,249 @@
+import { PassThrough } from "node:stream";
+import { Box, Text } from "ink";
+import React from "react";
+import { describe, expect, test } from "vitest";
+import { TitledBox } from "../../src/tui/components/TitledBox";
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+};
+
+function createStdoutStdin() {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 80;
+  stdout.rows = 24;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = false;
+  stdin.setRawMode = () => stdin;
+  return { stdout, stdin };
+}
+
+function stripAnsi(value: string) {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === "\u001B" && value[i + 1] === "[") {
+      i += 2;
+      while (i < value.length && !/[A-Za-z@~]/.test(value[i])) {
+        i += 1;
+      }
+      continue;
+    }
+    if (char !== "\r") {
+      output += char;
+    }
+  }
+  return output;
+}
+
+function collectElements(
+  node: React.ReactNode,
+  match: (element: React.ReactElement) => boolean,
+  results: React.ReactElement[] = [],
+) {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectElements(child, match, results);
+    }
+    return results;
+  }
+
+  if (!React.isValidElement(node)) {
+    return results;
+  }
+
+  if (match(node)) {
+    results.push(node);
+  }
+
+  const children = node.props.children as React.ReactNode;
+  if (children !== undefined) {
+    collectElements(children, match, results);
+  }
+
+  return results;
+}
+
+async function renderTitledBox(props: React.ComponentProps<typeof TitledBox>) {
+  const { stdout, stdin } = createStdoutStdin();
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  const { render } = await import("ink");
+  const instance = render(<TitledBox {...props} />, {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return {
+    rawOutput: chunks.join(""),
+    output: stripAnsi(chunks.join("")),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+describe("TitledBox", () => {
+  test("renders the top border with an embedded title and a bottom border", async () => {
+    const rendered = await renderTitledBox({
+      title: "Open Worktrees",
+      isFocused: true,
+      width: 28,
+      children: "content",
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    expect(lines[0].startsWith("╭ Open Worktrees ")).toBe(true);
+    expect(lines[0].endsWith("╮")).toBe(true);
+    expect(lines[0].length).toBe(28);
+    expect(lines[1]).toContain("content");
+    expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
+    expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
+    expect(lines[lines.length - 1].length).toBe(28);
+
+    rendered.unmount();
+  });
+
+  test("truncates the title with an ellipsis when the box is too narrow", async () => {
+    const rendered = await renderTitledBox({
+      title: "A very long title that will not fit",
+      isFocused: false,
+      width: 18,
+      children: "x",
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    expect(lines[0].startsWith("╭ ")).toBe(true);
+    expect(lines[0]).toContain("…");
+    expect(lines[0].length).toBe(18);
+    expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
+    expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
+    expect(lines[lines.length - 1].length).toBe(18);
+
+    rendered.unmount();
+  });
+
+  test("keeps all rendered border lines within the requested width", async () => {
+    const width = 26;
+    const rendered = await renderTitledBox({
+      title: "Status",
+      isFocused: true,
+      width,
+      children: "alpha\nbeta",
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    expect(lines.every((line) => line.length <= width)).toBe(true);
+
+    rendered.unmount();
+  });
+
+  test("renders side borders for every line of multiline content", async () => {
+    const rendered = await renderTitledBox({
+      title: "Logs",
+      isFocused: false,
+      width: 20,
+      children: <Text>{`line one\nline two`}</Text>,
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    const contentLines = lines.filter(
+      (line) => line.includes("line one") || line.includes("line two"),
+    );
+
+    expect(contentLines).toHaveLength(2);
+    expect(contentLines.every((line) => line.startsWith("│"))).toBe(true);
+    expect(contentLines.every((line) => line.endsWith("│"))).toBe(true);
+
+    rendered.unmount();
+  });
+
+  test("applies focused cyan bold styling and unfocused dim styling", async () => {
+    const focusedTree = TitledBox({
+      title: "Focused",
+      isFocused: true,
+      width: 20,
+      children: "content",
+    });
+    const unfocusedTree = TitledBox({
+      title: "Unfocused",
+      isFocused: false,
+      width: 20,
+      children: "content",
+    });
+
+    const focusedTexts = collectElements(
+      focusedTree,
+      (element) => element.type === Text,
+    );
+    const unfocusedTexts = collectElements(
+      unfocusedTree,
+      (element) => element.type === Text,
+    );
+    const focusedBoxes = collectElements(
+      focusedTree,
+      (element) => element.type === Box,
+    );
+    const unfocusedBoxes = collectElements(
+      unfocusedTree,
+      (element) => element.type === Box,
+    );
+
+    expect(
+      focusedTexts.some(
+        (node) => node.props.color === "cyan" && node.props.bold,
+      ),
+    ).toBe(true);
+    expect(focusedTexts.every((node) => node.props.dimColor !== true)).toBe(
+      true,
+    );
+    expect(unfocusedTexts.some((node) => node.props.dimColor === true)).toBe(
+      true,
+    );
+    expect(unfocusedTexts.every((node) => node.props.color !== "cyan")).toBe(
+      true,
+    );
+
+    const focusedBorder = focusedBoxes.find(
+      (node) => node.props.borderStyle === "round",
+    );
+    const unfocusedBorder = unfocusedBoxes.find(
+      (node) => node.props.borderStyle === "round",
+    );
+
+    expect(focusedBorder?.props.borderLeftColor).toBe("cyan");
+    expect(focusedBorder?.props.borderRightColor).toBe("cyan");
+    expect(focusedBorder?.props.borderLeftDimColor).toBe(false);
+    expect(focusedBorder?.props.borderRightDimColor).toBe(false);
+    expect(unfocusedBorder?.props.borderLeftDimColor).toBe(true);
+    expect(unfocusedBorder?.props.borderRightDimColor).toBe(true);
+    expect(unfocusedBorder?.props.borderLeftColor).toBeUndefined();
+    expect(unfocusedBorder?.props.borderRightColor).toBeUndefined();
+  });
+});

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -160,6 +160,25 @@ describe("TitledBox", () => {
     rendered.unmount();
   });
 
+  test("truncates emoji titles without splitting grapheme clusters", async () => {
+    const width = 6;
+    const rendered = await renderTitledBox({
+      title: "👨‍👩‍👧‍👦abc",
+      isFocused: false,
+      width,
+      children: "x",
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    expect(lines[0]).toContain("👨‍👩‍👧‍👦…");
+
+    rendered.unmount();
+  });
+
   test("keeps content lines aligned to the requested width", async () => {
     const width = 24;
     const rendered = await renderTitledBox({

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -160,6 +160,25 @@ describe("TitledBox", () => {
     rendered.unmount();
   });
 
+  test("keeps content lines aligned to the requested width", async () => {
+    const width = 24;
+    const rendered = await renderTitledBox({
+      title: "Branch",
+      isFocused: true,
+      width,
+      children: "my-feature",
+    });
+
+    const lines = rendered.output
+      .split("\n")
+      .map((line) => line.replace(/\s+$/, ""))
+      .filter((line) => line.length > 0);
+
+    expect(lines.every((line) => line.length === width)).toBe(true);
+
+    rendered.unmount();
+  });
+
   test("renders side borders for every line of multiline content", async () => {
     const rendered = await renderTitledBox({
       title: "Logs",


### PR DESCRIPTION
## Summary

- Add `TitledBox` component that renders `╭ Title ───╮ │ content │ ╰──────────╯` using Ink's native border with per-side toggles for correct multiline rendering
- Replace `BracketInput`, `PromptArea`, and `Modal` with `TitledBox`-based variants
- Wrap `ModeSelector` and `ScrollableList` (PR/branch pickers) in titled boxes
- Truncate long titles with ellipsis and long list items with `wrap="truncate"`

## Test plan

- [x] Run `bun run test` — all existing + new `TitledBox` tests pass
- [x] Run `bun run src/index.ts tui`, press `o`, verify all modal steps render with rounded titled boxes
- [x] Test narrow terminal (< 40 cols) — titles truncate gracefully
- [x] Test "From PR" with long branch names — items truncate, no line wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modals and the open dialog now accept and respect a width, constraining their layout to terminal size.
  * Added a titled box UI element with Unicode borders, centered content and focus-aware styling.
  * Input and step screens adjusted to better fit constrained widths.

* **Bug Fixes / Improvements**
  * List items and descriptions now truncate cleanly to avoid overflow and preserve spacing.

* **Tests**
  * Added comprehensive tests for titled box rendering, truncation, padding, and focus styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->