### PR TITLE
chore(deps): align @effect/platform-bun and @effect/vitest to beta.83

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "tab-cli",
       "dependencies": {
-        "@effect/platform-bun": "4.0.0-beta.80",
+        "@effect/platform-bun": "4.0.0-beta.83",
         "effect": "4.0.0-beta.83",
         "ink": "7.0.5",
         "react": "^19.2.7",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
-        "@effect/vitest": "4.0.0-beta.80",
+        "@effect/vitest": "4.0.0-beta.83",
         "@types/bun": "1.3.14",
         "@types/react": "^19.2.17",
         "bun-types": "1.3.14",
@@ -45,11 +45,11 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.80", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.80" }, "peerDependencies": { "effect": "^4.0.0-beta.80" } }, "sha512-/fLVvp/sGzuhNHaW0bOT3d0Jh2GqOKsTDtFshe8lSmBga6Fkwf1tjaJ8Swzc2+q1F12b+DZyWrV38momX5xz8Q=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.83", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.83" }, "peerDependencies": { "effect": "^4.0.0-beta.83" } }, "sha512-Mop8U1Ad1FFyL6C4VWWCCYG3Mh7BHvGsfhYAIfBZffEDRjgUME1Ol8rno2CoHYzJ6qaUOL8D4djtPGkwS68/Qw=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.80", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.80" } }, "sha512-VY+p9cgD20T/Qot/390wbaBYx1ngE5bC8PbyIsHmjKRcnOVO/774wxn528GEfRMOQtLc5zh1stcQOp/GlXNF6Q=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.83", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.83" } }, "sha512-+yr/+PJmKTgmJq1QOINSBPgLu7Cjc4CZcotBXnGjyDEizOmimFgTkN2B8PBJAKIKUWYWfobjXqC+58/VhhPKAw=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.80", "", { "peerDependencies": { "effect": "^4.0.0-beta.80", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-z5oKKRO8iLprjFwQpEMbiak0c7SPGyeli4EQLVtXrcZzir6FybiC812Rw3iZJTQhTRQOlLcxgkq89UO2j7Vamw=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.83", "", { "peerDependencies": { "effect": "^4.0.0-beta.83", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-HKGnBkIAPEIDWwmwQtmGTVLN5txlB3M1lVS+BBsPt6M2CeLJ53cyc/2SBUldZM/HQ/aM7s/siiBOXsB9arRdKg=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
-    "@effect/vitest": "4.0.0-beta.80",
+    "@effect/vitest": "4.0.0-beta.83",
     "@types/bun": "1.3.14",
     "@types/react": "^19.2.17",
     "bun-types": "1.3.14",
@@ -29,7 +29,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.80",
+    "@effect/platform-bun": "4.0.0-beta.83",
     "effect": "4.0.0-beta.83",
     "ink": "7.0.5",
     "react": "^19.2.7"


### PR DESCRIPTION
Aligns the remaining `@effect/*` packages to `4.0.0-beta.83` to match `effect` (merged in #91).

Effect's monorepo packages are released in lockstep; running `effect@beta.83` against `@effect/platform-bun@beta.80` / `@effect/vitest@beta.80` is an unsupported beta combo that can break on internal API drift.

- Build compiles cleanly
- 760/760 tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for testing and platform tools to latest beta releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->