### PR TITLE
Add --path/--branch flags to up/down and u/d TUI keybindings

### DIFF
--- a/docs/superpowers/plans/2026-04-12-up-down-enhancements.md
+++ b/docs/superpowers/plans/2026-04-12-up-down-enhancements.md
@@ -1237,3 +1237,72 @@ git commit -m "feat: add u:up keybinding with UpModal in TUI (#54)"
 gh issue close 53 --comment "Implemented --path and --branch flags for up/down commands"
 gh issue close 54 --comment "Implemented u:up and d:down keybindings in TUI"
 ```
+
+---
+
+### Task 8: Address TUI review regressions
+
+**Files:**
+- Modify: `src/tui/App.tsx`
+- Modify: `src/tui/components/UpModal.tsx`
+- Modify: `src/tui/components/form-controls.tsx`
+- Modify: `tests/tui/adjust-index.test.ts`
+- Create: `tests/tui/up-modal.test.ts`
+
+- [ ] **Step 1: Add a shared session handoff helper before destructive TUI actions**
+
+Ensure the TUI computes a safe fallback tmux session for the tracked client and awaits the switch before spawning `wct down`. Reuse the same helper for the existing close flow so both destructive paths follow the same session-handoff behavior.
+
+- [ ] **Step 2: Block `UpModal` submit when the profile filter has no matches**
+
+Treat an empty filtered profile list as a non-submittable state. Keep the existing `No matches` list feedback, early-return in submit logic, and render the submit control as disabled until a real profile selection is available again.
+
+- [ ] **Step 3: Add regression tests for the new decision helpers**
+
+Cover the session fallback selection logic in `tests/tui/adjust-index.test.ts` and add a focused `tests/tui/up-modal.test.ts` suite for the `UpModal` submission resolver so the “no matches” case cannot silently fall back to the default configuration.
+
+- [ ] **Step 4: Let repository stop hooks perform verification**
+
+Do not run tests or lint manually in this repo. Rely on the configured stop hooks for `biome lint --write` and `bun run test`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-04-12-up-down-enhancements.md \
+  src/tui/App.tsx \
+  src/tui/components/UpModal.tsx \
+  src/tui/components/form-controls.tsx \
+  tests/tui/adjust-index.test.ts \
+  tests/tui/up-modal.test.ts
+git commit -m "fix: address TUI review regressions"
+```
+
+---
+
+### Task 9: Address follow-up tmux handoff review gaps
+
+**Files:**
+- Modify: `src/tui/App.tsx`
+- Modify: `src/tui/hooks/useTmux.ts`
+- Modify: `tests/tui/adjust-index.test.ts`
+- Modify: `tests/tui/use-tmux.test.ts`
+
+- [ ] **Step 1: Distinguish blocked tmux handoff from no-op handoff**
+
+Replace the nullable handoff result in the TUI with an explicit three-state decision so destructive actions can refuse to proceed when the tracked client is still on the target session and there is no alternate session to switch to.
+
+- [ ] **Step 2: Keep tracked client state in sync after session switches**
+
+Update `useTmux.switchSession()` to persist the new session name into local hook state after a successful tmux client switch. This keeps later `close`/`down` safety checks aligned with the actual adjacent client session immediately after `u` auto-switch.
+
+- [ ] **Step 3: Refresh the tracked client after UpModal auto-switch**
+
+After a successful `u` auto-switch, refresh both sessions and the tracked client so the TUI re-renders against canonical tmux state.
+
+- [ ] **Step 4: Add regression coverage for the new states**
+
+Extend `tests/tui/adjust-index.test.ts` to cover the blocked handoff state and extend `tests/tui/use-tmux.test.ts` to cover immediate client-session updates after `switchSession()`.
+
+- [ ] **Step 5: Let repository stop hooks perform verification**
+
+Do not run tests or lint manually in this repo. Rely on the configured stop hooks for `biome lint --write` and `bun run test`.

--- a/src/cli/root-command.ts
+++ b/src/cli/root-command.ts
@@ -126,6 +126,13 @@ const upCliCommand = Command.make(
   {
     noIde: booleanFlag("no-ide", "Skip opening IDE"),
     noAttach: booleanFlag("no-attach", "Do not attach to tmux outside tmux"),
+    path: optionalStringFlag("path", "Path to worktree directory", undefined, "path"),
+    branch: optionalStringFlag(
+      "branch",
+      "Branch name to resolve worktree from",
+      "b",
+      "NAME",
+    ),
     profile: optionalStringFlag(
       "profile",
       "Use a named config profile",
@@ -133,8 +140,14 @@ const upCliCommand = Command.make(
       "NAME",
     ),
   },
-  ({ noIde, noAttach, profile }) =>
-    upCommand({ noIde, noAttach, profile: optionToUndefined(profile) }),
+  ({ noIde, noAttach, path, branch, profile }) =>
+    upCommand({
+      noIde,
+      noAttach,
+      path: optionToUndefined(path),
+      branch: optionToUndefined(branch),
+      profile: optionToUndefined(profile),
+    }),
 ).pipe(
   Command.withDescription(
     "Start tmux session and open IDE in current directory",

--- a/src/cli/root-command.ts
+++ b/src/cli/root-command.ts
@@ -154,9 +154,7 @@ const upCliCommand = Command.make(
       profile: optionToUndefined(profile),
     }),
 ).pipe(
-  Command.withDescription(
-    "Start tmux session and open IDE in current directory",
-  ),
+  Command.withDescription("Start tmux session and open IDE for a worktree"),
 );
 
 const openCliCommand = Command.make(

--- a/src/cli/root-command.ts
+++ b/src/cli/root-command.ts
@@ -94,9 +94,28 @@ const closeCliCommand = Command.make(
     }),
 ).pipe(Command.withDescription("Kill tmux session and remove worktree"));
 
