### PR TITLE
[codex] Make project registration explicit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,3 +11,15 @@ and the derived `WCT_*` environment.
 
 Workspace does not include project registry membership, PR cache state, or the
 TUI repo list.
+
+### Project Registry
+
+The Project Registry is the user's explicit list of repositories managed in the
+TUI repo list. A repository becomes a registered project only through explicit
+project registration.
+
+### Explicit Project Registration
+
+Explicit Project Registration is the user action that adds a repository to the
+Project Registry. Opening, starting, initializing, or otherwise operating on a
+Workspace does not imply project registration.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,6 @@ import { Effect, FileSystem } from "effect";
 import { CONFIG_FILENAME } from "../config/loader";
 import type { WctServices } from "../effect/services";
 import { commandError, type WctError } from "../errors";
-import { registerProject } from "../services/project-registration";
 import * as logger from "../utils/logger";
 import type { CommandDef } from "./command-def";
 
@@ -85,13 +84,7 @@ export function initCommand(): Effect.Effect<void, WctError, WctServices> {
     );
 
     yield* logger.success(`Created ${CONFIG_FILENAME}`);
-
-    // Auto-register repo in TUI registry
-    yield* Effect.catch(
-      registerProject({ tolerateConfigErrors: true }),
-      () => Effect.void,
-    );
-
+    yield* logger.info("Run 'wct projects add' to show this repo in the TUI");
     yield* logger.info("Edit the config file to customize your workflow");
   });
 }

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,10 +1,7 @@
-import { basename } from "node:path";
 import { Effect } from "effect";
 import { JsonFlag } from "../cli/json-flag";
 import type { WctServices } from "../effect/services";
 import type { WctError } from "../errors";
-import { toWctError } from "../errors";
-import { registerProject } from "../services/project-registration";
 import {
   type WorkspaceOpenOptions,
   type WorkspaceOpenResult,
@@ -86,17 +83,6 @@ export interface OpenOptions {
 
 export interface OpenCommandOptions extends WorkspaceOpenOptions {
   noAttach?: boolean;
-}
-
-function registrationFailure(error: unknown) {
-  const wctError = toWctError(error);
-  return {
-    status: "failed" as const,
-    error: {
-      code: wctError.code,
-      message: wctError.message,
-    },
-  };
 }
 
 function logWorkspaceOpenResult(result: WorkspaceOpenResult) {
@@ -236,36 +222,13 @@ export function openCommand(
           : { reporter: createOpenHumanReporter(workspaceOptions) }),
       }),
     );
-    const registration = yield* Effect.match(
-      registerProject({
-        path: result.mainRepoPath,
-        name: result.projectName ?? basename(result.mainRepoPath),
-        tolerateConfigErrors: true,
-      }),
-      {
-        onFailure: (error) => registrationFailure(error),
-        onSuccess: (success) => success.registration,
-      },
-    );
 
     if (json) {
-      yield* jsonSuccess({
-        workspace: result,
-        registration,
-      });
+      yield* jsonSuccess({ workspace: result });
       return;
     }
 
     yield* logWorkspaceOpenResult(result);
-    if (registration.status === "registered") {
-      yield* logger.success(
-        `Registered project '${registration.item.project}'`,
-      );
-    } else if (registration.status === "failed") {
-      yield* logger.warn(
-        `Project registration failed after open: ${registration.error.message}`,
-      );
-    }
 
     if (result.attempts.tmux.attempted && result.attempts.tmux.ok) {
       yield* maybeAttachSession(result.sessionName, noAttach);

--- a/src/tui/hooks/useModalActions.ts
+++ b/src/tui/hooks/useModalActions.ts
@@ -157,20 +157,6 @@ export function createHandleOpen(deps: ModalActionDeps) {
             );
           }
 