-const downCliCommand = Command.make("down", {}, () => downCommand()).pipe(
-  Command.withDescription("Kill tmux session for current directory"),
-);
+const downCliCommand = Command.make(
+  "down",
+  {
+    path: optionalStringFlag(
+      "path",
+      "Path to worktree directory",
+      undefined,
+      "path",
+    ),
+    branch: optionalStringFlag(
+      "branch",
+      "Branch name to resolve worktree from",
+      "b",
+      "NAME",
+    ),
+  },
+  ({ path, branch }) =>
+    downCommand({
+      path: optionToUndefined(path),
+      branch: optionToUndefined(branch),
+    }),
+).pipe(Command.withDescription("Kill tmux session for a worktree"));
 
 const initCliCommand = Command.make("init", {}, () => initCommand()).pipe(
   Command.withDescription("Generate a starter .wct.yaml config file"),

--- a/src/cli/root-command.ts
+++ b/src/cli/root-command.ts
@@ -126,7 +126,12 @@ const upCliCommand = Command.make(
   {
     noIde: booleanFlag("no-ide", "Skip opening IDE"),
     noAttach: booleanFlag("no-attach", "Do not attach to tmux outside tmux"),
-    path: optionalStringFlag("path", "Path to worktree directory", undefined, "path"),
+    path: optionalStringFlag(
+      "path",
+      "Path to worktree directory",
+      undefined,
+      "path",
+    ),
     branch: optionalStringFlag(
       "branch",
       "Branch name to resolve worktree from",

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -1,12 +1,9 @@
-import { basename } from "node:path";
 import { Effect } from "effect";
 import type { WctServices } from "../effect/services";
-import { commandError, type WctError } from "../errors";
-import { formatSessionName, TmuxService } from "../services/tmux";
-import { WorktreeService } from "../services/worktree-service";
+import type { WctError } from "../errors";
 import * as logger from "../utils/logger";
 import type { CommandDef } from "./command-def";
-import { resolveWorktreePath } from "./resolve-worktree-path";
+import { stopWorktreeSession } from "./worktree-session";
 
 export const commandDef: CommandDef = {
   name: "down",
@@ -38,34 +35,16 @@ export function downCommand(
   options?: DownOptions,
 ): Effect.Effect<void, WctError, WctServices> {
   return Effect.gen(function* () {
-    const cwd = yield* resolveWorktreePath({
+    const result = yield* stopWorktreeSession({
       path: options?.path,
       branch: options?.branch,
     });
 
-    const isRepo = yield* WorktreeService.use((service) =>
-      service.isGitRepo(cwd),
-    );
-    if (!isRepo) {
-      return yield* Effect.fail(
-        commandError("not_git_repo", "Not a git repository"),
-      );
-    }
-
-    const sessionName = formatSessionName(basename(cwd));
-
-    const exists = yield* TmuxService.use((service) =>
-      service.sessionExists(sessionName),
-    );
-    if (!exists) {
-      yield* logger.warn(`No tmux session '${sessionName}' found`);
+    if (!result.existed) {
+      yield* logger.warn(`No tmux session '${result.sessionName}' found`);
       return;
     }
 
-    yield* logger.info(`Killing tmux session '${sessionName}'...`);
-
-    yield* TmuxService.use((service) => service.killSession(sessionName));
-
-    yield* logger.success(`Killed tmux session '${sessionName}'`);
+    yield* logger.success(`Killed tmux session '${result.sessionName}'`);
   });
 }

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -1,26 +1,57 @@
 import { basename } from "node:path";
 import { Effect } from "effect";
-import { commandError } from "../errors";
+import type { WctServices } from "../effect/services";
+import { commandError, type WctError } from "../errors";
 import { formatSessionName, TmuxService } from "../services/tmux";
 import { WorktreeService } from "../services/worktree-service";
 import * as logger from "../utils/logger";
 import type { CommandDef } from "./command-def";
+import { resolveWorktreePath } from "./resolve-worktree-path";
 
 export const commandDef: CommandDef = {
   name: "down",
-  description: "Kill tmux session for current directory",
+  description: "Kill tmux session for a worktree",
+  options: [
+    {
+      name: "path",
+      type: "string",
+      placeholder: "path",
+      description: "Path to worktree directory",
+    },
+    {
+      name: "branch",
+      short: "b",
+      type: "string",
+      placeholder: "name",
+      description: "Branch name to resolve worktree from",
+      completionValues: "__wct_branches",
+    },
+  ],
 };
 
-export function downCommand() {
+export interface DownOptions {
+  path?: string;
+  branch?: string;
+}
+
+export function downCommand(
+  options?: DownOptions,
+): Effect.Effect<void, WctError, WctServices> {
   return Effect.gen(function* () {
-    const isRepo = yield* WorktreeService.use((service) => service.isGitRepo());
+    const cwd = yield* resolveWorktreePath({
+      path: options?.path,
+      branch: options?.branch,
+    });
+
+    const isRepo = yield* WorktreeService.use((service) =>
+      service.isGitRepo(cwd),
+    );
     if (!isRepo) {
       return yield* Effect.fail(
         commandError("not_git_repo", "Not a git repository"),
       );
     }
 
-    const cwd = process.cwd();
     const sessionName = formatSessionName(basename(cwd));
 
     const exists = yield* TmuxService.use((service) =>

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -24,7 +24,7 @@ export const commandDef: CommandDef = {
       type: "string",
       placeholder: "name",
       description: "Branch name to resolve worktree from",
-      completionValues: "__wct_branches",
+      completionValues: "__wct_worktree_branches",
     },
   ],
 };

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -79,7 +79,7 @@ export function projectsAddCommand(opts?: {
 
     const mainDir = yield* Effect.ensuring(
       WorktreeService.use((service) => service.getMainRepoPath()),
-      opts?.path ? changeDirectory(originalCwd) : Effect.void,
+      opts?.path ? Effect.ignore(changeDirectory(originalCwd)) : Effect.void,
     );
 
     if (!mainDir) {
@@ -133,7 +133,7 @@ export function projectsRemoveCommand(
 
     const mainDir = yield* Effect.ensuring(
       WorktreeService.use((service) => service.getMainRepoPath()),
-      path ? changeDirectory(originalCwd) : Effect.void,
+      path ? Effect.ignore(changeDirectory(originalCwd)) : Effect.void,
     );
 
     const targetPath = mainDir ?? repoPath;

--- a/src/commands/resolve-worktree-path.ts
+++ b/src/commands/resolve-worktree-path.ts
@@ -42,6 +42,14 @@ export function resolveWorktreePath(
       return match.path;
     }
 
-    return process.cwd();
+    return yield* Effect.try({
+      try: () => process.cwd(),
+      catch: (err) =>
+        commandError(
+          "unexpected_error",
+          "Failed to resolve current working directory",
+          err,
+        ),
+    });
   });
 }

--- a/src/commands/resolve-worktree-path.ts
+++ b/src/commands/resolve-worktree-path.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { Effect } from "effect";
 import type { WctRuntimeServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
@@ -23,7 +24,7 @@ export function resolveWorktreePath(
       );
     }
 
-    if (path) return path;
+    if (path) return resolve(path);
 
     if (branch) {
       const match = yield* WorktreeService.use((service) =>

--- a/src/commands/resolve-worktree-path.ts
+++ b/src/commands/resolve-worktree-path.ts
@@ -26,10 +26,9 @@ export function resolveWorktreePath(
     if (path) return path;
 
     if (branch) {
-      const worktrees = yield* WorktreeService.use((service) =>
-        service.listWorktrees(),
+      const match = yield* WorktreeService.use((service) =>
+        service.findWorktreeByBranch(branch),
       );
-      const match = worktrees.find((worktree) => worktree.branch === branch);
 
       if (!match) {
         return yield* Effect.fail(

--- a/src/commands/resolve-worktree-path.ts
+++ b/src/commands/resolve-worktree-path.ts
@@ -1,0 +1,48 @@
+import { Effect } from "effect";
+import type { WctServices } from "../effect/services";
+import { commandError, type WctError } from "../errors";
+import { WorktreeService } from "../services/worktree-service";
+
+export interface ResolveWorktreePathOptions {
+  path?: string;
+  branch?: string;
+}
+
+export function resolveWorktreePath(
+  options: ResolveWorktreePathOptions,
+): Effect.Effect<string, WctError, WctServices> {
+  return Effect.gen(function* () {
+    const { path, branch } = options;
+
+    if (path && branch) {
+      return yield* Effect.fail(
+        commandError(
+          "invalid_options",
+          "--path and --branch are mutually exclusive",
+        ),
+      );
+    }
+
+    if (path) return path;
+
+    if (branch) {
+      const worktrees = yield* WorktreeService.use((service) =>
+        service.listWorktrees(),
+      );
+      const match = worktrees.find((worktree) => worktree.branch === branch);
+
+      if (!match) {
+        return yield* Effect.fail(
+          commandError(
+            "worktree_not_found",
+            `No worktree found for branch '${branch}'`,
+          ),
+        );
+      }
+
+      return match.path;
+    }
+
+    return process.cwd();
+  });
+}

--- a/src/commands/resolve-worktree-path.ts
+++ b/src/commands/resolve-worktree-path.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import type { WctServices } from "../effect/services";
+import type { WctRuntimeServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
 import { WorktreeService } from "../services/worktree-service";
 
@@ -10,7 +10,7 @@ export interface ResolveWorktreePathOptions {
 
 export function resolveWorktreePath(
   options: ResolveWorktreePathOptions,
-): Effect.Effect<string, WctError, WctServices> {
+): Effect.Effect<string, WctError, WctRuntimeServices> {
   return Effect.gen(function* () {
     const { path, branch } = options;
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -11,6 +11,47 @@ function canAutoAttachTmux() {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
+export function maybeAttachSession(
+  sessionName: string,
+  noAttach?: boolean,
+): Effect.Effect<void, WctError, WctServices> {
+  return Effect.gen(function* () {
+    if (noAttach || !canAutoAttachTmux()) {
+      yield* Console.log(
+        `\nAttach to tmux session: ${logger.bold(`tmux attach -t ${sessionName}`)}`,
+      );
+      return;
+    }
+
+    if (process.env.TMUX) {
+      yield* Effect.catch(
+        TmuxService.use((service) => service.switchSession(sessionName)).pipe(
+          Effect.tap(() =>
+            logger.success(`Switched to tmux session '${sessionName}'`),
+          ),
+        ),
+        (error) =>
+          logger.warn(`Failed to switch session: ${toWctError(error).message}`),
+      );
+      return;
+    }
+
+    yield* Console.log("");
+    yield* logger.info(`Attaching to tmux session '${sessionName}'...`);
+    yield* Effect.catch(
+      TmuxService.use((service) => service.attachSession(sessionName)).pipe(
+        Effect.tap(() =>
+          logger.success(`Attached to tmux session '${sessionName}'`),
+        ),
+      ),
+      (error) =>
+        logger.warn(
+          `Failed to attach session: ${toWctError(error).message}\nAttach manually with: ${logger.bold(`tmux attach -t ${sessionName}`)}`,
+        ),
+    );
+  });
+}
+
 export function launchSessionAndIde(opts: {
   sessionName: string;
   workingDir: string;
@@ -89,38 +130,6 @@ export function launchSessionAndIde(opts: {
       return;
     }
 
-    if (noAttach || !canAutoAttachTmux()) {
-      yield* Console.log(
-        `\nAttach to tmux session: ${logger.bold(`tmux attach -t ${sessionName}`)}`,
-      );
-      return;
-    }
-
-    if (process.env.TMUX) {
-      yield* Effect.catch(
-        TmuxService.use((service) => service.switchSession(sessionName)).pipe(
-          Effect.tap(() =>
-            logger.success(`Switched to tmux session '${sessionName}'`),
-          ),
-        ),
-        (error) =>
-          logger.warn(`Failed to switch session: ${toWctError(error).message}`),
-      );
-      return;
-    }
-
-    yield* Console.log("");
-    yield* logger.info(`Attaching to tmux session '${sessionName}'...`);
-    yield* Effect.catch(
-      TmuxService.use((service) => service.attachSession(sessionName)).pipe(
-        Effect.tap(() =>
-          logger.success(`Attached to tmux session '${sessionName}'`),
-        ),
-      ),
-      (error) =>
-        logger.warn(
-          `Failed to attach session: ${toWctError(error).message}\nAttach manually with: ${logger.bold(`tmux attach -t ${sessionName}`)}`,
-        ),
-    );
+    yield* maybeAttachSession(sessionName, noAttach);
   });
 }

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,15 +1,10 @@
-import { basename } from "node:path";
 import { Effect } from "effect";
-import { loadConfig, resolveProfile } from "../config/loader";
 import type { WctServices } from "../effect/services";
-import { commandError, type WctError } from "../errors";
-import { formatSessionName } from "../services/tmux";
-import { WorktreeService } from "../services/worktree-service";
-import type { WctEnv } from "../types/env";
+import type { WctError } from "../errors";
 import * as logger from "../utils/logger";
 import type { CommandDef } from "./command-def";
-import { resolveWorktreePath } from "./resolve-worktree-path";
-import { launchSessionAndIde } from "./session";
+import { maybeAttachSession } from "./session";
+import { startWorktreeSession } from "./worktree-session";
 
 export const commandDef: CommandDef = {
   name: "up",
@@ -45,7 +40,7 @@ export const commandDef: CommandDef = {
       type: "string",
       placeholder: "name",
       description: "Branch name to resolve worktree from",
-      completionValues: "__wct_branches",
+      completionValues: "__wct_worktree_branches",
     },
   ],
 };
@@ -62,88 +57,42 @@ export function upCommand(
   options?: UpOptions,
 ): Effect.Effect<void, WctError, WctServices> {
   return Effect.gen(function* () {
-    const {
+    const { noIde, noAttach, profile, path, branch } = options ?? {};
+    const result = yield* startWorktreeSession({
       noIde,
-      noAttach,
       profile,
       path,
-      branch: branchOption,
-    } = options ?? {};
-    const cwd = yield* resolveWorktreePath({
-      path,
-      branch: branchOption,
+      branch,
     });
 
-    const repo = yield* WorktreeService.use((service) =>
-      service.isGitRepo(cwd),
-    );
-    if (!repo) {
-      return yield* Effect.fail(
-        commandError("not_git_repo", "Not a git repository"),
-      );
+    if (result.profileName) {
+      yield* logger.info(`Using profile '${result.profileName}'`);
     }
 
-    const [mainRepoPath, branch] = yield* Effect.all([
-      WorktreeService.use((service) => service.getMainRepoPath(cwd)),
-      WorktreeService.use((service) => service.getCurrentBranch(cwd)),
-    ]);
-
-    if (!mainRepoPath) {
-      return yield* Effect.fail(
-        commandError("worktree_error", "Could not determine repository root"),
-      );
-    }
-    if (!branch) {
-      return yield* Effect.fail(
-        commandError(
-          "detached_head",
-          "Could not determine current branch (detached HEAD is not supported)",
-        ),
-      );
+    if (result.tmux.attempted) {
+      if (result.tmux.ok) {
+        yield* result.tmux.value._tag === "AlreadyExists"
+          ? logger.info(`Tmux session '${result.sessionName}' already exists`)
+          : logger.success(`Created tmux session '${result.sessionName}'`);
+      } else {
+        yield* logger.warn(
+          `Failed to create tmux session: ${result.tmux.error.message}`,
+        );
+      }
     }
 
-    const { config, errors } = yield* Effect.tryPromise({
-      try: () => loadConfig(mainRepoPath),
-      catch: (error) =>
-        commandError("config_error", "Failed to load configuration", error),
-    });
-    if (!config) {
-      return yield* Effect.fail(
-        commandError("config_error", errors.join("\n")),
-      );
+    if (result.ide.attempted) {
+      if (result.ide.ok) {
+        yield* logger.success("IDE opened");
+      } else {
+        yield* logger.warn(`Failed to open IDE: ${result.ide.error.message}`);
+      }
     }
 
-    const { config: resolved, profileName } = yield* Effect.try({
-      try: () => resolveProfile(config, branch, profile),
-      catch: (error) =>
-        commandError(
-          "config_error",
-          error instanceof Error ? error.message : String(error),
-        ),
-    });
-    if (profileName) {
-      yield* logger.info(`Using profile '${profileName}'`);
+    if (result.tmux.attempted && result.tmux.ok) {
+      yield* maybeAttachSession(result.sessionName, noAttach);
     }
 
-    const sessionName = formatSessionName(basename(cwd));
-
-    const env: WctEnv = {
-      WCT_WORKTREE_DIR: cwd,
-      WCT_MAIN_DIR: mainRepoPath,
-      WCT_BRANCH: branch,
-      WCT_PROJECT: config.project_name,
-    };
-
-    yield* launchSessionAndIde({
-      sessionName,
-      workingDir: cwd,
-      tmuxConfig: resolved.tmux,
-      env,
-      ideCommand: resolved.ide?.command,
-      noIde,
-      noAttach,
-    });
-
-    yield* logger.success(`Environment ready for '${branch}'`);
+    yield* logger.success(`Environment ready for '${result.branch}'`);
   });
 }

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,9 +1,6 @@
 import { basename } from "node:path";
 import { Effect } from "effect";
-import {
-  loadConfig,
-  resolveProfile,
-} from "../config/loader";
+import { loadConfig, resolveProfile } from "../config/loader";
 import type { WctServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
 import { formatSessionName } from "../services/tmux";
@@ -65,8 +62,13 @@ export function upCommand(
   options?: UpOptions,
 ): Effect.Effect<void, WctError, WctServices> {
   return Effect.gen(function* () {
-    const { noIde, noAttach, profile, path, branch: branchOption } =
-      options ?? {};
+    const {
+      noIde,
+      noAttach,
+      profile,
+      path,
+      branch: branchOption,
+    } = options ?? {};
     const repo = yield* WorktreeService.use((service) => service.isGitRepo());
     if (!repo) {
       return yield* Effect.fail(

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -13,7 +13,7 @@ import { launchSessionAndIde } from "./session";
 
 export const commandDef: CommandDef = {
   name: "up",
-  description: "Start tmux session and open IDE in current directory",
+  description: "Start tmux session and open IDE for a worktree",
   options: [
     {
       name: "no-ide",
@@ -69,17 +69,19 @@ export function upCommand(
       path,
       branch: branchOption,
     } = options ?? {};
-    const repo = yield* WorktreeService.use((service) => service.isGitRepo());
+    const cwd = yield* resolveWorktreePath({
+      path,
+      branch: branchOption,
+    });
+
+    const repo = yield* WorktreeService.use((service) =>
+      service.isGitRepo(cwd),
+    );
     if (!repo) {
       return yield* Effect.fail(
         commandError("not_git_repo", "Not a git repository"),
       );
     }
-
-    const cwd = yield* resolveWorktreePath({
-      path,
-      branch: branchOption,
-    });
 
     const [mainRepoPath, branch] = yield* Effect.all([
       WorktreeService.use((service) => service.getMainRepoPath(cwd)),

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,6 +1,9 @@
 import { basename } from "node:path";
 import { Effect } from "effect";
-import { loadConfig, resolveProfile } from "../config/loader";
+import {
+  loadConfig,
+  resolveProfile,
+} from "../config/loader";
 import type { WctServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
 import { formatSessionName } from "../services/tmux";
@@ -8,6 +11,7 @@ import { WorktreeService } from "../services/worktree-service";
 import type { WctEnv } from "../types/env";
 import * as logger from "../utils/logger";
 import type { CommandDef } from "./command-def";
+import { resolveWorktreePath } from "./resolve-worktree-path";
 import { launchSessionAndIde } from "./session";
 
 export const commandDef: CommandDef = {
@@ -32,6 +36,20 @@ export const commandDef: CommandDef = {
       description: "Use a named config profile",
       completionValues: "__wct_profiles",
     },
+    {
+      name: "path",
+      type: "string",
+      placeholder: "path",
+      description: "Path to worktree directory",
+    },
+    {
+      name: "branch",
+      short: "b",
+      type: "string",
+      placeholder: "name",
+      description: "Branch name to resolve worktree from",
+      completionValues: "__wct_branches",
+    },
   ],
 };
 
@@ -39,13 +57,16 @@ export interface UpOptions {
   noIde?: boolean;
   noAttach?: boolean;
   profile?: string;
+  path?: string;
+  branch?: string;
 }
 
 export function upCommand(
   options?: UpOptions,
 ): Effect.Effect<void, WctError, WctServices> {
   return Effect.gen(function* () {
-    const { noIde, noAttach, profile } = options ?? {};
+    const { noIde, noAttach, profile, path, branch: branchOption } =
+      options ?? {};
     const repo = yield* WorktreeService.use((service) => service.isGitRepo());
     if (!repo) {
       return yield* Effect.fail(
@@ -53,11 +74,14 @@ export function upCommand(
       );
     }
 
-    const cwd = process.cwd();
+    const cwd = yield* resolveWorktreePath({
+      path,
+      branch: branchOption,
+    });
 
     const [mainRepoPath, branch] = yield* Effect.all([
-      WorktreeService.use((service) => service.getMainRepoPath()),
-      WorktreeService.use((service) => service.getCurrentBranch()),
+      WorktreeService.use((service) => service.getMainRepoPath(cwd)),
+      WorktreeService.use((service) => service.getCurrentBranch(cwd)),
     ]);
 
     if (!mainRepoPath) {

--- a/src/commands/worktree-session.ts
+++ b/src/commands/worktree-session.ts
@@ -1,0 +1,214 @@
+import { basename } from "node:path";
+import { Effect } from "effect";
+import { loadConfig, resolveProfile } from "../config/loader";
+import type { WctRuntimeServices } from "../effect/services";
+import { commandError, toWctError, type WctError } from "../errors";
+import {
+  IdeService,
+  type IdeService as IdeServiceApi,
+} from "../services/ide-service";
+import {
+  type CreateSessionResult,
+  formatSessionName,
+  TmuxService,
+} from "../services/tmux";
+import { WorktreeService } from "../services/worktree-service";
+import type { WctEnv } from "../types/env";
+import {
+  type ResolveWorktreePathOptions,
+  resolveWorktreePath,
+} from "./resolve-worktree-path";
+
+export type OperationAttempt<T> =
+  | { attempted: false }
+  | { attempted: true; ok: true; value: T }
+  | { attempted: true; ok: false; error: WctError };
+
+export interface StartWorktreeSessionOptions
+  extends ResolveWorktreePathOptions {
+  noIde?: boolean;
+  profile?: string;
+}
+
+export interface StartWorktreeSessionResult {
+  worktreePath: string;
+  mainRepoPath: string;
+  branch: string;
+  sessionName: string;
+  projectName: string;
+  profileName?: string;
+  env: WctEnv;
+  tmux: OperationAttempt<CreateSessionResult>;
+  ide: OperationAttempt<void>;
+}
+
+export interface StopWorktreeSessionOptions
+  extends ResolveWorktreePathOptions {}
+
+export interface StopWorktreeSessionResult {
+  worktreePath: string;
+  sessionName: string;
+  existed: boolean;
+}
+
+function skippedAttempt<T>(): OperationAttempt<T> {
+  return { attempted: false };
+}
+
+function captureAttempt<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<OperationAttempt<A>, never, R> {
+  return Effect.match(effect, {
+    onFailure: (error) => ({
+      attempted: true as const,
+      ok: false as const,
+      error: toWctError(error),
+    }),
+    onSuccess: (value) => ({
+      attempted: true as const,
+      ok: true as const,
+      value,
+    }),
+  });
+}
+
+export function startWorktreeSession(
+  options: StartWorktreeSessionOptions = {},
+): Effect.Effect<
+  StartWorktreeSessionResult,
+  WctError,
+  WctRuntimeServices | IdeServiceApi
+> {
+  return Effect.gen(function* () {
+    const { noIde, profile, path, branch: branchOption } = options;
+    const worktreePath = yield* resolveWorktreePath({
+      path,
+      branch: branchOption,
+    });
+
+    const repo = yield* WorktreeService.use((service) =>
+      service.isGitRepo(worktreePath),
+    );
+    if (!repo) {
+      return yield* Effect.fail(
+        commandError("not_git_repo", "Not a git repository"),
+      );
+    }
+
+    const [mainRepoPath, branch] = yield* Effect.all([
+      WorktreeService.use((service) => service.getMainRepoPath(worktreePath)),
+      WorktreeService.use((service) => service.getCurrentBranch(worktreePath)),
+    ]);
+
+    if (!mainRepoPath) {
+      return yield* Effect.fail(
+        commandError("worktree_error", "Could not determine repository root"),
+      );
+    }
+    if (!branch) {
+      return yield* Effect.fail(
+        commandError(
+          "detached_head",
+          "Could not determine current branch (detached HEAD is not supported)",
+        ),
+      );
+    }
+
+    const { config, errors } = yield* Effect.tryPromise({
+      try: () => loadConfig(mainRepoPath),
+      catch: (error) =>
+        commandError("config_error", "Failed to load configuration", error),
+    });
+    if (!config) {
+      return yield* Effect.fail(
+        commandError("config_error", errors.join("\n")),
+      );
+    }
+
+    const { config: resolved, profileName } = yield* Effect.try({
+      try: () => resolveProfile(config, branch, profile),
+      catch: (error) =>
+        commandError(
+          "config_error",
+          error instanceof Error ? error.message : String(error),
+        ),
+    });
+
+    const sessionName = formatSessionName(basename(worktreePath));
+    const env: WctEnv = {
+      WCT_WORKTREE_DIR: worktreePath,
+      WCT_MAIN_DIR: mainRepoPath,
+      WCT_BRANCH: branch,
+      WCT_PROJECT: config.project_name,
+    };
+
+    const [tmux, ide] = yield* Effect.all(
+      [
+        resolved.tmux
+          ? captureAttempt(
+              TmuxService.use((service) =>
+                service.createSession(
+                  sessionName,
+                  worktreePath,
+                  resolved.tmux,
+                  env,
+                ),
+              ),
+            )
+          : Effect.succeed(skippedAttempt<CreateSessionResult>()),
+        resolved.ide?.command && !noIde
+          ? captureAttempt(
+              IdeService.use((service) =>
+                service.openIDE(resolved.ide?.command ?? "", env),
+              ),
+            )
+          : Effect.succeed(skippedAttempt<void>()),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    return {
+      worktreePath,
+      mainRepoPath,
+      branch,
+      sessionName,
+      projectName: config.project_name,
+      profileName,
+      env,
+      tmux,
+      ide,
+    };
+  });
+}
+
+export function stopWorktreeSession(
+  options: StopWorktreeSessionOptions = {},
+): Effect.Effect<StopWorktreeSessionResult, WctError, WctRuntimeServices> {
+  return Effect.gen(function* () {
+    const worktreePath = yield* resolveWorktreePath(options);
+
+    const isRepo = yield* WorktreeService.use((service) =>
+      service.isGitRepo(worktreePath),
+    );
+    if (!isRepo) {
+      return yield* Effect.fail(
+        commandError("not_git_repo", "Not a git repository"),
+      );
+    }
+
+    const sessionName = formatSessionName(basename(worktreePath));
+    const existed = yield* TmuxService.use((service) =>
+      service.sessionExists(sessionName),
+    );
+
+    if (existed) {
+      yield* TmuxService.use((service) => service.killSession(sessionName));
+    }
+
+    return {
+      worktreePath,
+      sessionName,
+      existed,
+    };
+  });
+}

--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -129,7 +129,7 @@ export function parseRemoteOwnerRepo(
   url: string,
 ): { owner: string; repo: string } | null {
   const match = url.match(GITHUB_REMOTE_PATTERN);
-  if (match) return { owner: match[1], repo: match[2] };
+  if (match?.[1] && match[2]) return { owner: match[1], repo: match[2] };
   return null;
 }
 
@@ -144,14 +144,14 @@ export function findMatchingRemote(
 
   for (const line of remoteOutput.split("\n")) {
     const parts = line.split(/\s+/);
-    if (parts.length >= 3 && parts[2] === "(fetch)") {
-      const parsed = parseRemoteOwnerRepo(parts[1]);
+    const [name, url, fetchTag] = parts;
+    if (name && url && fetchTag === "(fetch)") {
+      const parsed = parseRemoteOwnerRepo(url);
       if (
         parsed &&
         parsed.owner.toLowerCase() === lowerOwner &&
         parsed.repo.toLowerCase() === lowerRepo
       ) {
-        const name = parts[0];
         if (name === "origin") return "origin";
         if (name === "upstream" && bestMatch !== "origin") bestMatch = name;
         bestMatch ??= name;

--- a/src/services/ide-service.ts
+++ b/src/services/ide-service.ts
@@ -1,5 +1,5 @@
 import { Effect, ServiceMap } from "effect";
-import type { WctServices } from "../effect/services";
+import type { WctRuntimeServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
 import type { WctEnv } from "../types/env";
 import { execShell, getProcessErrorMessage } from "./process";
@@ -20,7 +20,7 @@ export interface IdeService {
   openIDE: (
     command: string,
     env: WctEnv,
-  ) => Effect.Effect<void, WctError, WctServices>;
+  ) => Effect.Effect<void, WctError, WctRuntimeServices>;
 }
 
 export const IdeService = ServiceMap.Service<IdeService>("wct/IdeService");

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -3,6 +3,12 @@
 import { basename } from "node:path";
 import { Box, type Key, render, Text, useApp, useInput, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type StartWorktreeSessionResult,
+  startWorktreeSession,
+  stopWorktreeSession,
+} from "../commands/worktree-session";
+import { toWctError } from "../errors";
 import { formatSessionName } from "../services/tmux";
 import { OpenModal, type OpenModalResult } from "./components/OpenModal";
 import { StatusBar } from "./components/StatusBar";
@@ -11,7 +17,8 @@ import { UpModal, type UpModalResult } from "./components/UpModal";
 import { useGitHub } from "./hooks/useGitHub";
 import { useRefresh } from "./hooks/useRefresh";
 import { type RepoInfo, useRegistry } from "./hooks/useRegistry";
-import { useTmux } from "./hooks/useTmux";
+import { type TmuxClientDiscovery, useTmux } from "./hooks/useTmux";
+import { tuiRuntime } from "./runtime";
 import {
   Mode,
   type PaneInfo,
@@ -48,6 +55,17 @@ interface ResolveStatusBarPropsOptions {
   items: TreeItem[];
   selectedIndex: number;
 }
+
+interface ResolveSessionSwitchTargetOptions {
+  client: TmuxClientDiscovery;
+  targetSession: string;
+  sessions: Array<{ name: string }>;
+}
+
+type SessionHandoff =
+  | { type: "not-needed" }
+  | { type: "blocked" }
+  | { type: "switch"; sessionName: string };
 
 interface ResolveExpandedRightArrowActionOptions {
   repos: RepoInfo[];
@@ -444,6 +462,47 @@ export function resolveStatusBarProps({
   };
 }
 
+export function resolveSessionHandoff({
+  client,
+  targetSession,
+  sessions,
+}: ResolveSessionSwitchTargetOptions): SessionHandoff {
+  if (client.type === "multiple" || client.type === "error") {
+    return { type: "blocked" };
+  }
+
+  if (client.type !== "single" || client.client.session !== targetSession) {
+    return { type: "not-needed" };
+  }
+
+  const fallbackSession = sessions.find(
+    (session) => session.name !== targetSession,
+  )?.name;
+
+  if (!fallbackSession) {
+    return { type: "blocked" };
+  }
+
+  return {
+    type: "switch",
+    sessionName: fallbackSession,
+  };
+}
+
+function resolveStartActionMessage(
+  result: StartWorktreeSessionResult,
+): string | null {
+  if (result.tmux.attempted && !result.tmux.ok) {
+    return result.tmux.error.message;
+  }
+
+  if (result.ide.attempted && !result.ide.ok) {
+    return result.ide.error.message;
+  }
+
+  return null;
+}
+
 export function App() {
   const { exit } = useApp();
   const { stdout } = useStdout();
@@ -452,7 +511,6 @@ export function App() {
   const { repos, loading, refresh: refreshRegistry } = useRegistry();
   const { prData } = useGitHub(repos);
   const {
-    client,
     sessions,
     panes,
     error: tmuxError,
@@ -473,6 +531,7 @@ export function App() {
   const [openModalRepoPath, setOpenModalRepoPath] = useState("");
   const [mode, setMode] = useState<Mode>(Mode.Navigate);
   const [searchQuery, setSearchQuery] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
   const [pendingActions, setPendingActions] = useState<
     Map<string, PendingAction>
   >(new Map());
@@ -480,6 +539,9 @@ export function App() {
   const confirmDownReturnSelectedIndexRef = useRef<number>(0);
   const upModalReturnModeRef = useRef<Mode>(Mode.Navigate);
   const upModalReturnSelectedIndexRef = useRef<number>(0);
+  const actionErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -590,6 +652,92 @@ export function App() {
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
   }, [refreshRegistry, refreshSessions, discoverClient]);
+
+  const clearActionError = useCallback(() => {
+    if (actionErrorTimeoutRef.current) {
+      clearTimeout(actionErrorTimeoutRef.current);
+      actionErrorTimeoutRef.current = null;
+    }
+    setActionError(null);
+  }, []);
+
+  const showActionError = useCallback((message: string) => {
+    if (actionErrorTimeoutRef.current) {
+      clearTimeout(actionErrorTimeoutRef.current);
+    }
+    setActionError(message);
+    actionErrorTimeoutRef.current = setTimeout(() => {
+      actionErrorTimeoutRef.current = null;
+      setActionError(null);
+    }, 5000);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (actionErrorTimeoutRef.current) {
+        clearTimeout(actionErrorTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const switchClientAwayFromSession = useCallback(
+    async (sessionName: string) => {
+      const [client, latestSessions] = await Promise.all([
+        discoverClient(),
+        refreshSessions(),
+      ]);
+      const handoff = resolveSessionHandoff({
+        client,
+        targetSession: sessionName,
+        sessions: latestSessions,
+      });
+
+      if (handoff.type === "not-needed") {
+        return true;
+      }
+
+      if (handoff.type === "blocked") {
+        return false;
+      }
+
+      return client.type === "single"
+        ? switchSession(handoff.sessionName, client.client)
+        : false;
+    },
+    [discoverClient, refreshSessions, switchSession],
+  );
+
+  const handleStartResult = useCallback(
+    async (result: StartWorktreeSessionResult, autoSwitch: boolean) => {
+      const actionMessage = resolveStartActionMessage(result);
+
+      if (result.tmux.attempted && result.tmux.ok && autoSwitch) {
+        const switched = await switchSession(result.sessionName);
+        await Promise.all([refreshSessions(), discoverClient()]);
+
+        if (!switched) {
+          showActionError(
+            `Started session '${result.sessionName}', but failed to switch client`,
+          );
+          return;
+        }
+      } else {
+        await refreshAll();
+      }
+
+      if (actionMessage) {
+        showActionError(actionMessage);
+      }
+    },
+    [
+      discoverClient,
+      refreshAll,
+      refreshSessions,
+      showActionError,
+      switchSession,
+    ],
+  );
 
   useRefresh(refreshAll);
 
@@ -719,6 +867,7 @@ export function App() {
     if (mode.type !== "UpModal") return;
 
     const { worktreePath, worktreeKey } = mode;
+    clearActionError();
     setSelectedIndex(upModalReturnSelectedIndexRef.current);
     setMode(upModalReturnModeRef.current);
 
@@ -732,28 +881,27 @@ export function App() {
       }),
     );
 
-    const args = ["up", "--no-attach", "--path", worktreePath];
-    if (result.profile) args.push("--profile", result.profile);
-    if (result.noIde) args.push("--no-ide");
-
-    const proc = Bun.spawn(["wct", ...args], {
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    proc.exited.then(async (code) => {
-      if (code === 0 && result.autoSwitch) {
-        const sessionName = formatSessionName(basename(worktreePath));
-        await switchSession(sessionName);
-        await refreshSessions();
-      } else {
+    void (async () => {
+      try {
+        const startResult = await tuiRuntime.runPromise(
+          startWorktreeSession({
+            path: worktreePath,
+            profile: result.profile,
+            noIde: result.noIde,
+          }),
+        );
+        await handleStartResult(startResult, result.autoSwitch);
+      } catch (error) {
+        showActionError(toWctError(error).message);
         await refreshAll();
+      } finally {
+        setPendingActions((prev) => {
+          const next = new Map(prev);
+          next.delete(worktreeKey);
+          return next;
+        });
       }
-      setPendingActions((prev) => {
-        const next = new Map(prev);
-        next.delete(worktreeKey);
-        return next;
-      });
-    });
+    })();
   }
 
   /** Move selection up or down in the flat tree list, skipping headers */
@@ -798,10 +946,15 @@ export function App() {
     const sessionName = formatSessionName(basename(wt.path));
     const hasSession = sessions.some((s) => s.name === sessionName);
     if (hasSession) {
-      switchSession(sessionName);
+      clearActionError();
+      void switchSession(sessionName).then((switched) => {
+        if (!switched) {
+          showActionError(`Failed to switch to tmux session '${sessionName}'`);
+        }
+      });
     } else {
-      // Create session with wct up, then switch
       const pendingActionKey = pendingKey(repo.project, wt.branch);
+      clearActionError();
       setPendingActions((prev) =>
         new Map(prev).set(pendingActionKey, {
           type: "starting",
@@ -809,21 +962,23 @@ export function App() {
           project: repo.project,
         }),
       );
-      const proc = Bun.spawn(["wct", "up", "--no-attach"], {
-        cwd: wt.path,
-        stdio: ["ignore", "ignore", "ignore"],
-      });
-      proc.exited.then(async (code) => {
-        if (code === 0) {
-          await refreshSessions();
-          switchSession(sessionName);
+      void (async () => {
+        try {
+          const startResult = await tuiRuntime.runPromise(
+            startWorktreeSession({ path: wt.path }),
+          );
+          await handleStartResult(startResult, true);
+        } catch (error) {
+          showActionError(toWctError(error).message);
+          await refreshAll();
+        } finally {
+          setPendingActions((prev) => {
+            const next = new Map(prev);
+            next.delete(pendingActionKey);
+            return next;
+          });
         }
-        setPendingActions((prev) => {
-          const next = new Map(prev);
-          next.delete(pendingActionKey);
-          return next;
-        });
-      });
+      })();
     }
   }
 
@@ -836,13 +991,6 @@ export function App() {
     });
     if (action.type === "noop") {
       return;
-    }
-
-    if (action.nextSelectedIndex !== undefined) {
-      setSelectedIndex(action.nextSelectedIndex);
-    }
-    if (action.nextMode) {
-      setMode(action.nextMode);
     }
 
     const currentItem = treeItems[action.worktreeIndex];
@@ -861,39 +1009,54 @@ export function App() {
     }
 
     const closingSession = formatSessionName(basename(currentWorktree.path));
-    if (client && client.session === closingSession) {
-      const other = sessions.find((s) => s.name !== closingSession);
-      if (other) {
-        switchSession(other.name);
-      }
-    }
-
     const pendingActionKey = pendingKey(
       currentRepo.project,
       currentWorktree.branch,
     );
-    setPendingActions((prev) =>
-      new Map(prev).set(pendingActionKey, {
-        type: "closing",
-        branch: currentWorktree.branch,
-        project: currentRepo.project,
-      }),
-    );
+    clearActionError();
 
-    const proc = Bun.spawn(["wct", "close", currentWorktree.branch, "--yes"], {
-      cwd: currentRepo.repoPath,
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    proc.exited.then(() => {
-      refreshAll().then(() => {
-        setPendingActions((prev) => {
-          const next = new Map(prev);
-          next.delete(pendingActionKey);
-          return next;
+    void (async () => {
+      const canProceed = await switchClientAwayFromSession(closingSession);
+      if (!canProceed) {
+        showActionError(
+          "Cannot safely close the worktree because the active tmux client could not be moved away",
+        );
+        return;
+      }
+
+      if (action.nextSelectedIndex !== undefined) {
+        setSelectedIndex(action.nextSelectedIndex);
+      }
+      if (action.nextMode) {
+        setMode(action.nextMode);
+      }
+
+      setPendingActions((prev) =>
+        new Map(prev).set(pendingActionKey, {
+          type: "closing",
+          branch: currentWorktree.branch,
+          project: currentRepo.project,
+        }),
+      );
+
+      const proc = Bun.spawn(
+        ["wct", "close", currentWorktree.branch, "--yes"],
+        {
+          cwd: currentRepo.repoPath,
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      );
+      proc.exited.then(() => {
+        refreshAll().then(() => {
+          setPendingActions((prev) => {
+            const next = new Map(prev);
+            next.delete(pendingActionKey);
+            return next;
+          });
         });
       });
-    });
+    })();
   }
 
   function handleNavigateInput(input: string, key: Key) {
@@ -1148,32 +1311,49 @@ export function App() {
     }
 
     if (key.return) {
-      const { branch, worktreeKey, worktreePath } = mode;
-      setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
-      setMode(confirmDownReturnModeRef.current);
+      const { branch, worktreeKey, worktreePath, sessionName } = mode;
+      clearActionError();
 
-      const project = worktreeKey.split("/")[0] ?? "unknown";
-      setPendingActions((prev) =>
-        new Map(prev).set(worktreeKey, {
-          type: "stopping",
-          branch,
-          project,
-        }),
-      );
+      void (async () => {
+        const canProceed = await switchClientAwayFromSession(sessionName);
+        if (!canProceed) {
+          showActionError(
+            "Cannot safely stop the tmux session because the active client could not be moved away",
+          );
+          return;
+        }
 
-      const proc = Bun.spawn(["wct", "down", "--path", worktreePath], {
-        stdout: "ignore",
-        stderr: "ignore",
-      });
-      proc.exited.then(() => {
-        refreshAll().then(() => {
+        setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
+        setMode(confirmDownReturnModeRef.current);
+
+        const project = worktreeKey.split("/")[0] ?? "unknown";
+        setPendingActions((prev) =>
+          new Map(prev).set(worktreeKey, {
+            type: "stopping",
+            branch,
+            project,
+          }),
+        );
+
+        try {
+          const result = await tuiRuntime.runPromise(
+            stopWorktreeSession({ path: worktreePath }),
+          );
+          if (!result.existed) {
+            showActionError(`No tmux session '${result.sessionName}' found`);
+          }
+          await refreshAll();
+        } catch (error) {
+          showActionError(toWctError(error).message);
+          await refreshAll();
+        } finally {
           setPendingActions((prev) => {
             const next = new Map(prev);
             next.delete(worktreeKey);
             return next;
           });
-        });
-      });
+        }
+      })();
     }
   }
 
@@ -1271,7 +1451,10 @@ export function App() {
           }}
         />
       ) : (
-        <StatusBar {...statusBarProps} searchQuery={searchQuery} />
+        <Box flexDirection="column">
+          {actionError ? <Text color="red">{actionError}</Text> : null}
+          <StatusBar {...statusBarProps} searchQuery={searchQuery} />
+        </Box>
       )}
     </Box>
   );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -743,7 +743,7 @@ export function App() {
     proc.exited.then(async (code) => {
       if (code === 0 && result.autoSwitch) {
         const sessionName = formatSessionName(basename(worktreePath));
-        switchSession(sessionName);
+        await switchSession(sessionName);
         await refreshSessions();
       } else {
         await refreshAll();

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -297,7 +297,9 @@ export function resolveCloseSelectedWorktreeAction({
 
   const worktreeKey = pendingKey(repo.project, worktree.branch);
   if (
-    (mode.type === "Expanded" || mode.type === "ConfirmKill") &&
+    (mode.type === "Expanded" ||
+      mode.type === "ConfirmKill" ||
+      mode.type === "ConfirmDown") &&
     mode.worktreeKey === worktreeKey
   ) {
     return {
@@ -473,6 +475,7 @@ export function App() {
   const [pendingActions, setPendingActions] = useState<
     Map<string, PendingAction>
   >(new Map());
+  const confirmDownReturnModeRef = useRef<Mode>(Mode.Navigate);
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -507,7 +510,9 @@ export function App() {
   }, [repos, searchQuery]);
 
   const expandedWorktreeKey =
-    mode.type === "Expanded" || mode.type === "ConfirmKill"
+    mode.type === "Expanded" ||
+    mode.type === "ConfirmKill" ||
+    mode.type === "ConfirmDown"
       ? mode.worktreeKey
       : null;
 
@@ -839,6 +844,11 @@ export function App() {
       return;
     }
 
+    if (input === "d") {
+      handleDownSelectedWorktree();
+      return;
+    }
+
     if (key.upArrow) {
       navigateTree(-1);
       return;
@@ -951,6 +961,11 @@ export function App() {
       return;
     }
 
+    if (input === "d") {
+      handleDownSelectedWorktree();
+      return;
+    }
+
     if (input === "c") {
       handleCloseSelectedWorktree();
       return;
@@ -1017,13 +1032,91 @@ export function App() {
     }
   }
 
+  function handleDownSelectedWorktree() {
+    const worktreeIndex = resolveSelectedWorktreeIndex(treeItems, selectedIndex);
+    if (worktreeIndex === null) return;
+
+    const item = treeItems[worktreeIndex];
+    if (!item || item.type !== "worktree") return;
+
+    const repo = filteredRepos[item.repoIndex];
+    const wt = repo?.worktrees[item.worktreeIndex];
+    if (!repo || !wt) return;
+
+    const sessionName = formatSessionName(basename(wt.path));
+    const hasSession = sessions.some((s) => s.name === sessionName);
+    if (!hasSession) return;
+
+    const worktreeKey = pendingKey(repo.project, wt.branch);
+    confirmDownReturnModeRef.current =
+      mode.type === "Expanded" ? Mode.Expanded(worktreeKey) : Mode.Navigate;
+    setMode(Mode.ConfirmDown(sessionName, wt.branch, worktreeKey));
+  }
+
+  function handleConfirmDownInput(_input: string, key: Key) {
+    if (mode.type !== "ConfirmDown") {
+      return;
+    }
+
+    if (key.escape) {
+      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
+      if (parentIndex !== null) {
+        setSelectedIndex(parentIndex);
+      }
+      setMode(confirmDownReturnModeRef.current);
+      return;
+    }
+
+    if (key.return) {
+      const { sessionName, branch, worktreeKey } = mode;
+      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
+      if (parentIndex !== null) {
+        setSelectedIndex(parentIndex);
+      }
+      setMode(confirmDownReturnModeRef.current);
+
+      const project = worktreeKey.split("/")[0] ?? "unknown";
+      setPendingActions((prev) =>
+        new Map(prev).set(worktreeKey, {
+          type: "stopping",
+          branch,
+          project,
+        }),
+      );
+
+      const worktreeIndex = resolveSelectedWorktreeIndex(treeItems, selectedIndex);
+      const item = worktreeIndex !== null ? treeItems[worktreeIndex] : null;
+      const repo =
+        item && item.type === "worktree" ? filteredRepos[item.repoIndex] : null;
+      const wt =
+        item && item.type === "worktree" && repo
+          ? repo.worktrees[item.worktreeIndex]
+          : null;
+
+      const proc = Bun.spawn(["wct", "down", "--path", wt?.path ?? sessionName], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      proc.exited.then(() => {
+        refreshAll().then(() => {
+          setPendingActions((prev) => {
+            const next = new Map(prev);
+            next.delete(worktreeKey);
+            return next;
+          });
+        });
+      });
+    }
+  }
+
   useInput((input, key) => {
     // Global keys (work in any mode)
     if (
       input === "q" &&
       mode.type !== "OpenModal" &&
       mode.type !== "Search" &&
-      mode.type !== "ConfirmKill"
+      mode.type !== "ConfirmKill" &&
+      mode.type !== "ConfirmDown"
     ) {
       exit();
       return;
@@ -1041,6 +1134,8 @@ export function App() {
         return handleExpandedInput(input, key);
       case "ConfirmKill":
         return handleConfirmKillInput(input, key);
+      case "ConfirmDown":
+        return handleConfirmDownInput(input, key);
     }
   });
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -7,6 +7,7 @@ import { formatSessionName } from "../services/tmux";
 import { OpenModal, type OpenModalResult } from "./components/OpenModal";
 import { StatusBar } from "./components/StatusBar";
 import { TreeView } from "./components/TreeView";
+import { UpModal, type UpModalResult } from "./components/UpModal";
 import { useGitHub } from "./hooks/useGitHub";
 import { useRefresh } from "./hooks/useRefresh";
 import { type RepoInfo, useRegistry } from "./hooks/useRegistry";
@@ -513,6 +514,7 @@ export function App() {
   const expandedWorktreeKey =
     mode.type === "Expanded" ||
     mode.type === "ConfirmKill" ||
+    mode.type === "UpModal" ||
     (mode.type === "ConfirmDown" &&
       confirmDownReturnModeRef.current.type === "Expanded")
       ? mode.worktreeKey
@@ -689,6 +691,64 @@ export function App() {
     });
   }
 
+  function prepareUpModal() {
+    const worktreeIndex = resolveSelectedWorktreeIndex(
+      treeItems,
+      selectedIndex,
+    );
+    if (worktreeIndex === null) return;
+
+    const item = treeItems[worktreeIndex];
+    if (!item || item.type !== "worktree") return;
+
+    const repo = filteredRepos[item.repoIndex];
+    const wt = repo?.worktrees[item.worktreeIndex];
+    if (!repo || !wt) return;
+
+    const worktreeKey = pendingKey(repo.project, wt.branch);
+    setMode(Mode.UpModal(wt.path, worktreeKey, repo.profileNames));
+  }
+
+  function handleUpSubmit(result: UpModalResult) {
+    if (mode.type !== "UpModal") return;
+
+    const { worktreePath, worktreeKey } = mode;
+    setMode(Mode.Navigate);
+
+    const branch = worktreeKey.split("/").slice(1).join("/");
+    const project = worktreeKey.split("/")[0] ?? "unknown";
+    setPendingActions((prev) =>
+      new Map(prev).set(worktreeKey, {
+        type: "starting",
+        branch,
+        project,
+      }),
+    );
+
+    const args = ["up", "--no-attach", "--path", worktreePath];
+    if (result.profile) args.push("--profile", result.profile);
+    if (result.noIde) args.push("--no-ide");
+
+    const proc = Bun.spawn(["wct", ...args], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    proc.exited.then(async (code) => {
+      if (code === 0 && result.autoSwitch) {
+        await refreshSessions();
+        const sessionName = formatSessionName(basename(worktreePath));
+        switchSession(sessionName);
+      } else {
+        await refreshAll();
+      }
+      setPendingActions((prev) => {
+        const next = new Map(prev);
+        next.delete(worktreeKey);
+        return next;
+      });
+    });
+  }
+
   /** Move selection up or down in the flat tree list, skipping headers */
   function navigateTree(direction: 1 | -1) {
     setSelectedIndex((prev) => {
@@ -851,6 +911,11 @@ export function App() {
       return;
     }
 
+    if (input === "u") {
+      prepareUpModal();
+      return;
+    }
+
     if (key.upArrow) {
       navigateTree(-1);
       return;
@@ -965,6 +1030,11 @@ export function App() {
 
     if (input === "d") {
       handleDownSelectedWorktree();
+      return;
+    }
+
+    if (input === "u") {
+      prepareUpModal();
       return;
     }
 
@@ -1105,6 +1175,7 @@ export function App() {
     if (
       input === "q" &&
       mode.type !== "OpenModal" &&
+      mode.type !== "UpModal" &&
       mode.type !== "Search" &&
       mode.type !== "ConfirmKill" &&
       mode.type !== "ConfirmDown"
@@ -1119,6 +1190,9 @@ export function App() {
       case "Search":
         return handleSearchInput(input, key);
       case "OpenModal":
+        // Modal handles its own input
+        return;
+      case "UpModal":
         // Modal handles its own input
         return;
       case "Expanded":
@@ -1176,6 +1250,14 @@ export function App() {
           repoPath={openModalRepoPath}
           prList={openModalPRList}
           onSubmit={handleOpen}
+          onCancel={() => setMode(Mode.Navigate)}
+        />
+      ) : mode.type === "UpModal" ? (
+        <UpModal
+          visible
+          width={Math.min(termCols, 60)}
+          profileNames={mode.profileNames}
+          onSubmit={handleUpSubmit}
           onCancel={() => setMode(Mode.Navigate)}
         />
       ) : (

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -476,6 +476,7 @@ export function App() {
     Map<string, PendingAction>
   >(new Map());
   const confirmDownReturnModeRef = useRef<Mode>(Mode.Navigate);
+  const confirmDownReturnSelectedIndexRef = useRef<number>(0);
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -512,7 +513,8 @@ export function App() {
   const expandedWorktreeKey =
     mode.type === "Expanded" ||
     mode.type === "ConfirmKill" ||
-    mode.type === "ConfirmDown"
+    (mode.type === "ConfirmDown" &&
+      confirmDownReturnModeRef.current.type === "Expanded")
       ? mode.worktreeKey
       : null;
 
@@ -1051,6 +1053,7 @@ export function App() {
     if (!hasSession) return;
 
     const worktreeKey = pendingKey(repo.project, wt.branch);
+    confirmDownReturnSelectedIndexRef.current = selectedIndex;
     confirmDownReturnModeRef.current =
       mode.type === "Expanded" ? Mode.Expanded(worktreeKey) : Mode.Navigate;
     setMode(Mode.ConfirmDown(sessionName, wt.branch, wt.path, worktreeKey));
@@ -1062,20 +1065,14 @@ export function App() {
     }
 
     if (key.escape) {
-      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
-      if (parentIndex !== null) {
-        setSelectedIndex(parentIndex);
-      }
+      setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
       setMode(confirmDownReturnModeRef.current);
       return;
     }
 
     if (key.return) {
       const { branch, worktreeKey, worktreePath } = mode;
-      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
-      if (parentIndex !== null) {
-        setSelectedIndex(parentIndex);
-      }
+      setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
       setMode(confirmDownReturnModeRef.current);
 
       const project = worktreeKey.split("/")[0] ?? "unknown";

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1033,7 +1033,10 @@ export function App() {
   }
 
   function handleDownSelectedWorktree() {
-    const worktreeIndex = resolveSelectedWorktreeIndex(treeItems, selectedIndex);
+    const worktreeIndex = resolveSelectedWorktreeIndex(
+      treeItems,
+      selectedIndex,
+    );
     if (worktreeIndex === null) return;
 
     const item = treeItems[worktreeIndex];
@@ -1050,7 +1053,7 @@ export function App() {
     const worktreeKey = pendingKey(repo.project, wt.branch);
     confirmDownReturnModeRef.current =
       mode.type === "Expanded" ? Mode.Expanded(worktreeKey) : Mode.Navigate;
-    setMode(Mode.ConfirmDown(sessionName, wt.branch, worktreeKey));
+    setMode(Mode.ConfirmDown(sessionName, wt.branch, wt.path, worktreeKey));
   }
 
   function handleConfirmDownInput(_input: string, key: Key) {
@@ -1068,7 +1071,7 @@ export function App() {
     }
 
     if (key.return) {
-      const { sessionName, branch, worktreeKey } = mode;
+      const { branch, worktreeKey, worktreePath } = mode;
       const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
       if (parentIndex !== null) {
         setSelectedIndex(parentIndex);
@@ -1084,16 +1087,7 @@ export function App() {
         }),
       );
 
-      const worktreeIndex = resolveSelectedWorktreeIndex(treeItems, selectedIndex);
-      const item = worktreeIndex !== null ? treeItems[worktreeIndex] : null;
-      const repo =
-        item && item.type === "worktree" ? filteredRepos[item.repoIndex] : null;
-      const wt =
-        item && item.type === "worktree" && repo
-          ? repo.worktrees[item.worktreeIndex]
-          : null;
-
-      const proc = Bun.spawn(["wct", "down", "--path", wt?.path ?? sessionName], {
+      const proc = Bun.spawn(["wct", "down", "--path", worktreePath], {
         stdout: "ignore",
         stderr: "ignore",
       });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -478,6 +478,8 @@ export function App() {
   >(new Map());
   const confirmDownReturnModeRef = useRef<Mode>(Mode.Navigate);
   const confirmDownReturnSelectedIndexRef = useRef<number>(0);
+  const upModalReturnModeRef = useRef<Mode>(Mode.Navigate);
+  const upModalReturnSelectedIndexRef = useRef<number>(0);
 
   // Auto-expand all repos on first load
   useEffect(() => {
@@ -514,7 +516,8 @@ export function App() {
   const expandedWorktreeKey =
     mode.type === "Expanded" ||
     mode.type === "ConfirmKill" ||
-    mode.type === "UpModal" ||
+    (mode.type === "UpModal" &&
+      upModalReturnModeRef.current.type === "Expanded") ||
     (mode.type === "ConfirmDown" &&
       confirmDownReturnModeRef.current.type === "Expanded")
       ? mode.worktreeKey
@@ -706,6 +709,9 @@ export function App() {
     if (!repo || !wt) return;
 
     const worktreeKey = pendingKey(repo.project, wt.branch);
+    upModalReturnSelectedIndexRef.current = selectedIndex;
+    upModalReturnModeRef.current =
+      mode.type === "Expanded" ? Mode.Expanded(worktreeKey) : Mode.Navigate;
     setMode(Mode.UpModal(wt.path, worktreeKey, repo.profileNames));
   }
 
@@ -713,7 +719,8 @@ export function App() {
     if (mode.type !== "UpModal") return;
 
     const { worktreePath, worktreeKey } = mode;
-    setMode(Mode.Navigate);
+    setSelectedIndex(upModalReturnSelectedIndexRef.current);
+    setMode(upModalReturnModeRef.current);
 
     const branch = worktreeKey.split("/").slice(1).join("/");
     const project = worktreeKey.split("/")[0] ?? "unknown";
@@ -735,9 +742,9 @@ export function App() {
     });
     proc.exited.then(async (code) => {
       if (code === 0 && result.autoSwitch) {
-        await refreshSessions();
         const sessionName = formatSessionName(basename(worktreePath));
         switchSession(sessionName);
+        await refreshSessions();
       } else {
         await refreshAll();
       }
@@ -1258,7 +1265,10 @@ export function App() {
           width={Math.min(termCols, 60)}
           profileNames={mode.profileNames}
           onSubmit={handleUpSubmit}
-          onCancel={() => setMode(Mode.Navigate)}
+          onCancel={() => {
+            setSelectedIndex(upModalReturnSelectedIndexRef.current);
+            setMode(upModalReturnModeRef.current);
+          }}
         />
       ) : (
         <StatusBar {...statusBarProps} searchQuery={searchQuery} />

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -8,14 +8,14 @@ interface Props {
 }
 
 export function DetailRow({ item, isSelected }: Props) {
-  const { detailKind, label, meta } = item;
+  const { detailKind, label } = item;
   const prefix = isSelected ? "▸ " : "  ";
   const indent =
     detailKind === "pr" || detailKind === "pane-header"
       ? "      " // section header: 6 spaces
       : "        "; // section item: 8 spaces
 
-  switch (detailKind) {
+  switch (item.detailKind) {
     case "pane-header":
       return (
         <Box>
@@ -43,8 +43,8 @@ export function DetailRow({ item, isSelected }: Props) {
       );
 
     case "check": {
-      const icon = checkIcon(meta?.state ?? "");
-      const color = checkColor(meta?.state ?? "");
+      const icon = checkIcon(item.meta?.state ?? "");
+      const color = checkColor(item.meta?.state ?? "");
       return (
         <Box>
           <Text>{indent}</Text>
@@ -66,7 +66,7 @@ export function DetailRow({ item, isSelected }: Props) {
           <Text>{indent}</Text>
           <Text color={isSelected ? "cyan" : "dim"} bold={isSelected}>
             {prefix}
-            {meta?.zoomed && meta?.active ? "🔍 " : ""}
+            {item.meta?.zoomed && item.meta?.active ? "🔍 " : ""}
             {label}
           </Text>
         </Box>

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -5,6 +5,7 @@ import { useBlink } from "../hooks/useBlink";
 import { tuiRuntime } from "../runtime";
 import type { PRInfo } from "../types";
 import { Modal } from "./Modal";
+import { SubmitButton, ToggleRow } from "./form-controls";
 import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
 import { TitledBox } from "./TitledBox";
 
@@ -149,54 +150,6 @@ function PromptArea({
         {isFocused ? (cursorVisible ? "▎" : " ") : ""}
       </Text>
     </TitledBox>
-  );
-}
-
-function ToggleRow({
-  label,
-  checked,
-  isFocused,
-  onToggle,
-}: {
-  label: string;
-  checked: boolean;
-  isFocused: boolean;
-  onToggle: () => void;
-}) {
-  useInput(
-    (input) => {
-      if (input === " ") onToggle();
-    },
-    { isActive: isFocused },
-  );
-
-  return (
-    <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
-      {checked ? "[x]" : "[ ]"} {label}
-    </Text>
-  );
-}
-
-function SubmitButton({
-  isFocused,
-  onSubmit,
-}: {
-  isFocused: boolean;
-  onSubmit: () => void;
-}) {
-  useInput(
-    (input, key) => {
-      if (key.return || input === " ") onSubmit();
-    },
-    { isActive: isFocused },
-  );
-
-  return (
-    <Box marginTop={1}>
-      <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
-        {isFocused ? "▸ " : "  "}Submit
-      </Text>
-    </Box>
   );
 }
 

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -4,8 +4,8 @@ import { WorktreeService } from "../../services/worktree-service";
 import { useBlink } from "../hooks/useBlink";
 import { tuiRuntime } from "../runtime";
 import type { PRInfo } from "../types";
-import { Modal } from "./Modal";
 import { SubmitButton, ToggleRow } from "./form-controls";
+import { Modal } from "./Modal";
 import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
 import { TitledBox } from "./TitledBox";
 

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -34,6 +34,8 @@ function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
       return [`Kill pane ${mode.label}?`, "enter:confirm  esc:cancel"];
     case "ConfirmDown":
       return [`Kill session for ${mode.branch}?`, "enter:confirm  esc:cancel"];
+    case "UpModal":
+      return ["", ""];
   }
 }
 

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -33,10 +33,7 @@ function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
     case "ConfirmKill":
       return [`Kill pane ${mode.label}?`, "enter:confirm  esc:cancel"];
     case "ConfirmDown":
-      return [
-        `Kill session for ${mode.branch}?`,
-        "enter:confirm  esc:cancel",
-      ];
+      return [`Kill session for ${mode.branch}?`, "enter:confirm  esc:cancel"];
   }
 }
 

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -13,7 +13,7 @@ function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
     case "Navigate":
       return [
         "↑↓:navigate  ←→:expand/collapse  space:switch  o:open",
-        "c:close  /:search  q:quit",
+        "u:up  d:down  c:close  /:search  q:quit",
       ];
     case "Search":
       return ["type to filter", "esc:cancel  enter:done"];
@@ -27,11 +27,16 @@ function getHints(mode: Mode, selectedPaneRow?: boolean): [string, string] {
         ];
       }
       return [
-        "↑↓:navigate  ←:collapse  space:action  o:open  c:close",
-        "/:search  q:quit",
+        "↑↓:navigate  ←:collapse  space:action  o:open",
+        "u:up  d:down  c:close  /:search  q:quit",
       ];
     case "ConfirmKill":
       return [`Kill pane ${mode.label}?`, "enter:confirm  esc:cancel"];
+    case "ConfirmDown":
+      return [
+        `Kill session for ${mode.branch}?`,
+        "enter:confirm  esc:cancel",
+      ];
   }
 }
 
@@ -40,7 +45,7 @@ export function StatusBar({ mode, searchQuery, selectedPaneRow }: Props) {
   const cols = stdout?.columns ?? 50;
   const divider = "─".repeat(Math.max(1, cols));
 
-  if (mode.type === "ConfirmKill") {
+  if (mode.type === "ConfirmKill" || mode.type === "ConfirmDown") {
     const [line1, line2] = getHints(mode, selectedPaneRow);
     return (
       <Box flexDirection="column">

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -178,7 +178,7 @@ export function UpModal({
         />
         <SubmitButton isFocused={currentField === "submit"} onSubmit={submit} />
         <Box height={1} />
-        <Text dimColor>tab:next  shift+tab:prev  esc:cancel</Text>
+        <Text dimColor>{"tab:next  shift+tab:prev  esc:cancel"}</Text>
       </Box>
     </Modal>
   );

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -21,6 +21,31 @@ export interface UpModalProps {
 
 type UpModalField = "profile" | "noIde" | "autoSwitch" | "submit";
 
+export interface UpModalSubmission {
+  canSubmit: boolean;
+  profile?: string;
+}
+
+export function resolveUpModalSubmission(
+  profileNames: string[],
+  filteredProfiles: ListItem[],
+  selectedProfileIndex: number,
+): UpModalSubmission {
+  if (profileNames.length === 0) {
+    return { canSubmit: true };
+  }
+
+  const selectedProfile = filteredProfiles[selectedProfileIndex];
+  if (!selectedProfile) {
+    return { canSubmit: false };
+  }
+
+  return {
+    canSubmit: true,
+    profile: selectedProfile.value || undefined,
+  };
+}
+
 export function UpModal({
   visible,
   width,
@@ -60,6 +85,15 @@ export function UpModal({
     return nextFields;
   }, [profileNames.length]);
   const currentField = fields[focusIndex];
+  const submission = useMemo(
+    () =>
+      resolveUpModalSubmission(
+        profileNames,
+        filteredProfiles,
+        selectedProfileIndex,
+      ),
+    [profileNames, filteredProfiles, selectedProfileIndex],
+  );
 
   useEffect(() => {
     if (!visible) {
@@ -87,12 +121,12 @@ export function UpModal({
   };
 
   const submit = () => {
-    const selectedProfile =
-      profileNames.length > 0
-        ? filteredProfiles[selectedProfileIndex]?.value
-        : undefined;
+    if (!submission.canSubmit) {
+      return;
+    }
+
     onSubmit({
-      profile: selectedProfile || undefined,
+      profile: submission.profile,
       noIde,
       autoSwitch,
     });
@@ -176,7 +210,11 @@ export function UpModal({
           isFocused={currentField === "autoSwitch"}
           onToggle={() => setAutoSwitch((prev) => !prev)}
         />
-        <SubmitButton isFocused={currentField === "submit"} onSubmit={submit} />
+        <SubmitButton
+          isFocused={currentField === "submit"}
+          disabled={!submission.canSubmit}
+          onSubmit={submit}
+        />
         <Box height={1} />
         <Text dimColor>{"tab:next  shift+tab:prev  esc:cancel"}</Text>
       </Box>

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -35,11 +35,16 @@ export function UpModal({
   const [autoSwitch, setAutoSwitch] = useState(true);
 
   const profileItems = useMemo<ListItem[]>(
-    () =>
-      profileNames.map((profileName) => ({
+    () => [
+      {
+        label: "(default)",
+        value: "",
+      },
+      ...profileNames.map((profileName) => ({
         label: profileName,
         value: profileName,
       })),
+    ],
     [profileNames],
   );
   const filteredProfiles = useMemo(
@@ -57,12 +62,16 @@ export function UpModal({
   const currentField = fields[focusIndex];
 
   useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
     setProfileQuery("");
     setSelectedProfileIndex(0);
     setFocusIndex(0);
     setNoIde(false);
     setAutoSwitch(true);
-  }, [visible, profileNames.join("\0")]);
+  }, [visible]);
 
   useEffect(() => {
     setSelectedProfileIndex((prev) => {
@@ -83,7 +92,7 @@ export function UpModal({
         ? filteredProfiles[selectedProfileIndex]?.value
         : undefined;
     onSubmit({
-      profile: selectedProfile,
+      profile: selectedProfile || undefined,
       noIde,
       autoSwitch,
     });
@@ -168,6 +177,8 @@ export function UpModal({
           onToggle={() => setAutoSwitch((prev) => !prev)}
         />
         <SubmitButton isFocused={currentField === "submit"} onSubmit={submit} />
+        <Box height={1} />
+        <Text dimColor>tab:next  shift+tab:prev  esc:cancel</Text>
       </Box>
     </Modal>
   );

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -1,0 +1,174 @@
+import { Box, Text, useInput } from "ink";
+import { useEffect, useMemo, useState } from "react";
+import { SubmitButton, ToggleRow } from "./form-controls";
+import { Modal } from "./Modal";
+import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
+import { TitledBox } from "./TitledBox";
+
+export interface UpModalResult {
+  profile?: string;
+  noIde: boolean;
+  autoSwitch: boolean;
+}
+
+export interface UpModalProps {
+  visible: boolean;
+  width?: number;
+  profileNames: string[];
+  onSubmit: (result: UpModalResult) => void;
+  onCancel: () => void;
+}
+
+type UpModalField = "profile" | "noIde" | "autoSwitch" | "submit";
+
+export function UpModal({
+  visible,
+  width,
+  profileNames,
+  onSubmit,
+  onCancel,
+}: UpModalProps) {
+  const [profileQuery, setProfileQuery] = useState("");
+  const [selectedProfileIndex, setSelectedProfileIndex] = useState(0);
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [noIde, setNoIde] = useState(false);
+  const [autoSwitch, setAutoSwitch] = useState(true);
+
+  const profileItems = useMemo<ListItem[]>(
+    () =>
+      profileNames.map((profileName) => ({
+        label: profileName,
+        value: profileName,
+      })),
+    [profileNames],
+  );
+  const filteredProfiles = useMemo(
+    () => filterItems(profileItems, profileQuery),
+    [profileItems, profileQuery],
+  );
+  const fields = useMemo<UpModalField[]>(() => {
+    const nextFields: UpModalField[] = [];
+    if (profileNames.length > 0) {
+      nextFields.push("profile");
+    }
+    nextFields.push("noIde", "autoSwitch", "submit");
+    return nextFields;
+  }, [profileNames.length]);
+  const currentField = fields[focusIndex];
+
+  useEffect(() => {
+    setProfileQuery("");
+    setSelectedProfileIndex(0);
+    setFocusIndex(0);
+    setNoIde(false);
+    setAutoSwitch(true);
+  }, [visible, profileNames.join("\0")]);
+
+  useEffect(() => {
+    setSelectedProfileIndex((prev) => {
+      if (filteredProfiles.length === 0) {
+        return 0;
+      }
+      return Math.min(prev, filteredProfiles.length - 1);
+    });
+  }, [filteredProfiles.length]);
+
+  const moveFocus = (delta: number) => {
+    setFocusIndex((prev) => (prev + delta + fields.length) % fields.length);
+  };
+
+  const submit = () => {
+    const selectedProfile =
+      profileNames.length > 0
+        ? filteredProfiles[selectedProfileIndex]?.value
+        : undefined;
+    onSubmit({
+      profile: selectedProfile,
+      noIde,
+      autoSwitch,
+    });
+  };
+
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        onCancel();
+        return;
+      }
+
+      if (key.tab) {
+        moveFocus(key.shift ? -1 : 1);
+        return;
+      }
+
+      if (currentField !== "profile") {
+        return;
+      }
+
+      if (key.upArrow) {
+        setSelectedProfileIndex((prev) => Math.max(0, prev - 1));
+        return;
+      }
+
+      if (key.downArrow) {
+        if (filteredProfiles.length === 0) {
+          return;
+        }
+        setSelectedProfileIndex((prev) =>
+          Math.min(filteredProfiles.length - 1, prev + 1),
+        );
+        return;
+      }
+
+      if (key.backspace || key.delete) {
+        setProfileQuery((prev) => prev.slice(0, -1));
+        return;
+      }
+
+      if (input && !key.ctrl && !key.meta && !key.return) {
+        setProfileQuery((prev) => prev + input);
+      }
+    },
+    { isActive: visible },
+  );
+
+  return (
+    <Modal title="wct up" visible={visible} width={width}>
+      <Box flexDirection="column">
+        <Text dimColor>Start worktree session</Text>
+        <Box height={1} />
+        {profileNames.length > 0 ? (
+          <TitledBox
+            title={profileQuery ? `Profile filter: ${profileQuery}` : "Profile"}
+            isFocused={currentField === "profile"}
+            width={width ? width - 2 : undefined}
+          >
+            <ScrollableList
+              items={profileItems}
+              selectedIndex={selectedProfileIndex}
+              filterQuery={profileQuery}
+              isFocused={currentField === "profile"}
+              maxVisible={6}
+            />
+          </TitledBox>
+        ) : (
+          <Text dimColor>No profiles configured</Text>
+        )}
+        <Box height={1} />
+        <ToggleRow
+          label="No IDE"
+          checked={noIde}
+          isFocused={currentField === "noIde"}
+          onToggle={() => setNoIde((prev) => !prev)}
+        />
+        <ToggleRow
+          label="Auto-switch"
+          checked={autoSwitch}
+          isFocused={currentField === "autoSwitch"}
+          onToggle={() => setAutoSwitch((prev) => !prev)}
+        />
+        <SubmitButton isFocused={currentField === "submit"} onSubmit={submit} />
+      </Box>
+    </Modal>
+  );
+}

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -8,7 +8,7 @@ interface Props {
   changedFiles: number;
   isSelected: boolean;
   isChildSelected?: boolean;
-  pendingStatus?: "opening" | "closing" | "starting";
+  pendingStatus?: "opening" | "closing" | "starting" | "stopping";
   isExpanded?: boolean;
   hasExpandableData?: boolean;
   maxWidth: number;
@@ -62,6 +62,13 @@ export function WorktreeItem({
       prefix.length + `${indicator} `.length + " closing...".length,
     ),
   );
+  const stoppingDisplayBranch = truncateBranch(
+    branch,
+    branchBudget(
+      maxWidth,
+      prefix.length + `${indicator} `.length + " stopping...".length,
+    ),
+  );
   const mainSuffix =
     attached + (pendingStatus === "starting" ? " starting..." : "");
   const mainDisplayBranch = truncateBranch(
@@ -97,6 +104,17 @@ export function WorktreeItem({
         <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
         <Text dimColor>
           {indicator} {closingDisplayBranch} closing...
+        </Text>
+      </Box>
+    );
+  }
+
+  if (pendingStatus === "stopping") {
+    return (
+      <Box>
+        <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+        <Text dimColor>
+          {indicator} {stoppingDisplayBranch} stopping...
         </Text>
       </Box>
     );

--- a/src/tui/components/form-controls.tsx
+++ b/src/tui/components/form-controls.tsx
@@ -27,21 +27,23 @@ export function ToggleRow({
 
 export function SubmitButton({
   isFocused,
+  disabled = false,
   onSubmit,
 }: {
   isFocused: boolean;
+  disabled?: boolean;
   onSubmit: () => void;
 }) {
   useInput(
     (input, key) => {
       if (key.return || input === " ") onSubmit();
     },
-    { isActive: isFocused },
+    { isActive: isFocused && !disabled },
   );
 
   return (
     <Box marginTop={1}>
-      <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
+      <Text color={!disabled && isFocused ? "cyan" : "dim"} bold={isFocused}>
         {isFocused ? "▸ " : "  "}Submit
       </Text>
     </Box>

--- a/src/tui/components/form-controls.tsx
+++ b/src/tui/components/form-controls.tsx
@@ -1,0 +1,49 @@
+import { Box, Text, useInput } from "ink";
+
+export function ToggleRow({
+  label,
+  checked,
+  isFocused,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  isFocused: boolean;
+  onToggle: () => void;
+}) {
+  useInput(
+    (input) => {
+      if (input === " ") onToggle();
+    },
+    { isActive: isFocused },
+  );
+
+  return (
+    <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
+      {checked ? "[x]" : "[ ]"} {label}
+    </Text>
+  );
+}
+
+export function SubmitButton({
+  isFocused,
+  onSubmit,
+}: {
+  isFocused: boolean;
+  onSubmit: () => void;
+}) {
+  useInput(
+    (input, key) => {
+      if (key.return || input === " ") onSubmit();
+    },
+    { isActive: isFocused },
+  );
+
+  return (
+    <Box marginTop={1}>
+      <Text color={isFocused ? "cyan" : "dim"} bold={isFocused}>
+        {isFocused ? "▸ " : "  "}Submit
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/hooks/useTmux.ts
+++ b/src/tui/hooks/useTmux.ts
@@ -13,6 +13,12 @@ export interface TmuxSessionInfo {
   attached: boolean;
 }
 
+export type TmuxClientDiscovery =
+  | { type: "none" }
+  | { type: "single"; client: TmuxClient }
+  | { type: "multiple" }
+  | { type: "error" };
+
 async function runPaneAction(
   effect: Parameters<typeof tuiRuntime.runPromise>[0],
 ) {
@@ -63,7 +69,7 @@ export function useTmux() {
         if (!result) {
           setSessions([]);
           setPanes(EMPTY_PANES);
-          return;
+          return [];
         }
         const parsed = result.map((session) => ({
           name: session.name,
@@ -71,9 +77,11 @@ export function useTmux() {
         }));
         setSessions(parsed);
         await refreshPanes(parsed, signal);
+        return parsed;
       } catch {
         setSessions([]);
         setPanes(EMPTY_PANES);
+        return [];
       }
     },
     [refreshPanes],
@@ -90,31 +98,41 @@ export function useTmux() {
       if (clients.length === 0) {
         setError("No tmux client found — start tmux in the other pane");
         setClient(null);
-      } else if (clients.length === 1) {
-        const [onlyClient] = clients;
-        setClient(onlyClient ?? null);
-        setError(null);
-      } else {
-        setError(
-          `Multiple tmux clients found (${clients.length}). Multi-client support coming soon.`,
-        );
-        setClient(null);
+        return { type: "none" } as const;
       }
+
+      if (clients.length === 1) {
+        const [onlyClient] = clients;
+        const client = onlyClient ?? null;
+        setClient(client);
+        setError(null);
+        return client
+          ? ({ type: "single", client } as const)
+          : ({ type: "none" } as const);
+      }
+
+      setError(
+        `Multiple tmux clients found (${clients.length}). Multi-client support coming soon.`,
+      );
+      setClient(null);
+      return { type: "multiple" } as const;
     } catch {
       setError("No tmux client found — start tmux in the other pane");
       setClient(null);
+      return { type: "error" } as const;
     }
   }, []);
 
   const switchSession = useCallback(
-    async (sessionName: string) => {
-      if (!client) return false;
+    async (sessionName: string, activeClient: TmuxClient | null = client) => {
+      if (!activeClient) return false;
       try {
         await tuiRuntime.runPromise(
           TmuxService.use((service) =>
-            service.switchClientToPane(client.tty, `=${sessionName}`),
+            service.switchClientToPane(activeClient.tty, `=${sessionName}`),
           ),
         );
+        setClient({ ...activeClient, session: sessionName });
         return true;
       } catch {
         return false;
@@ -132,12 +150,13 @@ export function useTmux() {
             service.switchClientToPane(client.tty, paneId),
           ),
         );
+        await discoverClient();
         return true;
       } catch {
         return false;
       }
     },
-    [client],
+    [client, discoverClient],
   );
 
   const zoomPane = useCallback(

--- a/src/tui/hooks/useTmux.ts
+++ b/src/tui/hooks/useTmux.ts
@@ -111,9 +111,6 @@ export function useTmux() {
           : ({ type: "none" } as const);
       }
 
-      setError(
-        `Multiple tmux clients found (${clients.length}). Multi-client support coming soon.`,
-      );
       setClient(null);
       return { type: "multiple" } as const;
     } catch {

--- a/src/tui/runtime.ts
+++ b/src/tui/runtime.ts
@@ -1,6 +1,7 @@
 import { BunServices } from "@effect/platform-bun";
 import { Layer, ManagedRuntime } from "effect";
 import { GitHubService, liveGitHubService } from "../services/github-service";
+import { IdeService, liveIdeService } from "../services/ide-service";
 import {
   liveRegistryService,
   RegistryService,
@@ -15,6 +16,7 @@ const tuiLayer = Layer.mergeAll(
   Layer.succeed(TmuxService, liveTmuxService),
   Layer.succeed(WorktreeService, liveWorktreeService),
   Layer.succeed(GitHubService, liveGitHubService),
+  Layer.succeed(IdeService, liveIdeService),
   Layer.succeed(RegistryService, liveRegistryService),
   BunServices.layer,
 );

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -7,6 +7,12 @@ export type Mode =
   | { type: "Navigate" }
   | { type: "Search" }
   | { type: "OpenModal" }
+  | {
+      type: "UpModal";
+      worktreePath: string;
+      worktreeKey: string;
+      profileNames: string[];
+    }
   | { type: "Expanded"; worktreeKey: string }
   | {
       type: "ConfirmKill";
@@ -26,6 +32,16 @@ export const Mode = {
   Navigate: { type: "Navigate" } as Mode,
   Search: { type: "Search" } as Mode,
   OpenModal: { type: "OpenModal" } as Mode,
+  UpModal: (
+    worktreePath: string,
+    worktreeKey: string,
+    profileNames: string[],
+  ): Mode => ({
+    type: "UpModal",
+    worktreePath,
+    worktreeKey,
+    profileNames,
+  }),
   Expanded: (worktreeKey: string): Mode => ({
     type: "Expanded",
     worktreeKey,

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -13,6 +13,12 @@ export type Mode =
       paneId: string;
       label: string;
       worktreeKey: string;
+    }
+  | {
+      type: "ConfirmDown";
+      sessionName: string;
+      branch: string;
+      worktreeKey: string;
     };
 
 export const Mode = {
@@ -27,6 +33,16 @@ export const Mode = {
     type: "ConfirmKill",
     paneId,
     label,
+    worktreeKey,
+  }),
+  ConfirmDown: (
+    sessionName: string,
+    branch: string,
+    worktreeKey: string,
+  ): Mode => ({
+    type: "ConfirmDown",
+    sessionName,
+    branch,
     worktreeKey,
   }),
 };
@@ -65,7 +81,7 @@ type DetailItem<
 
 /** Pending action for optimistic UI */
 export interface PendingAction {
-  type: "opening" | "closing" | "starting";
+  type: "opening" | "closing" | "starting" | "stopping";
   branch: string;
   project: string;
 }

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -18,6 +18,7 @@ export type Mode =
       type: "ConfirmDown";
       sessionName: string;
       branch: string;
+      worktreePath: string;
       worktreeKey: string;
     };
 
@@ -38,11 +39,13 @@ export const Mode = {
   ConfirmDown: (
     sessionName: string,
     branch: string,
+    worktreePath: string,
     worktreeKey: string,
   ): Mode => ({
     type: "ConfirmDown",
     sessionName,
     branch,
+    worktreePath,
     worktreeKey,
   }),
 };

--- a/tests/down.test.ts
+++ b/tests/down.test.ts
@@ -8,7 +8,7 @@ import {
   test,
   vi,
 } from "vitest";
-import { downCommand } from "../src/commands/down";
+import { downCommand, type DownOptions } from "../src/commands/down";
 import { runBunPromise } from "../src/effect/runtime";
 import { commandError } from "../src/errors";
 import {
@@ -23,9 +23,10 @@ import {
 import { withTestServices } from "./helpers/services";
 
 async function runCommand(
+  options?: DownOptions,
   overrides: { tmux?: TmuxService; worktree?: WorktreeService } = {},
 ) {
-  await runBunPromise(withTestServices(downCommand(), overrides));
+  await runBunPromise(withTestServices(downCommand(options), overrides));
 }
 
 describe("downCommand", () => {
@@ -54,10 +55,11 @@ describe("downCommand behavior", () => {
   beforeEach(() => {
     cwdSpy = vi
       .spyOn(process, "cwd")
-      .mockReturnValue("/tmp/myapp-feature-auth");
+      .mockReturnValue("/tmp/outside-git-repo");
     worktreeOverrides = {
       ...liveWorktreeService,
       isGitRepo: () => Effect.succeed(true),
+      findWorktreeByBranch: () => Effect.succeed(null),
     };
     tmuxOverrides = {
       ...liveTmuxService,
@@ -72,6 +74,7 @@ describe("downCommand behavior", () => {
 
   test("kills tmux session derived from cwd basename", async () => {
     const killCalls: string[] = [];
+    let isGitRepoArg: string | undefined;
     tmuxOverrides = {
       ...tmuxOverrides,
       killSession: (name: string) =>
@@ -79,11 +82,92 @@ describe("downCommand behavior", () => {
           killCalls.push(name);
         }),
     };
+    worktreeOverrides = {
+      ...worktreeOverrides,
+      isGitRepo: (cwd?: string) =>
+        Effect.sync(() => {
+          isGitRepoArg = cwd;
+          return true;
+        }),
+    };
+    cwdSpy.mockReturnValue("/tmp/myapp-feature-auth");
 
     await expect(
-      runCommand({ tmux: tmuxOverrides, worktree: worktreeOverrides }),
+      runCommand(undefined, { tmux: tmuxOverrides, worktree: worktreeOverrides }),
     ).resolves.toBeUndefined();
+    expect(isGitRepoArg).toBe("/tmp/myapp-feature-auth");
     expect(killCalls).toEqual(["myapp-feature-auth"]);
+  });
+
+  test("kills tmux session for worktree specified by --path", async () => {
+    const killCalls: string[] = [];
+    let isGitRepoArg: string | undefined;
+    cwdSpy.mockReturnValue("/tmp/outside-git-repo");
+    const pathOverrides: TmuxService = {
+      ...liveTmuxService,
+      sessionExists: () => Effect.succeed(true),
+      killSession: (name: string) =>
+        Effect.sync(() => {
+          killCalls.push(name);
+        }),
+    };
+    const worktreePathOverrides: WorktreeService = {
+      ...liveWorktreeService,
+      isGitRepo: (cwd?: string) =>
+        Effect.sync(() => {
+          isGitRepoArg = cwd;
+          return true;
+        }),
+    };
+
+    await runCommand(
+      { path: "/tmp/myproject-feature-x" },
+      { tmux: pathOverrides, worktree: worktreePathOverrides },
+    );
+
+    expect(isGitRepoArg).toBe("/tmp/myproject-feature-x");
+    expect(killCalls).toEqual(["myproject-feature-x"]);
+  });
+
+  test("kills tmux session for worktree resolved by --branch", async () => {
+    const killCalls: string[] = [];
+    let isGitRepoArg: string | undefined;
+    cwdSpy.mockReturnValue("/tmp/outside-git-repo");
+    const tmuxOverridesByBranch: TmuxService = {
+      ...liveTmuxService,
+      sessionExists: () => Effect.succeed(true),
+      killSession: (name: string) =>
+        Effect.sync(() => {
+          killCalls.push(name);
+        }),
+    };
+    const worktreeOverridesByBranch: WorktreeService = {
+      ...liveWorktreeService,
+      isGitRepo: (cwd?: string) =>
+        Effect.sync(() => {
+          isGitRepoArg = cwd;
+          return true;
+        }),
+      findWorktreeByBranch: (branch: string) =>
+        Effect.succeed(
+          branch === "feat-y"
+            ? {
+                path: "/tmp/myproject-feat-y",
+                branch: "feat-y",
+                commit: "abc123",
+                isBare: false,
+              }
+            : null,
+        ),
+    };
+
+    await runCommand(
+      { branch: "feat-y" },
+      { tmux: tmuxOverridesByBranch, worktree: worktreeOverridesByBranch },
+    );
+
+    expect(isGitRepoArg).toBe("/tmp/myproject-feat-y");
+    expect(killCalls).toEqual(["myproject-feat-y"]);
   });
 
   test("propagates tmux kill failures", async () => {
@@ -93,7 +177,7 @@ describe("downCommand behavior", () => {
     };
 
     await expect(
-      runCommand({
+      runCommand(undefined, {
         tmux: tmuxOverrides,
         worktree: worktreeOverrides,
       }),

--- a/tests/down.test.ts
+++ b/tests/down.test.ts
@@ -8,7 +8,9 @@ import {
   test,
   vi,
 } from "vitest";
-import { downCommand, type DownOptions } from "../src/commands/down";
+import { type DownOptions, downCommand } from "../src/commands/down";
+import { rootCommand } from "../src/cli/root-command";
+import { Command } from "../src/effect/cli";
 import { runBunPromise } from "../src/effect/runtime";
 import { commandError } from "../src/errors";
 import {
@@ -27,6 +29,18 @@ async function runCommand(
   overrides: { tmux?: TmuxService; worktree?: WorktreeService } = {},
 ) {
   await runBunPromise(withTestServices(downCommand(options), overrides));
+}
+
+async function runRootCommand(
+  args: string[],
+  overrides: { tmux?: TmuxService; worktree?: WorktreeService } = {},
+) {
+  await runBunPromise(
+    withTestServices(
+      Command.runWith(rootCommand, { version: "1.0.0" })(args),
+      overrides,
+    ),
+  );
 }
 
 describe("downCommand", () => {
@@ -53,9 +67,7 @@ describe("downCommand behavior", () => {
   let worktreeOverrides: WorktreeService;
 
   beforeEach(() => {
-    cwdSpy = vi
-      .spyOn(process, "cwd")
-      .mockReturnValue("/tmp/outside-git-repo");
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/tmp/outside-git-repo");
     worktreeOverrides = {
       ...liveWorktreeService,
       isGitRepo: () => Effect.succeed(true),
@@ -93,7 +105,10 @@ describe("downCommand behavior", () => {
     cwdSpy.mockReturnValue("/tmp/myapp-feature-auth");
 
     await expect(
-      runCommand(undefined, { tmux: tmuxOverrides, worktree: worktreeOverrides }),
+      runCommand(undefined, {
+        tmux: tmuxOverrides,
+        worktree: worktreeOverrides,
+      }),
     ).resolves.toBeUndefined();
     expect(isGitRepoArg).toBe("/tmp/myapp-feature-auth");
     expect(killCalls).toEqual(["myapp-feature-auth"]);
@@ -123,6 +138,36 @@ describe("downCommand behavior", () => {
     await runCommand(
       { path: "/tmp/myproject-feature-x" },
       { tmux: pathOverrides, worktree: worktreePathOverrides },
+    );
+
+    expect(isGitRepoArg).toBe("/tmp/myproject-feature-x");
+    expect(killCalls).toEqual(["myproject-feature-x"]);
+  });
+
+  test("parses down --path through the root command", async () => {
+    const killCalls: string[] = [];
+    let isGitRepoArg: string | undefined;
+    cwdSpy.mockReturnValue("/tmp/outside-git-repo");
+    const tmuxOverridesViaRoot: TmuxService = {
+      ...liveTmuxService,
+      sessionExists: () => Effect.succeed(true),
+      killSession: (name: string) =>
+        Effect.sync(() => {
+          killCalls.push(name);
+        }),
+    };
+    const worktreeOverridesViaRoot: WorktreeService = {
+      ...liveWorktreeService,
+      isGitRepo: (cwd?: string) =>
+        Effect.sync(() => {
+          isGitRepoArg = cwd;
+          return true;
+        }),
+    };
+
+    await runRootCommand(
+      ["down", "--path", "/tmp/myproject-feature-x"],
+      { tmux: tmuxOverridesViaRoot, worktree: worktreeOverridesViaRoot },
     );
 
     expect(isGitRepoArg).toBe("/tmp/myproject-feature-x");

--- a/tests/down.test.ts
+++ b/tests/down.test.ts
@@ -8,8 +8,8 @@ import {
   test,
   vi,
 } from "vitest";
-import { type DownOptions, downCommand } from "../src/commands/down";
 import { rootCommand } from "../src/cli/root-command";
+import { type DownOptions, downCommand } from "../src/commands/down";
 import { Command } from "../src/effect/cli";
 import { runBunPromise } from "../src/effect/runtime";
 import { commandError } from "../src/errors";
@@ -165,10 +165,10 @@ describe("downCommand behavior", () => {
         }),
     };
 
-    await runRootCommand(
-      ["down", "--path", "/tmp/myproject-feature-x"],
-      { tmux: tmuxOverridesViaRoot, worktree: worktreeOverridesViaRoot },
-    );
+    await runRootCommand(["down", "--path", "/tmp/myproject-feature-x"], {
+      tmux: tmuxOverridesViaRoot,
+      worktree: worktreeOverridesViaRoot,
+    });
 
     expect(isGitRepoArg).toBe("/tmp/myproject-feature-x");
     expect(killCalls).toEqual(["myproject-feature-x"]);

--- a/tests/helpers/services.ts
+++ b/tests/helpers/services.ts
@@ -12,6 +12,11 @@ import {
   liveIdeService,
 } from "../../src/services/ide-service";
 import {
+  liveRegistryService,
+  RegistryService,
+  type RegistryServiceApi,
+} from "../../src/services/registry-service";
+import {
   liveSetupService,
   SetupService,
   type SetupService as SetupServiceApi,
@@ -32,13 +37,13 @@ import {
   type WorktreeService as WorktreeServiceApi,
 } from "../../src/services/worktree-service";
 
-type JsonFlagRequirement =
-  typeof JsonFlag extends Effect.Effect<unknown, unknown, infer R> ? R : never;
+type JsonFlagRequirement = "effect/unstable/cli/GlobalFlag/json";
 
 export interface ServiceOverrides {
   github?: GitHubServiceApi;
   ide?: IdeServiceApi;
   json?: boolean;
+  registry?: RegistryServiceApi;
   setup?: SetupServiceApi;
   tmux?: TmuxServiceApi;
   vscodeWorkspace?: VSCodeWorkspaceServiceApi;
@@ -80,6 +85,11 @@ export function withTestServices<A, E, R>(
     provided,
     WorktreeService,
     overrides.worktree ?? liveWorktreeService,
+  );
+  provided = Effect.provideService(
+    provided,
+    RegistryService,
+    overrides.registry ?? liveRegistryService,
   );
   provided = Effect.provideService(provided, JsonFlag, overrides.json ?? false);
 

--- a/tests/resolve-worktree-path.test.ts
+++ b/tests/resolve-worktree-path.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Effect } from "effect";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { resolveWorktreePath } from "../src/commands/resolve-worktree-path";
+import { runBunPromise } from "../src/effect/runtime";
+import {
+  liveWorktreeService,
+  WorktreeService,
+} from "../src/services/worktree-service";
+import { withTestServices } from "./helpers/services";
+
+function withWorktreeService<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return withTestServices(
+    Effect.provideService(effect, WorktreeService, liveWorktreeService),
+  );
+}
+
+async function runResolveWorktreePath(
+  options: Parameters<typeof resolveWorktreePath>[0],
+) {
+  return await runBunPromise(
+    withWorktreeService(resolveWorktreePath(options)),
+  );
+}
+
+async function createWorktreeFixture() {
+  const repoDir = await mkdtemp(join(tmpdir(), "wct-test-resolve-"));
+  const worktreeRoot = await mkdtemp(join(tmpdir(), "wct-test-resolve-wt-"));
+
+  await $`git init -b main`.quiet().cwd(repoDir);
+  await $`git config user.email "test@test.com"`.quiet().cwd(repoDir);
+  await $`git config user.name "Test"`.quiet().cwd(repoDir);
+  await $`git config commit.gpgSign false`.quiet().cwd(repoDir);
+  await $`git commit --allow-empty -m "initial"`.quiet().cwd(repoDir);
+
+  const worktreePath = join(worktreeRoot, "feature-branch");
+  await $`git worktree add -b feature-branch ${worktreePath}`
+    .quiet()
+    .cwd(repoDir);
+
+  return { repoDir, worktreeRoot, worktreePath };
+}
+
+describe("resolveWorktreePath", () => {
+  let repoDir: string;
+  let worktreeRoot: string;
+  let worktreePath: string;
+  const originalDir = process.cwd();
+
+  beforeAll(async () => {
+    const fixture = await createWorktreeFixture();
+    repoDir = fixture.repoDir;
+    worktreeRoot = fixture.worktreeRoot;
+    worktreePath = fixture.worktreePath;
+  });
+
+  afterAll(async () => {
+    process.chdir(originalDir);
+    await rm(repoDir, { recursive: true, force: true });
+    await rm(worktreeRoot, { recursive: true, force: true });
+  });
+
+  test("returns cwd when no options given", async () => {
+    process.chdir(repoDir);
+
+    await expect(runResolveWorktreePath({})).resolves.toBe(repoDir);
+  });
+
+  test("returns path directly when --path is given", async () => {
+    process.chdir(repoDir);
+    const explicitPath = join(worktreeRoot, "explicit-path");
+
+    await expect(runResolveWorktreePath({ path: explicitPath })).resolves.toBe(
+      explicitPath,
+    );
+  });
+
+  test("resolves path from branch name when --branch is given", async () => {
+    process.chdir(repoDir);
+
+    await expect(
+      runResolveWorktreePath({ branch: "feature-branch" }),
+    ).resolves.toBe(worktreePath);
+  });
+
+  test("errors when both --path and --branch are given", async () => {
+    process.chdir(repoDir);
+
+    await expect(
+      runResolveWorktreePath({
+        path: join(worktreeRoot, "explicit-path"),
+        branch: "feature-branch",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_options",
+      message: "--path and --branch are mutually exclusive",
+    });
+  });
+
+  test("errors when --branch does not match any worktree", async () => {
+    process.chdir(repoDir);
+
+    await expect(
+      runResolveWorktreePath({ branch: "missing-branch" }),
+    ).rejects.toMatchObject({
+      code: "worktree_not_found",
+      message: "No worktree found for branch 'missing-branch'",
+    });
+  });
+});

--- a/tests/resolve-worktree-path.test.ts
+++ b/tests/resolve-worktree-path.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { $ } from "bun";
@@ -21,14 +21,16 @@ function withWorktreeService<A, E, R>(effect: Effect.Effect<A, E, R>) {
 async function runResolveWorktreePath(
   options: Parameters<typeof resolveWorktreePath>[0],
 ) {
-  return await runBunPromise(
-    withWorktreeService(resolveWorktreePath(options)),
-  );
+  return await runBunPromise(withWorktreeService(resolveWorktreePath(options)));
 }
 
 async function createWorktreeFixture() {
-  const repoDir = await mkdtemp(join(tmpdir(), "wct-test-resolve-"));
-  const worktreeRoot = await mkdtemp(join(tmpdir(), "wct-test-resolve-wt-"));
+  const repoDir = await realpath(
+    await mkdtemp(join(tmpdir(), "wct-test-resolve-")),
+  );
+  const worktreeRoot = await realpath(
+    await mkdtemp(join(tmpdir(), "wct-test-resolve-wt-")),
+  );
 
   await $`git init -b main`.quiet().cwd(repoDir);
   await $`git config user.email "test@test.com"`.quiet().cwd(repoDir);
@@ -41,7 +43,11 @@ async function createWorktreeFixture() {
     .quiet()
     .cwd(repoDir);
 
-  return { repoDir, worktreeRoot, worktreePath };
+  return {
+    repoDir: await realpath(repoDir),
+    worktreeRoot: await realpath(worktreeRoot),
+    worktreePath: await realpath(worktreePath),
+  };
 }
 
 describe("resolveWorktreePath", () => {
@@ -66,7 +72,7 @@ describe("resolveWorktreePath", () => {
   test("returns cwd when no options given", async () => {
     process.chdir(repoDir);
 
-    await expect(runResolveWorktreePath({})).resolves.toBe(repoDir);
+    await expect(runResolveWorktreePath({})).resolves.toBe(process.cwd());
   });
 
   test("returns path directly when --path is given", async () => {

--- a/tests/tui/adjust-index.test.ts
+++ b/tests/tui/adjust-index.test.ts
@@ -5,6 +5,7 @@ import {
   resolveExpandedRightArrowAction,
   resolveRecoveredSelectionIndex,
   resolveSelectedWorktreeIndex,
+  resolveSessionHandoff,
   treeItemId,
 } from "../../src/tui/App";
 import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
@@ -401,5 +402,79 @@ describe("resolveExpandedRightArrowAction", () => {
       nextMode: Mode.Expanded(pendingKey("repo-a", "feature-b")),
       nextSelectedIndex: 2,
     });
+  });
+});
+
+describe("resolveSessionHandoff", () => {
+  test("returns a switch plan when the active client is on the target", () => {
+    expect(
+      resolveSessionHandoff({
+        client: {
+          type: "single",
+          client: { tty: "/dev/ttys001", session: "feature-a" },
+        },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }, { name: "main" }],
+      }),
+    ).toEqual({
+      type: "switch",
+      sessionName: "main",
+    });
+  });
+
+  test("returns a no-op plan when the active client is on a different session", () => {
+    expect(
+      resolveSessionHandoff({
+        client: {
+          type: "single",
+          client: { tty: "/dev/ttys001", session: "main" },
+        },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }, { name: "main" }],
+      }),
+    ).toEqual({ type: "not-needed" });
+  });
+
+  test("returns a no-op plan when there is no active client", () => {
+    expect(
+      resolveSessionHandoff({
+        client: { type: "none" },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }, { name: "main" }],
+      }),
+    ).toEqual({ type: "not-needed" });
+  });
+
+  test("returns a blocked plan when there is no alternate session to switch to", () => {
+    expect(
+      resolveSessionHandoff({
+        client: {
+          type: "single",
+          client: { tty: "/dev/ttys001", session: "feature-a" },
+        },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }],
+      }),
+    ).toEqual({ type: "blocked" });
+  });
+
+  test("returns a blocked plan when multiple tmux clients are attached", () => {
+    expect(
+      resolveSessionHandoff({
+        client: { type: "multiple" },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }, { name: "main" }],
+      }),
+    ).toEqual({ type: "blocked" });
+  });
+
+  test("returns a blocked plan when client discovery fails", () => {
+    expect(
+      resolveSessionHandoff({
+        client: { type: "error" },
+        targetSession: "feature-a",
+        sessions: [{ name: "feature-a" }, { name: "main" }],
+      }),
+    ).toEqual({ type: "blocked" });
   });
 });

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -139,9 +139,9 @@ describe("buildTreeItems", () => {
         [
           sessionName,
           [
-            { ...sessionPanes[0], paneId: "%9", zoomed: true, active: true },
+            { ...sessionPanes[0]!, paneId: "%9", zoomed: true, active: true },
             {
-              ...sessionPanes[1],
+              ...sessionPanes[1]!,
               command: "htop",
               window: "renamed-window",
               paneIndex: 4,
@@ -154,7 +154,7 @@ describe("buildTreeItems", () => {
 
     expect(resolved).toEqual({
       pane: {
-        ...sessionPanes[1],
+        ...sessionPanes[1]!,
         command: "htop",
         window: "renamed-window",
         paneIndex: 4,

--- a/tests/tui/build-tree-items.test.ts
+++ b/tests/tui/build-tree-items.test.ts
@@ -65,24 +65,23 @@ describe("buildTreeItems", () => {
     const repoPath = "/tmp/example-repo";
     const worktreePath = "/tmp/worktree-pane-actions";
     const sessionName = formatSessionName(basename(worktreePath));
-    const sessionPanes: PaneInfo[] = [
-      {
-        paneId: "%1",
-        paneIndex: 0,
-        command: "bun run dev",
-        window: "editor",
-        zoomed: false,
-        active: false,
-      },
-      {
-        paneId: "%2",
-        paneIndex: 1,
-        command: "git status",
-        window: "editor",
-        zoomed: true,
-        active: true,
-      },
-    ];
+    const pane0: PaneInfo = {
+      paneId: "%1",
+      paneIndex: 0,
+      command: "bun run dev",
+      window: "editor",
+      zoomed: false,
+      active: false,
+    };
+    const pane1: PaneInfo = {
+      paneId: "%2",
+      paneIndex: 1,
+      command: "git status",
+      window: "editor",
+      zoomed: true,
+      active: true,
+    };
+    const sessionPanes: PaneInfo[] = [pane0, pane1];
 
     const items = buildTreeItems({
       repos: [
@@ -139,9 +138,9 @@ describe("buildTreeItems", () => {
         [
           sessionName,
           [
-            { ...sessionPanes[0]!, paneId: "%9", zoomed: true, active: true },
+            { ...pane0, paneId: "%9", zoomed: true, active: true },
             {
-              ...sessionPanes[1]!,
+              ...pane1,
               command: "htop",
               window: "renamed-window",
               paneIndex: 4,
@@ -154,7 +153,7 @@ describe("buildTreeItems", () => {
 
     expect(resolved).toEqual({
       pane: {
-        ...sessionPanes[1]!,
+        ...pane1,
         command: "htop",
         window: "renamed-window",
         paneIndex: 4,

--- a/tests/tui/status-bar-wiring.test.ts
+++ b/tests/tui/status-bar-wiring.test.ts
@@ -75,6 +75,7 @@ describe("resolveStatusBarProps", () => {
     const confirmDown = Mode.ConfirmDown(
       "myapp-feature",
       "feature",
+      "/tmp/myapp-feature",
       "proj/feature",
     );
 

--- a/tests/tui/status-bar-wiring.test.ts
+++ b/tests/tui/status-bar-wiring.test.ts
@@ -70,4 +70,26 @@ describe("resolveStatusBarProps", () => {
       selectedPaneRow: true,
     });
   });
+
+  test("passes ConfirmDown mode through unchanged", () => {
+    const confirmDown = Mode.ConfirmDown(
+      "myapp-feature",
+      "feature",
+      "proj/feature",
+    );
+
+    expect(
+      resolveStatusBarProps({
+        mode: confirmDown,
+        items: [
+          { type: "repo", repoIndex: 0 },
+          { type: "worktree", repoIndex: 0, worktreeIndex: 0 },
+        ],
+        selectedIndex: 1,
+      }),
+    ).toEqual({
+      mode: confirmDown,
+      selectedPaneRow: false,
+    });
+  });
 });

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -69,7 +69,9 @@ describe("StatusBar", () => {
     expect(rendered.output).toContain(
       "↑↓:navigate  ←:collapse  space:action  o:open",
     );
-    expect(rendered.output).toContain("u:up  d:down  c:close  /:search  q:quit");
+    expect(rendered.output).toContain(
+      "u:up  d:down  c:close  /:search  q:quit",
+    );
 
     rendered.unmount();
   });
@@ -87,7 +89,12 @@ describe("StatusBar", () => {
 
   test("shows the down confirmation prompt", async () => {
     const rendered = await renderStatusBar({
-      mode: Mode.ConfirmDown("myapp-feature", "feature", "proj/feature"),
+      mode: Mode.ConfirmDown(
+        "myapp-feature",
+        "feature",
+        "/tmp/myapp-feature",
+        "proj/feature",
+      ),
     });
 
     expect(rendered.output).toContain("Kill session for feature?");

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -67,9 +67,9 @@ describe("StatusBar", () => {
     });
 
     expect(rendered.output).toContain(
-      "↑↓:navigate  ←:collapse  space:action  o:open  c:close",
+      "↑↓:navigate  ←:collapse  space:action  o:open",
     );
-    expect(rendered.output).toContain("/:search  q:quit");
+    expect(rendered.output).toContain("u:up  d:down  c:close  /:search  q:quit");
 
     rendered.unmount();
   });
@@ -80,6 +80,17 @@ describe("StatusBar", () => {
     });
 
     expect(rendered.output).toContain("Kill pane shell:1 vim?");
+    expect(rendered.output).toContain("enter:confirm  esc:cancel");
+
+    rendered.unmount();
+  });
+
+  test("shows the down confirmation prompt", async () => {
+    const rendered = await renderStatusBar({
+      mode: Mode.ConfirmDown("myapp-feature", "feature", "proj/feature"),
+    });
+
+    expect(rendered.output).toContain("Kill session for feature?");
     expect(rendered.output).toContain("enter:confirm  esc:cancel");
 
     rendered.unmount();

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -23,10 +23,10 @@ function createStdoutStdin() {
 function stripAnsi(value: string) {
   let output = "";
   for (let i = 0; i < value.length; i += 1) {
-    const char = value[i];
+    const char = value[i]!;
     if (char === "\u001B" && value[i + 1] === "[") {
       i += 2;
-      while (i < value.length && !/[A-Za-z@~]/.test(value[i])) {
+      while (i < value.length && !/[A-Za-z@~]/.test(value[i]!)) {
         i += 1;
       }
       continue;
@@ -58,7 +58,8 @@ function collectElements(
     results.push(node);
   }
 
-  const children = node.props.children as React.ReactNode;
+  const children = (node.props as Record<string, unknown>)
+    .children as React.ReactNode;
   if (children !== undefined) {
     collectElements(children, match, results);
   }
@@ -110,13 +111,13 @@ describe("TitledBox", () => {
         .map((line) => line.replace(/\s+$/, ""))
         .filter((line) => line.length > 0);
 
-      expect(lines[0].startsWith("╭ Open Worktrees ")).toBe(true);
-      expect(lines[0].endsWith("╮")).toBe(true);
-      expect(lines[0].length).toBe(28);
+      expect(lines[0]?.startsWith("╭ Open Worktrees ")).toBe(true);
+      expect(lines[0]?.endsWith("╮")).toBe(true);
+      expect(lines[0]?.length).toBe(28);
       expect(lines[1]).toContain("content");
-      expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
-      expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
-      expect(lines[lines.length - 1].length).toBe(28);
+      expect(lines[lines.length - 1]?.startsWith("╰")).toBe(true);
+      expect(lines[lines.length - 1]?.endsWith("╯")).toBe(true);
+      expect(lines[lines.length - 1]?.length).toBe(28);
     } finally {
       rendered?.unmount();
     }
@@ -138,12 +139,12 @@ describe("TitledBox", () => {
         .map((line) => line.replace(/\s+$/, ""))
         .filter((line) => line.length > 0);
 
-      expect(lines[0].startsWith("╭ ")).toBe(true);
-      expect(lines[0]).toContain("…");
-      expect(lines[0].length).toBe(18);
-      expect(lines[lines.length - 1].startsWith("╰")).toBe(true);
-      expect(lines[lines.length - 1].endsWith("╯")).toBe(true);
-      expect(lines[lines.length - 1].length).toBe(18);
+      expect(lines[0]?.startsWith("╭ ")).toBe(true);
+      expect(lines[0]!).toContain("…");
+      expect(lines[0]?.length).toBe(18);
+      expect(lines[lines.length - 1]?.startsWith("╰")).toBe(true);
+      expect(lines[lines.length - 1]?.endsWith("╯")).toBe(true);
+      expect(lines[lines.length - 1]?.length).toBe(18);
     } finally {
       rendered?.unmount();
     }
@@ -277,35 +278,30 @@ describe("TitledBox", () => {
       (element) => element.type === Box,
     );
 
+    // biome-ignore lint: test introspection requires any casts on React element props
+    const p = (node: React.ReactElement) => node.props as any;
+
     expect(
-      focusedTexts.some(
-        (node) => node.props.color === "cyan" && node.props.bold,
-      ),
+      focusedTexts.some((node) => p(node).color === "cyan" && p(node).bold),
     ).toBe(true);
-    expect(focusedTexts.every((node) => node.props.dimColor !== true)).toBe(
-      true,
-    );
-    expect(unfocusedTexts.some((node) => node.props.dimColor === true)).toBe(
-      true,
-    );
-    expect(unfocusedTexts.every((node) => node.props.color !== "cyan")).toBe(
-      true,
-    );
+    expect(focusedTexts.every((node) => p(node).dimColor !== true)).toBe(true);
+    expect(unfocusedTexts.some((node) => p(node).dimColor === true)).toBe(true);
+    expect(unfocusedTexts.every((node) => p(node).color !== "cyan")).toBe(true);
 
     const focusedBorder = focusedBoxes.find(
-      (node) => node.props.borderStyle === "round",
+      (node) => p(node).borderStyle === "round",
     );
     const unfocusedBorder = unfocusedBoxes.find(
-      (node) => node.props.borderStyle === "round",
+      (node) => p(node).borderStyle === "round",
     );
 
-    expect(focusedBorder?.props.borderLeftColor).toBe("cyan");
-    expect(focusedBorder?.props.borderRightColor).toBe("cyan");
-    expect(focusedBorder?.props.borderLeftDimColor).toBe(false);
-    expect(focusedBorder?.props.borderRightDimColor).toBe(false);
-    expect(unfocusedBorder?.props.borderLeftDimColor).toBe(true);
-    expect(unfocusedBorder?.props.borderRightDimColor).toBe(true);
-    expect(unfocusedBorder?.props.borderLeftColor).toBeUndefined();
-    expect(unfocusedBorder?.props.borderRightColor).toBeUndefined();
+    expect(p(focusedBorder!).borderLeftColor).toBe("cyan");
+    expect(p(focusedBorder!).borderRightColor).toBe("cyan");
+    expect(p(focusedBorder!).borderLeftDimColor).toBe(false);
+    expect(p(focusedBorder!).borderRightDimColor).toBe(false);
+    expect(p(unfocusedBorder!).borderLeftDimColor).toBe(true);
+    expect(p(unfocusedBorder!).borderRightDimColor).toBe(true);
+    expect(p(unfocusedBorder!).borderLeftColor).toBeUndefined();
+    expect(p(unfocusedBorder!).borderRightColor).toBeUndefined();
   });
 });

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -23,10 +23,10 @@ function createStdoutStdin() {
 function stripAnsi(value: string) {
   let output = "";
   for (let i = 0; i < value.length; i += 1) {
-    const char = value[i]!;
-    if (char === "\u001B" && value[i + 1] === "[") {
+    const char = value.charAt(i);
+    if (char === "\u001B" && value.charAt(i + 1) === "[") {
       i += 2;
-      while (i < value.length && !/[A-Za-z@~]/.test(value[i]!)) {
+      while (i < value.length && !/[A-Za-z@~]/.test(value.charAt(i))) {
         i += 1;
       }
       continue;
@@ -140,7 +140,7 @@ describe("TitledBox", () => {
         .filter((line) => line.length > 0);
 
       expect(lines[0]?.startsWith("╭ ")).toBe(true);
-      expect(lines[0]!).toContain("…");
+      expect(lines[0]).toContain("…");
       expect(lines[0]?.length).toBe(18);
       expect(lines[lines.length - 1]?.startsWith("╰")).toBe(true);
       expect(lines[lines.length - 1]?.endsWith("╯")).toBe(true);
@@ -295,13 +295,17 @@ describe("TitledBox", () => {
       (node) => p(node).borderStyle === "round",
     );
 
-    expect(p(focusedBorder!).borderLeftColor).toBe("cyan");
-    expect(p(focusedBorder!).borderRightColor).toBe("cyan");
-    expect(p(focusedBorder!).borderLeftDimColor).toBe(false);
-    expect(p(focusedBorder!).borderRightDimColor).toBe(false);
-    expect(p(unfocusedBorder!).borderLeftDimColor).toBe(true);
-    expect(p(unfocusedBorder!).borderRightDimColor).toBe(true);
-    expect(p(unfocusedBorder!).borderLeftColor).toBeUndefined();
-    expect(p(unfocusedBorder!).borderRightColor).toBeUndefined();
+    expect(focusedBorder).toBeDefined();
+    expect(unfocusedBorder).toBeDefined();
+    const fb = p(focusedBorder as React.ReactElement);
+    const ub = p(unfocusedBorder as React.ReactElement);
+    expect(fb.borderLeftColor).toBe("cyan");
+    expect(fb.borderRightColor).toBe("cyan");
+    expect(fb.borderLeftDimColor).toBe(false);
+    expect(fb.borderRightDimColor).toBe(false);
+    expect(ub.borderLeftDimColor).toBe(true);
+    expect(ub.borderRightDimColor).toBe(true);
+    expect(ub.borderLeftColor).toBeUndefined();
+    expect(ub.borderRightColor).toBeUndefined();
   });
 });

--- a/tests/tui/types.test.ts
+++ b/tests/tui/types.test.ts
@@ -18,14 +18,20 @@ describe("Mode", () => {
   });
 
   test("constructs ConfirmDown mode", () => {
-    expect(Mode.ConfirmDown("myapp-feature", "feature", "proj/feature")).toEqual(
-      {
-        type: "ConfirmDown",
-        sessionName: "myapp-feature",
-        branch: "feature",
-        worktreeKey: "proj/feature",
-      },
-    );
+    expect(
+      Mode.ConfirmDown(
+        "myapp-feature",
+        "feature",
+        "/tmp/myapp-feature",
+        "proj/feature",
+      ),
+    ).toEqual({
+      type: "ConfirmDown",
+      sessionName: "myapp-feature",
+      branch: "feature",
+      worktreePath: "/tmp/myapp-feature",
+      worktreeKey: "proj/feature",
+    });
   });
 });
 

--- a/tests/tui/types.test.ts
+++ b/tests/tui/types.test.ts
@@ -16,6 +16,17 @@ describe("Mode", () => {
       worktreeKey: "proj/branch",
     });
   });
+
+  test("constructs ConfirmDown mode", () => {
+    expect(Mode.ConfirmDown("myapp-feature", "feature", "proj/feature")).toEqual(
+      {
+        type: "ConfirmDown",
+        sessionName: "myapp-feature",
+        branch: "feature",
+        worktreeKey: "proj/feature",
+      },
+    );
+  });
 });
 
 describe("checkIcon", () => {

--- a/tests/tui/up-modal.test.ts
+++ b/tests/tui/up-modal.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import type { ListItem } from "../../src/tui/components/ScrollableList";
+import { resolveUpModalSubmission } from "../../src/tui/components/UpModal";
+
+const profileItems: ListItem[] = [
+  { label: "(default)", value: "" },
+  { label: "backend", value: "backend" },
+];
+
+describe("resolveUpModalSubmission", () => {
+  test("allows submit without a profile when none are configured", () => {
+    expect(resolveUpModalSubmission([], [], 0)).toEqual({
+      canSubmit: true,
+    });
+  });
+
+  test("blocks submit when the profile filter has no matches", () => {
+    expect(resolveUpModalSubmission(["backend"], [], 0)).toEqual({
+      canSubmit: false,
+    });
+  });
+
+  test("maps the default profile option to an omitted --profile flag", () => {
+    expect(resolveUpModalSubmission(["backend"], profileItems, 0)).toEqual({
+      canSubmit: true,
+      profile: undefined,
+    });
+  });
+
+  test("returns the selected named profile when one is highlighted", () => {
+    expect(resolveUpModalSubmission(["backend"], profileItems, 1)).toEqual({
+      canSubmit: true,
+      profile: "backend",
+    });
+  });
+});

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -156,9 +156,7 @@ describe("useTmux hook", () => {
     await flush(10);
 
     expect(harness.value.client).toBeNull();
-    expect(harness.value.error).toBe(
-      "Multiple tmux clients found (2). Multi-client support coming soon.",
-    );
+    expect(harness.value.error).toBeNull();
 
     harness.unmount();
   });
@@ -176,9 +174,7 @@ describe("useTmux hook", () => {
 
     expect(result).toEqual({ type: "multiple" });
     expect(harness.value.client).toBeNull();
-    expect(harness.value.error).toBe(
-      "Multiple tmux clients found (2). Multi-client support coming soon.",
-    );
+    expect(harness.value.error).toBeNull();
 
     harness.unmount();
   });

--- a/tests/tui/use-tmux.test.ts
+++ b/tests/tui/use-tmux.test.ts
@@ -163,6 +163,49 @@ describe("useTmux hook", () => {
     harness.unmount();
   });
 
+  test("discoverClient returns multiple when client ownership is ambiguous", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockResolvedValueOnce([
+      { tty: "/dev/ttys001", session: "main" },
+      { tty: "/dev/ttys002", session: "feature-a" },
+    ]);
+
+    const result = await harness.value.discoverClient();
+    await flush(2);
+
+    expect(result).toEqual({ type: "multiple" });
+    expect(harness.value.client).toBeNull();
+    expect(harness.value.error).toBe(
+      "Multiple tmux clients found (2). Multi-client support coming soon.",
+    );
+
+    harness.unmount();
+  });
+
+  test("refreshSessions returns the latest parsed tmux sessions", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise
+      .mockResolvedValueOnce([
+        { name: "main", attached: true },
+        { name: "feature-a", attached: false },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const result = await harness.value.refreshSessions();
+    await flush(2);
+
+    expect(result).toEqual([
+      { name: "main", attached: true },
+      { name: "feature-a", attached: false },
+    ]);
+    expect(harness.value.sessions).toEqual(result);
+
+    harness.unmount();
+  });
+
   test("switchSession returns false when no active client exists", async () => {
     // Mount with no clients so client stays null
     mockRunPromise
@@ -176,6 +219,65 @@ describe("useTmux hook", () => {
 
     const result = await harness.value.switchSession("foo");
     expect(result).toBe(false);
+
+    harness.unmount();
+  });
+
+  test("switchSession updates the tracked client session after success", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise.mockResolvedValueOnce(undefined);
+
+    const result = await harness.value.switchSession("feature-a");
+    await flush(2);
+
+    expect(result).toBe(true);
+    expect(harness.value.client).toEqual({
+      tty: "/dev/ttys001",
+      session: "feature-a",
+    });
+
+    harness.unmount();
+  });
+
+  test("switchSession can use an explicitly discovered client snapshot", async () => {
+    mockRunPromise
+      .mockResolvedValueOnce([]) // listClients
+      .mockResolvedValueOnce(null); // listSessions
+
+    const harness = await renderUseTmux();
+    await flush(10);
+
+    const result = await harness.value.switchSession("feature-a", {
+      tty: "/dev/ttys001",
+      session: "main",
+    });
+    await flush(2);
+
+    expect(result).toBe(true);
+    expect(harness.value.client).toEqual({
+      tty: "/dev/ttys001",
+      session: "feature-a",
+    });
+
+    harness.unmount();
+  });
+
+  test("jumpToPane refreshes the tracked client session after success", async () => {
+    const harness = await renderWithSingleClient();
+
+    mockRunPromise
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([{ tty: "/dev/ttys001", session: "feature-a" }]);
+
+    const result = await harness.value.jumpToPane("%42");
+    await flush(2);
+
+    expect(result).toBe(true);
+    expect(harness.value.client).toEqual({
+      tty: "/dev/ttys001",
+      session: "feature-a",
+    });
 
     harness.unmount();
   });

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -248,6 +248,62 @@ describe("upCommand", () => {
     expect(typeof upCommand).toBe("function");
   });
 
+  test("resolves worktree path via --branch flag", async () => {
+    const fixture = await createLinkedWorktreeFixture(
+      "wct-up-branch-flag-",
+      "wct-up-branch-flag-wt-",
+    );
+    const originalDir = process.cwd();
+    const wtPath = join(fixture.worktreeDir, "feature-branch");
+
+    try {
+      await Bun.write(
+        join(fixture.repoDir, ".wct.yaml"),
+        `version: 1
+worktree_dir: "../worktrees"
+project_name: "myapp"
+tmux:
+  windows:
+    - name: "main"
+`,
+      );
+
+      process.chdir(fixture.repoDir);
+
+      const createCalls: string[] = [];
+      await runBunPromise(
+        withTestServices(
+          upCommand({ branch: "feature-branch" }),
+          {
+            worktree: {
+              ...liveWorktreeService,
+              isGitRepo: () => Effect.succeed(true),
+              getMainRepoPath: () => Effect.succeed(fixture.repoDir),
+              getCurrentBranch: (cwd?: string) =>
+                Effect.succeed(cwd === wtPath ? "feature-branch" : "main"),
+            },
+            tmux: {
+              ...liveTmuxService,
+              createSession: (opts) =>
+                Effect.sync(() => {
+                  createCalls.push(opts.workingDir);
+                  return {
+                    _tag: "Created" as const,
+                    sessionName: "test",
+                  };
+                }),
+            },
+          },
+        ),
+      );
+
+      expect(createCalls[0]).toBe(wtPath);
+    } finally {
+      process.chdir(originalDir);
+      await cleanupLinkedWorktreeFixture(fixture, originalDir);
+    }
+  });
+
   test("does not print attach guidance when tmux session creation fails", async () => {
     const repoDir = await mkdtemp(join(tmpdir(), "wct-up-tmux-fail-"));
     const originalDir = process.cwd();

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { $ } from "bun";
 import { Effect } from "effect";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
-import { upCommand } from "../src/commands/up";
+import { commandDef, upCommand } from "../src/commands/up";
 import { runBunPromise } from "../src/effect/runtime";
 import { provideWctServices } from "../src/effect/services";
 import { commandError } from "../src/errors";
@@ -246,6 +246,14 @@ exec "${realGit}" "$@"
 describe("upCommand", () => {
   test("is exported as a function", () => {
     expect(typeof upCommand).toBe("function");
+  });
+
+  test("completes --branch from worktree branches only", () => {
+    const branchOption = commandDef.options?.find(
+      (option) => option.name === "branch",
+    );
+
+    expect(branchOption?.completionValues).toBe("__wct_worktree_branches");
   });
 
   test("resolves worktree path via --path flag outside a git repo", async () => {

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -248,6 +248,62 @@ describe("upCommand", () => {
     expect(typeof upCommand).toBe("function");
   });
 
+  test("resolves worktree path via --path flag outside a git repo", async () => {
+    const fixture = await createLinkedWorktreeFixture(
+      "wct-up-path-flag-",
+      "wct-up-path-flag-wt-",
+    );
+    const outsideDir = await mkdtemp(join(tmpdir(), "wct-up-outside-"));
+    const originalDir = process.cwd();
+    const wtPath = join(fixture.worktreeDir, "feature-branch");
+
+    try {
+      await Bun.write(
+        join(fixture.repoDir, ".wct.yaml"),
+        `version: 1
+worktree_dir: "../worktrees"
+project_name: "myapp"
+tmux:
+  windows:
+    - name: "main"
+`,
+      );
+
+      process.chdir(outsideDir);
+
+      const createCalls: string[] = [];
+      await runBunPromise(
+        withTestServices(upCommand({ path: wtPath }), {
+          worktree: {
+            ...liveWorktreeService,
+            isGitRepo: (cwd?: string) => Effect.succeed(cwd === wtPath),
+            getMainRepoPath: (cwd?: string) =>
+              Effect.succeed(cwd === wtPath ? fixture.repoDir : null),
+            getCurrentBranch: (cwd?: string) =>
+              Effect.succeed(cwd === wtPath ? "feature-branch" : null),
+          },
+          tmux: {
+            ...liveTmuxService,
+            createSession: (_name, workingDir) =>
+              Effect.sync(() => {
+                createCalls.push(workingDir);
+                return {
+                  _tag: "Created" as const,
+                  sessionName: "test",
+                };
+              }),
+          },
+        }),
+      );
+
+      expect(createCalls[0]).toBe(wtPath);
+    } finally {
+      process.chdir(originalDir);
+      await cleanupLinkedWorktreeFixture(fixture, originalDir);
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   test("resolves worktree path via --branch flag", async () => {
     const fixture = await createLinkedWorktreeFixture(
       "wct-up-branch-flag-",

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -272,29 +272,26 @@ tmux:
 
       const createCalls: string[] = [];
       await runBunPromise(
-        withTestServices(
-          upCommand({ branch: "feature-branch" }),
-          {
-            worktree: {
-              ...liveWorktreeService,
-              isGitRepo: () => Effect.succeed(true),
-              getMainRepoPath: () => Effect.succeed(fixture.repoDir),
-              getCurrentBranch: (cwd?: string) =>
-                Effect.succeed(cwd === wtPath ? "feature-branch" : "main"),
-            },
-            tmux: {
-              ...liveTmuxService,
-              createSession: (opts) =>
-                Effect.sync(() => {
-                  createCalls.push(opts.workingDir);
-                  return {
-                    _tag: "Created" as const,
-                    sessionName: "test",
-                  };
-                }),
-            },
+        withTestServices(upCommand({ branch: "feature-branch" }), {
+          worktree: {
+            ...liveWorktreeService,
+            isGitRepo: () => Effect.succeed(true),
+            getMainRepoPath: () => Effect.succeed(fixture.repoDir),
+            getCurrentBranch: (cwd?: string) =>
+              Effect.succeed(cwd === wtPath ? "feature-branch" : "main"),
           },
-        ),
+          tmux: {
+            ...liveTmuxService,
+            createSession: (_name, workingDir) =>
+              Effect.sync(() => {
+                createCalls.push(workingDir);
+                return {
+                  _tag: "Created" as const,
+                  sessionName: "test",
+                };
+              }),
+          },
+        }),
       );
 
       expect(createCalls[0]).toBe(wtPath);

--- a/tests/worktree-session.test.ts
+++ b/tests/worktree-session.test.ts
@@ -1,0 +1,217 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Effect } from "effect";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  startWorktreeSession,
+  stopWorktreeSession,
+} from "../src/commands/worktree-session";
+import { runBunPromise } from "../src/effect/runtime";
+import { commandError } from "../src/errors";
+import { liveTmuxService } from "../src/services/tmux";
+import { liveWorktreeService } from "../src/services/worktree-service";
+import { withTestServices } from "./helpers/services";
+
+interface LinkedWorktreeFixture {
+  repoDir: string;
+  worktreeDir: string;
+}
+
+async function createLinkedWorktreeFixture(
+  repoPrefix: string,
+  worktreePrefix: string,
+): Promise<LinkedWorktreeFixture> {
+  const repoDir = await realpath(await mkdtemp(join(tmpdir(), repoPrefix)));
+  const worktreeDir = await realpath(
+    await mkdtemp(join(tmpdir(), worktreePrefix)),
+  );
+
+  await $`git init -b main`.quiet().cwd(repoDir);
+  await $`git config user.email "test@test.com"`.quiet().cwd(repoDir);
+  await $`git config user.name "Test"`.quiet().cwd(repoDir);
+  await $`git config commit.gpgSign false`.quiet().cwd(repoDir);
+  await $`git commit --allow-empty -m "initial"`.quiet().cwd(repoDir);
+
+  const wtPath = join(worktreeDir, "feature-branch");
+  await $`git worktree add -b feature-branch ${wtPath}`.quiet().cwd(repoDir);
+
+  return { repoDir, worktreeDir };
+}
+
+async function cleanupLinkedWorktreeFixture(
+  fixture: LinkedWorktreeFixture,
+  originalDir: string,
+): Promise<void> {
+  process.chdir(originalDir);
+  await $`git worktree remove ${join(fixture.worktreeDir, "feature-branch")}`
+    .quiet()
+    .cwd(fixture.repoDir)
+    .nothrow();
+  await rm(fixture.repoDir, { recursive: true, force: true });
+  await rm(fixture.worktreeDir, { recursive: true, force: true });
+}
+
+describe("startWorktreeSession", () => {
+  let fixture: LinkedWorktreeFixture;
+  let wtPath: string;
+  const originalDir = process.cwd();
+
+  beforeAll(async () => {
+    fixture = await createLinkedWorktreeFixture(
+      "wct-shared-up-",
+      "wct-shared-up-wt-",
+    );
+    wtPath = join(fixture.worktreeDir, "feature-branch");
+
+    await Bun.write(
+      join(fixture.repoDir, ".wct.yaml"),
+      `version: 1
+worktree_dir: "../worktrees"
+project_name: "myapp"
+tmux:
+  windows:
+    - name: "main"
+ide:
+  command: "echo ide"
+`,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupLinkedWorktreeFixture(fixture, originalDir);
+  });
+
+  test("returns structured session start data for a worktree path", async () => {
+    const createCalls: Array<{ name: string; workingDir: string }> = [];
+    const ideCalls: string[] = [];
+
+    process.chdir(fixture.repoDir);
+
+    const result = await runBunPromise(
+      withTestServices(startWorktreeSession({ path: wtPath }), {
+        worktree: {
+          ...liveWorktreeService,
+          isGitRepo: (cwd?: string) => Effect.succeed(cwd === wtPath),
+          getMainRepoPath: (cwd?: string) =>
+            Effect.succeed(cwd === wtPath ? fixture.repoDir : null),
+          getCurrentBranch: (cwd?: string) =>
+            Effect.succeed(cwd === wtPath ? "feature-branch" : null),
+        },
+        tmux: {
+          ...liveTmuxService,
+          createSession: (name, workingDir) =>
+            Effect.sync(() => {
+              createCalls.push({ name, workingDir });
+              return {
+                _tag: "Created" as const,
+                sessionName: name,
+              };
+            }),
+        },
+        ide: {
+          openIDE: (_command, env) =>
+            Effect.sync(() => {
+              ideCalls.push(env.WCT_BRANCH);
+            }),
+        },
+      }),
+    );
+
+    expect(result.worktreePath).toBe(wtPath);
+    expect(result.mainRepoPath).toBe(fixture.repoDir);
+    expect(result.branch).toBe("feature-branch");
+    expect(result.sessionName).toBe("feature-branch");
+    expect(result.projectName).toBe("myapp");
+    expect(result.tmux).toEqual({
+      attempted: true,
+      ok: true,
+      value: {
+        _tag: "Created",
+        sessionName: "feature-branch",
+      },
+    });
+    expect(result.ide).toEqual({
+      attempted: true,
+      ok: true,
+      value: undefined,
+    });
+    expect(createCalls).toEqual([
+      {
+        name: "feature-branch",
+        workingDir: wtPath,
+      },
+    ]);
+    expect(ideCalls).toEqual(["feature-branch"]);
+  });
+
+  test("captures tmux creation failures without rejecting", async () => {
+    process.chdir(fixture.repoDir);
+
+    const result = await runBunPromise(
+      withTestServices(
+        startWorktreeSession({
+          path: wtPath,
+          noIde: true,
+        }),
+        {
+          worktree: {
+            ...liveWorktreeService,
+            isGitRepo: (cwd?: string) => Effect.succeed(cwd === wtPath),
+            getMainRepoPath: (cwd?: string) =>
+              Effect.succeed(cwd === wtPath ? fixture.repoDir : null),
+            getCurrentBranch: (cwd?: string) =>
+              Effect.succeed(cwd === wtPath ? "feature-branch" : null),
+          },
+          tmux: {
+            ...liveTmuxService,
+            createSession: () =>
+              Effect.fail(commandError("tmux_error", "tmux boom")),
+          },
+        },
+      ),
+    );
+
+    expect(result.tmux).toMatchObject({
+      attempted: true,
+      ok: false,
+      error: {
+        code: "tmux_error",
+        message: "tmux boom",
+      },
+    });
+    expect(result.ide).toEqual({ attempted: false });
+  });
+});
+
+describe("stopWorktreeSession", () => {
+  test("returns existed false when the session does not exist", async () => {
+    const killCalls: string[] = [];
+
+    const result = await runBunPromise(
+      withTestServices(stopWorktreeSession({ path: "/tmp/myapp-feature-x" }), {
+        worktree: {
+          ...liveWorktreeService,
+          isGitRepo: (cwd?: string) =>
+            Effect.succeed(cwd === "/tmp/myapp-feature-x"),
+        },
+        tmux: {
+          ...liveTmuxService,
+          sessionExists: () => Effect.succeed(false),
+          killSession: (name: string) =>
+            Effect.sync(() => {
+              killCalls.push(name);
+            }),
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      worktreePath: "/tmp/myapp-feature-x",
+      sessionName: "myapp-feature-x",
+      existed: false,
+    });
+    expect(killCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--path` and `--branch` mutually exclusive flags to `wct up` and `wct down` CLI commands, allowing targeting a worktree without `cd`-ing into it (#53)
- Add `u` keybinding in TUI to open an UpModal for starting a tmux session with profile/IDE/auto-switch options (#54)
- Add `d` keybinding in TUI with ConfirmDown confirmation to kill a worktree's tmux session (#54)
- Extract `ToggleRow` and `SubmitButton` from `OpenModal` into shared `form-controls.tsx` for reuse

## Test plan
- [ ] Run `wct up --branch <branch>` from the main repo — should start session for that worktree
- [ ] Run `wct up --path /path/to/worktree` — should start session at that path
- [ ] Run `wct down --branch <branch>` — should kill the session for that worktree
- [ ] Verify `--path` and `--branch` error when both provided
- [ ] Open TUI, navigate to a worktree, press `u` — UpModal should appear with profile/IDE/auto-switch options
- [ ] Open TUI, navigate to a worktree with active session, press `d` — confirmation prompt should appear, Enter kills session
- [ ] Verify `bun run test` passes

Closes #53, closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-worktree up/down options via --path/--branch; new start/stop worktree session APIs and safer attach/switch flow; TUI Up modal (u) and Confirm Down (d) workflows with form controls.

* **Bug Fixes**
  * Hardened remote parsing and safer cleanup semantics; improved tmux client/session handling to avoid incorrect errors.

* **UX Improvements**
  * Action error banner, updated status-bar hints (u/d), "stopping" indicator, and blocked Up submit when no profile matches.

* **Tests**
  * Extensive new and updated tests covering worktree/session flows, TUI handoff, and resolve path behavior.

* **Documentation**
  * Added implementation plan notes for follow-up TUI/tmux enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->