-          try {
-            await runTuiSilentPromise(
-              registerProject({
-                path: result.mainRepoPath,
-                name: result.projectName,
-                tolerateConfigErrors: true,
-              }),
-            );
-          } catch (error) {
-            appendWarning(
-              `Project registration failed after open: ${toWctError(error).message}`,
-            );
-          }
-
           if (!opts.noAttach && workspaceOpenStartedTmux(result)) {
             const liveClient = await deps.discoverClient();
             if (liveClient.type === "single") {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { initCommand } from "../src/commands/init";
+import { CONFIG_FILENAME } from "../src/config/loader";
+import { runBunPromise } from "../src/effect/runtime";
+import {
+  liveRegistryService,
+  type RegistryServiceApi,
+} from "../src/services/registry-service";
+import { liveWorktreeService } from "../src/services/worktree-service";
+import { withTestServices } from "./helpers/services";
+
+describe("init command", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "wct-init-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates config and hints at explicit project registration without registering", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const registerCalls: string[] = [];
+
+    try {
+      await runBunPromise(
+        withTestServices(initCommand(), {
+          registry: {
+            ...liveRegistryService,
+            register: (path: string) =>
+              Effect.sync(() => {
+                registerCalls.push(path);
+                return {
+                  status: "registered" as const,
+                  item: {
+                    id: "registry-item",
+                    repo_path: path,
+                    project: "init-project",
+                    created_at: 1,
+                  },
+                };
+              }),
+          } satisfies RegistryServiceApi,
+          worktree: {
+            ...liveWorktreeService,
+            getMainRepoPath: () => Effect.succeed(tempDir),
+          },
+        }),
+      );
+
+      expect(await Bun.file(join(tempDir, CONFIG_FILENAME)).exists()).toBe(
+        true,
+      );
+      expect(registerCalls).toEqual([]);
+      const loggedLines = logSpy.mock.calls.map((args) => String(args[0]));
+      expect(
+        loggedLines.some((line) =>
+          line.includes("Run 'wct projects add' to show this repo in the TUI"),
+        ),
+      ).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/tests/open.test.ts
+++ b/tests/open.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { openCommand } from "../src/commands/open";
 import { DEFAULT_IDE_CONFIG } from "../src/config/loader";
 import { runBunPromise } from "../src/effect/runtime";
-import { commandError, WctCommandError } from "../src/errors";
+import { WctCommandError } from "../src/errors";
 import { type IdeService, liveIdeService } from "../src/services/ide-service";
 import {
   liveRegistryService,
@@ -316,11 +316,6 @@ describe("open workflow", () => {
           existing: false,
         }),
         {
-          registry: {
-            ...liveRegistryService,
-            register: (path: string, name: string) =>
-              Effect.succeed(registeredResult(path, name)),
-          } satisfies RegistryServiceApi,
           worktree: {
             ...liveWorktreeService,
             isGitRepo: () => Effect.succeed(true),
@@ -395,11 +390,6 @@ describe("open workflow", () => {
                 ideCalls.push(command);
               }),
           } satisfies IdeService,
-          registry: {
-            ...liveRegistryService,
-            register: (path: string, name: string) =>
-              Effect.succeed(registeredResult(path, name)),
-          } satisfies RegistryServiceApi,
           worktree: {
             ...liveWorktreeService,
             isGitRepo: () => Effect.succeed(true),
@@ -434,11 +424,6 @@ describe("open workflow", () => {
                 ideCalls.push(command);
               }),
           } satisfies IdeService,
-          registry: {
-            ...liveRegistryService,
-            register: (path: string, name: string) =>
-              Effect.succeed(registeredResult(path, name)),
-          } satisfies RegistryServiceApi,
           worktree: {
             ...liveWorktreeService,
             isGitRepo: () => Effect.succeed(true),
@@ -479,11 +464,6 @@ describe("open workflow", () => {
               cwd: fixture.repoDir,
             }),
             {
-              registry: {
-                ...liveRegistryService,
-                register: (path: string, name: string) =>
-                  Effect.succeed(registeredResult(path, name)),
-              } satisfies RegistryServiceApi,
               worktree: {
                 ...liveWorktreeService,
                 isGitRepo: () => Effect.succeed(true),
@@ -536,11 +516,6 @@ describe("open workflow", () => {
               cwd: fixture.repoDir,
             }),
             {
-              registry: {
-                ...liveRegistryService,
-                register: (path: string, name: string) =>
-                  Effect.succeed(registeredResult(path, name)),
-              } satisfies RegistryServiceApi,
               worktree: {
                 ...liveWorktreeService,
                 isGitRepo: () => Effect.succeed(true),
@@ -583,11 +558,6 @@ describe("open workflow", () => {
           existing: false,
         }),
         {
-          registry: {
-            ...liveRegistryService,
-            register: (path: string, name: string) =>
-              Effect.succeed(registeredResult(path, name)),
-          } satisfies RegistryServiceApi,
           worktree: {
             ...liveWorktreeService,
             isGitRepo: () => Effect.succeed(true),
@@ -617,59 +587,21 @@ describe("open workflow", () => {
     ]);
   });
 
-  test("openCommand registers only after Workspace open succeeds", async () => {
+  test("openCommand does not register projects after Workspace open succeeds", async () => {
     const registerCalls: string[] = [];
-
-    await expect(
-      runBunPromise(
-        withTestServices(
-          openCommand({
-            branch: "fatal",
-            existing: false,
-          }),
-          {
-            workspace: {
-              open: () =>
-                Effect.fail(commandError("worktree_error", "fatal open")),
-              up: () => Effect.die("unused"),
-              down: () => Effect.die("unused"),
-              close: () => Effect.die("unused"),
-            },
-            registry: {
-              ...liveRegistryService,
-              register: (path: string) =>
-                Effect.sync(() => {
-                  registerCalls.push(path);
-                  return registeredResult(path, "myapp");
-                }),
-            } satisfies RegistryServiceApi,
-          },
-        ),
-      ),
-    ).rejects.toThrow("fatal open");
-
-    expect(registerCalls).toEqual([]);
-  });
-
-  test("openCommand auto-registration omits forceRename for existing registry rows", async () => {
-    const registerCalls: Array<{
-      path: string;
-      name: string;
-      forceRename?: boolean;
-    }> = [];
     const workspaceResult: WorkspaceOpenResult = {
       operation: "open",
-      worktreePath: "/tmp/myapp-existing-registration",
+      worktreePath: "/tmp/myapp-no-registration",
       mainRepoPath: fixture.repoDir,
-      branch: "existing-registration",
-      sessionName: "myapp-existing-registration",
-      projectName: "new-config-name",
+      branch: "no-registration",
+      sessionName: "myapp-no-registration",
+      projectName: "myapp",
       created: true,
       env: {
-        WCT_WORKTREE_DIR: "/tmp/myapp-existing-registration",
+        WCT_WORKTREE_DIR: "/tmp/myapp-no-registration",
         WCT_MAIN_DIR: fixture.repoDir,
-        WCT_BRANCH: "existing-registration",
-        WCT_PROJECT: "new-config-name",
+        WCT_BRANCH: "no-registration",
+        WCT_PROJECT: "myapp",
       },
       warnings: [],
       attempts: {
@@ -678,7 +610,7 @@ describe("open workflow", () => {
           ok: true,
           value: {
             _tag: "Created",
-            path: "/tmp/myapp-existing-registration",
+            path: "/tmp/myapp-no-registration",
           },
         },
         vscode: {
@@ -695,7 +627,7 @@ describe("open workflow", () => {
     await runBunPromise(
       withTestServices(
         openCommand({
-          branch: "existing-registration",
+          branch: "no-registration",
           existing: false,
         }),
         {
@@ -707,32 +639,22 @@ describe("open workflow", () => {
           },
           registry: {
             ...liveRegistryService,
-            register: (path, name, options) =>
+            register: (path: string) =>
               Effect.sync(() => {
-                registerCalls.push({
-                  path,
-                  name,
-                  forceRename: options?.forceRename,
-                });
-                return alreadyRegisteredResult(path, "original-name");
+                registerCalls.push(path);
+                return registeredResult(path, "myapp");
               }),
           } satisfies RegistryServiceApi,
         },
       ),
     );
 
-    expect(registerCalls).toEqual([
-      {
-        path: fixture.repoDir,
-        name: "new-config-name",
-        forceRename: undefined,
-      },
-    ]);
+    expect(registerCalls).toEqual([]);
   });
 
-  test("openCommand JSON emits final workspace result and registration outcome", async () => {
+  test("openCommand JSON emits final workspace result without registration outcome", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const registrationResult = registeredResult(fixture.repoDir, "myapp");
+    const registerCalls: string[] = [];
     const workspaceResult: WorkspaceOpenResult = {
       operation: "open" as const,
       worktreePath: "/tmp/myapp-json",
@@ -803,9 +725,8 @@ describe("open workflow", () => {
               ...liveRegistryService,
               register: (path: string, name: string) =>
                 Effect.sync(() => {
-                  expect(path).toBe(fixture.repoDir);
-                  expect(name).toBe("myapp");
-                  return registrationResult;
+                  registerCalls.push(`${path}:${name}`);
+                  return registeredResult(path, name);
                 }),
             } satisfies RegistryServiceApi,
           },
@@ -817,249 +738,22 @@ describe("open workflow", () => {
         ok: true,
         data: {
           workspace: workspaceResult,
-          registration: registrationResult,
         },
       });
       expect(output.data.workspace.warnings).toEqual(workspaceResult.warnings);
       expect(output.data.workspace.attempts.tmux).toEqual(
         workspaceResult.attempts.tmux,
       );
-      expect(output.data.registrationStatus).toBeUndefined();
+      expect(output.data.registration).toBeUndefined();
+      expect(registerCalls).toEqual([]);
     } finally {
       logSpy.mockRestore();
     }
   });
 
-  test("openCommand JSON preserves already-registered registration outcome", async () => {
+  test("openCommand passes a human reporter without project registration", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const registrationResult = alreadyRegisteredResult(
-      fixture.repoDir,
-      "original-name",
-    );
-    const workspaceResult: WorkspaceOpenResult = {
-      operation: "open" as const,
-      worktreePath: "/tmp/myapp-json-existing",
-      mainRepoPath: fixture.repoDir,
-      branch: "json-existing",
-      sessionName: "myapp-json-existing",
-      projectName: "myapp",
-      created: false,
-      env: {
-        WCT_WORKTREE_DIR: "/tmp/myapp-json-existing",
-        WCT_MAIN_DIR: fixture.repoDir,
-        WCT_BRANCH: "json-existing",
-        WCT_PROJECT: "myapp",
-      },
-      warnings: [],
-      attempts: {
-        worktree: {
-          attempted: true as const,
-          ok: true as const,
-          value: {
-            _tag: "AlreadyExists" as const,
-            path: "/tmp/myapp-json-existing",
-          },
-        },
-        vscode: {
-          attempted: false as const,
-          reason: "vscode_sync_not_configured",
-        },
-        copy: { attempted: false as const, reason: "copy_not_configured" },
-        setup: { attempted: false as const, reason: "setup_not_configured" },
-        tmux: { attempted: false as const, reason: "tmux_not_configured" },
-        ide: { attempted: false as const, reason: "ide_not_configured" },
-      },
-    };
-
-    try {
-      await runBunPromise(
-        withTestServices(
-          openCommand({
-            branch: "json-existing",
-            existing: false,
-          }),
-          {
-            json: true,
-            workspace: {
-              open: () => Effect.succeed(workspaceResult),
-              up: () => Effect.die("unused"),
-              down: () => Effect.die("unused"),
-              close: () => Effect.die("unused"),
-            },
-            registry: {
-              ...liveRegistryService,
-              register: () => Effect.succeed(registrationResult),
-            } satisfies RegistryServiceApi,
-          },
-        ),
-      );
-
-      const output = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
-      expect(output).toMatchObject({
-        ok: true,
-        data: {
-          workspace: workspaceResult,
-          registration: registrationResult,
-        },
-      });
-    } finally {
-      logSpy.mockRestore();
-    }
-  });
-
-  test("openCommand JSON reports registration failures distinctly", async () => {
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const workspaceResult: WorkspaceOpenResult = {
-      operation: "open" as const,
-      worktreePath: "/tmp/myapp-json-registration-failure",
-      mainRepoPath: fixture.repoDir,
-      branch: "json-registration-failure",
-      sessionName: "myapp-json-registration-failure",
-      projectName: "myapp",
-      created: true,
-      env: {
-        WCT_WORKTREE_DIR: "/tmp/myapp-json-registration-failure",
-        WCT_MAIN_DIR: fixture.repoDir,
-        WCT_BRANCH: "json-registration-failure",
-        WCT_PROJECT: "myapp",
-      },
-      warnings: [],
-      attempts: {
-        worktree: {
-          attempted: true as const,
-          ok: true as const,
-          value: {
-            _tag: "Created" as const,
-            path: "/tmp/myapp-json-registration-failure",
-          },
-        },
-        vscode: {
-          attempted: false as const,
-          reason: "vscode_sync_not_configured",
-        },
-        copy: { attempted: false as const, reason: "copy_not_configured" },
-        setup: { attempted: false as const, reason: "setup_not_configured" },
-        tmux: { attempted: false as const, reason: "tmux_not_configured" },
-        ide: { attempted: false as const, reason: "ide_not_configured" },
-      },
-    };
-
-    try {
-      await runBunPromise(
-        withTestServices(
-          openCommand({
-            branch: "json-registration-failure",
-            existing: false,
-          }),
-          {
-            json: true,
-            workspace: {
-              open: () => Effect.succeed(workspaceResult),
-              up: () => Effect.die("unused"),
-              down: () => Effect.die("unused"),
-              close: () => Effect.die("unused"),
-            },
-            registry: {
-              ...liveRegistryService,
-              register: () =>
-                Effect.fail(commandError("registry_error", "db locked")),
-            } satisfies RegistryServiceApi,
-          },
-        ),
-      );
-
-      const output = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
-      expect(output).toMatchObject({
-        ok: true,
-        data: {
-          workspace: workspaceResult,
-          registration: {
-            status: "failed",
-            error: {
-              code: "registry_error",
-              message: "db locked",
-            },
-          },
-        },
-      });
-    } finally {
-      logSpy.mockRestore();
-    }
-  });
-
-  test("openCommand warns when human auto-registration fails", async () => {
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const workspaceResult: WorkspaceOpenResult = {
-      operation: "open" as const,
-      worktreePath: "/tmp/myapp-registration-warning",
-      mainRepoPath: fixture.repoDir,
-      branch: "registration-warning",
-      sessionName: "myapp-registration-warning",
-      projectName: "myapp",
-      created: true,
-      env: {
-        WCT_WORKTREE_DIR: "/tmp/myapp-registration-warning",
-        WCT_MAIN_DIR: fixture.repoDir,
-        WCT_BRANCH: "registration-warning",
-        WCT_PROJECT: "myapp",
-      },
-      warnings: [],
-      attempts: {
-        worktree: {
-          attempted: true as const,
-          ok: true as const,
-          value: {
-            _tag: "Created" as const,
-            path: "/tmp/myapp-registration-warning",
-          },
-        },
-        vscode: {
-          attempted: false as const,
-          reason: "vscode_sync_not_configured",
-        },
-        copy: { attempted: false as const, reason: "copy_not_configured" },
-        setup: { attempted: false as const, reason: "setup_not_configured" },
-        tmux: { attempted: false as const, reason: "tmux_not_configured" },
-        ide: { attempted: false as const, reason: "ide_not_configured" },
-      },
-    };
-
-    try {
-      await runBunPromise(
-        withTestServices(
-          openCommand({
-            branch: "registration-warning",
-            existing: false,
-          }),
-          {
-            workspace: {
-              open: () => Effect.succeed(workspaceResult),
-              up: () => Effect.die("unused"),
-              down: () => Effect.die("unused"),
-              close: () => Effect.die("unused"),
-            },
-            registry: {
-              ...liveRegistryService,
-              register: () =>
-                Effect.fail(commandError("registry_error", "db locked")),
-            } satisfies RegistryServiceApi,
-          },
-        ),
-      );
-
-      const loggedLines = logSpy.mock.calls.map((args) => String(args[0]));
-      expect(
-        loggedLines.some((line) =>
-          line.includes("Project registration failed after open: db locked"),
-        ),
-      ).toBe(true);
-    } finally {
-      logSpy.mockRestore();
-    }
-  });
-
-  test("openCommand passes a human reporter and keeps already-registered auto-registration silent", async () => {
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const registerCalls: string[] = [];
     const workspaceResult = {
       operation: "open" as const,
       worktreePath: "/tmp/myapp-human",
@@ -1124,7 +818,10 @@ describe("open workflow", () => {
             registry: {
               ...liveRegistryService,
               register: (path: string, name: string) =>
-                Effect.succeed(alreadyRegisteredResult(path, name)),
+                Effect.sync(() => {
+                  registerCalls.push(`${path}:${name}`);
+                  return alreadyRegisteredResult(path, name);
+                }),
             } satisfies RegistryServiceApi,
           },
         ),
@@ -1137,6 +834,7 @@ describe("open workflow", () => {
       expect(
         loggedLines.some((line) => line.includes("Registered project")),
       ).toBe(false);
+      expect(registerCalls).toEqual([]);
     } finally {
       logSpy.mockRestore();
     }
@@ -1213,11 +911,6 @@ describe("open workflow", () => {
               down: () => Effect.die("unused"),
               close: () => Effect.die("unused"),
             },
-            registry: {
-              ...liveRegistryService,
-              register: (path: string, name: string) =>
-                Effect.succeed(alreadyRegisteredResult(path, name)),
-            } satisfies RegistryServiceApi,
           },
         ),
       );

--- a/tests/tui/modal-actions.test.ts
+++ b/tests/tui/modal-actions.test.ts
@@ -189,7 +189,7 @@ describe("createHandleOpen", () => {
     vi.restoreAllMocks();
   });
 
-  test("opens a branch through WorkspaceService, registers, refreshes, and clears pending", async () => {
+  test("opens a branch through WorkspaceService, refreshes, and clears pending without registering", async () => {
     const { tuiRuntime, runTuiSilentPromise } = await import(
       "../../src/tui/runtime"
     );
@@ -202,9 +202,6 @@ describe("createHandleOpen", () => {
     });
     const openResult = makeOpenResult();
     (tuiRuntime.runPromise as Mock).mockResolvedValueOnce(openResult);
-    (runTuiSilentPromise as Mock).mockResolvedValueOnce({
-      registration: { status: "registered" },
-    });
     const refreshAll = vi.fn().mockResolvedValue(undefined);
     const deps = makeDeps({
       openModalRepoProject: "proj",
@@ -240,14 +237,10 @@ describe("createHandleOpen", () => {
         noIde: true,
       });
       expect(tuiRuntime.runPromise).toHaveBeenCalledWith("mock-open-effect");
-      expect(registerProjectMock).toHaveBeenCalledWith({
-        path: "/repo",
-        name: "proj",
-        tolerateConfigErrors: true,
-      });
       expect(refreshAll).toHaveBeenCalled();
     });
-    expect(runTuiSilentPromise).toHaveBeenCalledWith("register-project-effect");
+    expect(registerProjectMock).not.toHaveBeenCalled();
+    expect(runTuiSilentPromise).not.toHaveBeenCalled();
     expect(deps.showActionError).not.toHaveBeenCalled();
     expect(pendingActions.size).toBe(0);
     expect(setPendingActions).toHaveBeenCalledTimes(2);
@@ -800,6 +793,7 @@ describe("createHandleUpSubmit", () => {
       );
       expect(handleStartResult).toHaveBeenCalledWith(upResult, true);
     });
+    expect(registerProjectMock).not.toHaveBeenCalled();
     expect(pendingActions.size).toBe(0);
     expect(setPendingActions).toHaveBeenCalledTimes(2);
   });

--- a/tests/up.test.ts
+++ b/tests/up.test.ts
@@ -9,6 +9,10 @@ import { DEFAULT_IDE_CONFIG } from "../src/config/loader";
 import { runBunPromise } from "../src/effect/runtime";
 import { provideWctServices } from "../src/effect/services";
 import { commandError } from "../src/errors";
+import {
+  liveRegistryService,
+  type RegistryServiceApi,
+} from "../src/services/registry-service";
 import type { WorkspaceService } from "../src/services/workspace-service";
 import {
   liveWorktreeService,
@@ -271,6 +275,7 @@ describe("upCommand", () => {
 
   test("passes CLI options through to WorkspaceService.up", async () => {
     const receivedOptions: unknown[] = [];
+    const registerCalls: string[] = [];
     const workspace: WorkspaceService = {
       open: () => Effect.die("unused"),
       up: (options) =>
@@ -313,7 +318,25 @@ describe("upCommand", () => {
           path: "/tmp/myapp-feature",
           branch: "feature",
         }),
-        { workspace },
+        {
+          workspace,
+          registry: {
+            ...liveRegistryService,
+            register: (path: string) =>
+              Effect.sync(() => {
+                registerCalls.push(path);
+                return {
+                  status: "registered" as const,
+                  item: {
+                    id: "registry-item",
+                    repo_path: path,
+                    project: "myapp",
+                    created_at: 1,
+                  },
+                };
+              }),
+          } satisfies RegistryServiceApi,
+        },
       ),
     );
 
@@ -326,6 +349,7 @@ describe("upCommand", () => {
         branch: "feature",
       },
     ]);
+    expect(registerCalls).toEqual([]);
   });
 
   test("resolves worktree path via --path flag outside a git repo", async () => {


### PR DESCRIPTION
## Summary

- Remove automatic project registration from `wct open`, TUI open, and `wct init`.
- Keep registration explicit through `wct projects add` and the TUI Add Project action.
- Change `wct open --json` to return workspace data without a registration field.
- Add glossary language for the Project Registry and Explicit Project Registration boundary.
- Update tests for open, up, init, and TUI modal actions.

## Validation

- `bunx biome check tests/open.test.ts tests/up.test.ts tests/tui/modal-actions.test.ts tests/init.test.ts`
- `git diff --check`

Full test/lint suite was left to repository hooks per repo instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation clarifying Project Registry and explicit project registration behavior

* **Refactor**
  * Init, open, and workspace commands no longer auto-register projects in the TUI
  * Users must now explicitly run `wct projects add` to add repositories to the TUI project list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->