### PR TITLE
feat(tui): add Ctrl+Enter submit shortcut to form modals

### DIFF
--- a/src/tui/components/AddProjectModal.tsx
+++ b/src/tui/components/AddProjectModal.tsx
@@ -97,7 +97,8 @@ export function AddProjectModal({
     if (!isGitRepo) return;
     const expanded = expandTilde(pathValue).replace(/\/+$/, "");
     const name = nameValue || path.basename(expanded);
-    onSubmit({ path: expanded, name, nameManuallyEdited: !nameAutoFilled });
+    const manuallyEdited = nameValue !== "" && !nameAutoFilled;
+    onSubmit({ path: expanded, name, nameManuallyEdited: manuallyEdited });
   }, [isGitRepo, pathValue, nameValue, nameAutoFilled, onSubmit]);
 
   useInput(

--- a/src/tui/components/AddProjectModal.tsx
+++ b/src/tui/components/AddProjectModal.tsx
@@ -4,7 +4,7 @@ import { Box, Text, useInput } from "ink";
 import { useCallback, useEffect, useState } from "react";
 import { useBlink } from "../hooks/useBlink";
 import { runTuiSilentPromise } from "../runtime";
-import { SubmitButton } from "./form-controls";
+import { isSubmitShortcut, SubmitButton } from "./form-controls";
 import { Modal } from "./Modal";
 import { expandTilde, PathInput } from "./PathInput";
 import { TitledBox } from "./TitledBox";
@@ -106,6 +106,10 @@ export function AddProjectModal({
         onCancel();
         return;
       }
+      if (isSubmitShortcut(key)) {
+        handleSubmit();
+        return;
+      }
       if (key.tab) {
         // When leaving path field, auto-fill name
         if (currentField === "path") autoFillName();
@@ -115,12 +119,12 @@ export function AddProjectModal({
         );
         return;
       }
-      if (key.return && currentField === "path") {
+      if (key.return && !key.ctrl && currentField === "path") {
         autoFillName();
         setFocusIndex(1); // advance to name
         return;
       }
-      if (key.return && currentField === "name") {
+      if (key.return && !key.ctrl && currentField === "name") {
         setFocusIndex(2); // advance to submit
         return;
       }

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "../hooks/useSessionOptionsState";
 import { tuiRuntime } from "../runtime";
 import type { PRInfo } from "../types";
+import { isSubmitShortcut } from "./form-controls";
 import { Modal } from "./Modal";
 import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
 import { SessionOptionsSection } from "./SessionOptionsSection";
@@ -65,7 +66,8 @@ function ModeSelector({
       if (key.upArrow) setSelected((s) => Math.max(0, s - 1));
       if (key.downArrow)
         setSelected((s) => Math.min(options.length - 1, s + 1));
-      if (key.return) onSelect(options[selected]?.step ?? "newBranch");
+      if (key.return && !key.ctrl)
+        onSelect(options[selected]?.step ?? "newBranch");
       if (key.escape) onCancel();
     },
     { isActive: true },
@@ -147,7 +149,7 @@ function PromptArea({
       if (!isFocused) return;
       if (key.backspace) {
         onChange(value.slice(0, -1));
-      } else if (key.return) {
+      } else if (key.return && !key.ctrl) {
         onChange(`${value}\n`);
       } else if (input && !key.ctrl && !key.meta) {
         onChange(value + input);
@@ -227,10 +229,27 @@ export function NewBranchForm({
     });
   };
 
+  const doSubmit = () => {
+    if (!branch.trim() || !submission.canSubmit) return;
+    onSubmit({
+      branch: branch.trim(),
+      base: base.trim() || undefined,
+      profile: submission.profile,
+      prompt: prompt.trim() || undefined,
+      existing: false,
+      noIde,
+      noAttach: !autoSwitch,
+    });
+  };
+
   useInput(
     (_input, key) => {
       if (key.escape) {
         onBack();
+        return;
+      }
+      if (isSubmitShortcut(key)) {
+        doSubmit();
         return;
       }
       if (key.tab) {
@@ -280,18 +299,7 @@ export function NewBranchForm({
         canSubmit={submission.canSubmit && branch.trim().length > 0}
         onNoIdeToggle={() => setNoIde((prev) => !prev)}
         onAutoSwitchToggle={() => setAutoSwitch((prev) => !prev)}
-        onSubmit={() => {
-          if (!branch.trim() || !submission.canSubmit) return;
-          onSubmit({
-            branch: branch.trim(),
-            base: base.trim() || undefined,
-            profile: submission.profile,
-            prompt: prompt.trim() || undefined,
-            existing: false,
-            noIde,
-            noAttach: !autoSwitch,
-          });
-        }}
+        onSubmit={doSubmit}
         onProfileChange={setSelectedProfileValue}
         resetKey="new-branch"
         width={width}
@@ -398,10 +406,31 @@ export function FromPRForm({
     });
   };
 
+  const doSubmit = () => {
+    if (isRefreshRowSelected) return;
+    const selectedPR = filteredPRItems[selectedPRIndex];
+    if (!selectedPR || !submission.canSubmit) return;
+    const pr = prList.find((p) => String(p.number) === selectedPR.value);
+    if (!pr) return;
+    onSubmit({
+      branch: pr.headRefName,
+      pr: String(pr.number),
+      profile: submission.profile,
+      prompt: prompt.trim() || undefined,
+      existing: false,
+      noIde,
+      noAttach: !autoSwitch,
+    });
+  };
+
   useInput(
     (input, key) => {
       if (key.escape) {
         onBack();
+        return;
+      }
+      if (isSubmitShortcut(key)) {
+        doSubmit();
         return;
       }
       if (key.tab) {
@@ -426,7 +455,7 @@ export function FromPRForm({
           });
           return;
         }
-        if (key.return) {
+        if (key.return && !key.ctrl) {
           if (isRefreshRowSelected && isRefreshRowSelectable) {
             onRefresh();
           }
@@ -497,22 +526,7 @@ export function FromPRForm({
         }
         onNoIdeToggle={() => setNoIde((prev) => !prev)}
         onAutoSwitchToggle={() => setAutoSwitch((prev) => !prev)}
-        onSubmit={() => {
-          if (isRefreshRowSelected) return;
-          const selectedPR = filteredPRItems[selectedPRIndex];
-          if (!selectedPR || !submission.canSubmit) return;
-          const pr = prList.find((p) => String(p.number) === selectedPR.value);
-          if (!pr) return;
-          onSubmit({
-            branch: pr.headRefName,
-            pr: String(pr.number),
-            profile: submission.profile,
-            prompt: prompt.trim() || undefined,
-            existing: false,
-            noIde,
-            noAttach: !autoSwitch,
-          });
-        }}
+        onSubmit={doSubmit}
         onProfileChange={setSelectedProfileValue}
         resetKey="from-pr"
         width={width}
@@ -611,10 +625,27 @@ export function ExistingBranchForm({
     });
   };
 
+  const doSubmit = () => {
+    const selectedBranch = filteredBranchItems[selectedBranchIndex];
+    if (!selectedBranch || !submission.canSubmit) return;
+    onSubmit({
+      branch: selectedBranch.value,
+      profile: submission.profile,
+      prompt: prompt.trim() || undefined,
+      existing: true,
+      noIde,
+      noAttach: !autoSwitch,
+    });
+  };
+
   useInput(
     (input, key) => {
       if (key.escape) {
         onBack();
+        return;
+      }
+      if (isSubmitShortcut(key)) {
+        doSubmit();
         return;
       }
       if (key.tab) {
@@ -689,18 +720,7 @@ export function ExistingBranchForm({
         }
         onNoIdeToggle={() => setNoIde((prev) => !prev)}
         onAutoSwitchToggle={() => setAutoSwitch((prev) => !prev)}
-        onSubmit={() => {
-          const selectedBranch = filteredBranchItems[selectedBranchIndex];
-          if (!selectedBranch || !submission.canSubmit) return;
-          onSubmit({
-            branch: selectedBranch.value,
-            profile: submission.profile,
-            prompt: prompt.trim() || undefined,
-            existing: true,
-            noIde,
-            noAttach: !autoSwitch,
-          });
-        }}
+        onSubmit={doSubmit}
         onProfileChange={setSelectedProfileValue}
         resetKey="existing-branch"
         width={width}

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -4,6 +4,7 @@ import {
   type SessionIdeDefaults,
   useSessionOptionsState,
 } from "../hooks/useSessionOptionsState";
+import { isSubmitShortcut } from "./form-controls";
 import { Modal } from "./Modal";
 import { SessionOptionsSection } from "./SessionOptionsSection";
 import { resolveSessionOptionsSubmitState } from "./session-options";
@@ -62,6 +63,15 @@ export function UpModal({
     [profileNames, selectedProfileValue],
   );
 
+  const doSubmit = () => {
+    if (!submission.canSubmit) return;
+    onSubmit({
+      profile: submission.profile,
+      noIde,
+      autoSwitch,
+    });
+  };
+
   useEffect(() => {
     setFocusIndex((prev) => clampFocusIndex(prev, fields));
   }, [fields]);
@@ -74,6 +84,10 @@ export function UpModal({
     (_input, key) => {
       if (key.escape) {
         onCancel();
+        return;
+      }
+      if (isSubmitShortcut(key)) {
+        doSubmit();
         return;
       }
       if (key.tab) {
@@ -102,14 +116,7 @@ export function UpModal({
           canSubmit={submission.canSubmit}
           onNoIdeToggle={() => setNoIde((prev) => !prev)}
           onAutoSwitchToggle={() => setAutoSwitch((prev) => !prev)}
-          onSubmit={() => {
-            if (!submission.canSubmit) return;
-            onSubmit({
-              profile: submission.profile,
-              noIde,
-              autoSwitch,
-            });
-          }}
+          onSubmit={doSubmit}
           onProfileChange={setSelectedProfileValue}
           resetKey={visible ? "visible" : "hidden"}
           width={width ? width - 2 : undefined}

--- a/src/tui/components/form-controls.tsx
+++ b/src/tui/components/form-controls.tsx
@@ -1,5 +1,12 @@
 import { Box, Text, useInput } from "ink";
 
+export function isSubmitShortcut(key: {
+  ctrl?: boolean;
+  return?: boolean;
+}): boolean {
+  return Boolean(key.ctrl && key.return);
+}
+
 export function ToggleRow({
   label,
   checked,
@@ -40,7 +47,7 @@ export function SubmitButton({
 }) {
   useInput(
     (input, key) => {
-      if (key.return || input === " ") onSubmit();
+      if ((key.return && !key.ctrl) || input === " ") onSubmit();
     },
     { isActive: isFocused && !disabled },
   );

--- a/tests/tui/ctrl-enter-submit.test.tsx
+++ b/tests/tui/ctrl-enter-submit.test.tsx
@@ -379,7 +379,7 @@ describe("Ctrl+Enter submit", () => {
   });
 
   describe("AddProjectModal", () => {
-    test("Ctrl+Enter with a valid git-repo path fires onSubmit with the expected payload", async () => {
+    test("Ctrl+Enter from path field fires onSubmit with nameManuallyEdited=false (name never touched)", async () => {
       runPromiseMock.mockResolvedValue(true);
       const onSubmitMock = vi.fn();
       const rendered = await renderAddProjectModal(onSubmitMock);
@@ -393,7 +393,33 @@ describe("Ctrl+Enter submit", () => {
           expect.objectContaining({
             path: expect.any(String),
             name: expect.any(String),
-            nameManuallyEdited: expect.any(Boolean),
+            nameManuallyEdited: false,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter after typing a custom name fires onSubmit with nameManuallyEdited=true", async () => {
+      runPromiseMock.mockResolvedValue(true);
+      const onSubmitMock = vi.fn();
+      const rendered = await renderAddProjectModal(onSubmitMock);
+
+      try {
+        await new Promise((r) => setTimeout(r, 150));
+        await sendKeys(rendered.stdin, ENTER);
+        await new Promise((r) => setTimeout(r, 0));
+        await sendKeys(rendered.stdin, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f");
+        await sendKeys(rendered.stdin, "my-proj");
+        await new Promise((r) => setTimeout(r, 0));
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "my-proj",
+            nameManuallyEdited: true,
           }),
         );
       } finally {

--- a/tests/tui/ctrl-enter-submit.test.tsx
+++ b/tests/tui/ctrl-enter-submit.test.tsx
@@ -410,7 +410,10 @@ describe("Ctrl+Enter submit", () => {
         await new Promise((r) => setTimeout(r, 150));
         await sendKeys(rendered.stdin, ENTER);
         await new Promise((r) => setTimeout(r, 0));
-        await sendKeys(rendered.stdin, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f");
+        await sendKeys(
+          rendered.stdin,
+          "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f",
+        );
         await sendKeys(rendered.stdin, "my-proj");
         await new Promise((r) => setTimeout(r, 0));
         await sendKeys(rendered.stdin, CTRL_ENTER);

--- a/tests/tui/ctrl-enter-submit.test.tsx
+++ b/tests/tui/ctrl-enter-submit.test.tsx
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { PRInfo } from "../../src/tui/types";
+
+const runPromiseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/tui/runtime", () => ({
+  tuiRuntime: {
+    runPromise: runPromiseMock,
+  },
+  runTuiSilentPromise: (effect: unknown) => runPromiseMock(effect),
+}));
+
+vi.mock("../../src/tui/hooks/useBlink", () => ({
+  useBlink: () => false,
+}));
+
+const { NewBranchForm, FromPRForm, ExistingBranchForm } = await import(
+  "../../src/tui/components/OpenModal"
+);
+const { UpModal } = await import("../../src/tui/components/UpModal");
+const { AddProjectModal } = await import(
+  "../../src/tui/components/AddProjectModal"
+);
+const { CTRL_ENTER, DOWN_ARROW, ENTER, TAB, renderWithInput, sendKeys, tick } =
+  await import("./keypress-harness");
+
+const defaultIdeDefaults = { baseNoIde: true, profileNoIde: {} };
+
+function renderForm(onSubmit: () => void) {
+  return renderWithInput(
+    <NewBranchForm
+      defaultBase="main"
+      profileNames={["default"]}
+      ideDefaults={defaultIdeDefaults}
+      onSubmit={onSubmit}
+      onBack={() => {}}
+      width={80}
+    />,
+  );
+}
+
+const singlePR: PRInfo = {
+  number: 123,
+  title: "Feature",
+  state: "OPEN",
+  headRefName: "feature-from-pr",
+  rollupState: null,
+};
+
+function renderFromPRForm(
+  onSubmit: () => void,
+  onRefresh: () => void = () => {},
+  prList: PRInfo[] = [singlePR],
+) {
+  return renderWithInput(
+    <FromPRForm
+      prList={prList}
+      profileNames={["default"]}
+      ideDefaults={defaultIdeDefaults}
+      isRefreshing={false}
+      onRefresh={onRefresh}
+      onSubmit={onSubmit}
+      onBack={() => {}}
+      width={80}
+    />,
+  );
+}
+
+function renderExistingBranchForm(onSubmit: () => void) {
+  return renderWithInput(
+    <ExistingBranchForm
+      repoPath="/repo"
+      profileNames={["default"]}
+      ideDefaults={defaultIdeDefaults}
+      onSubmit={onSubmit}
+      onBack={() => {}}
+      width={80}
+    />,
+  );
+}
+
+function renderUpModal(
+  onSubmit: () => void,
+  profileNames: string[] = ["default"],
+) {
+  return renderWithInput(
+    <UpModal
+      visible
+      profileNames={profileNames}
+      ideDefaults={defaultIdeDefaults}
+      onSubmit={onSubmit}
+      onCancel={() => {}}
+    />,
+  );
+}
+
+function renderAddProjectModal(onSubmit: () => void) {
+  return renderWithInput(
+    <AddProjectModal
+      visible
+      width={60}
+      onSubmit={onSubmit}
+      onCancel={() => {}}
+    />,
+  );
+}
+
+describe("Ctrl+Enter submit", () => {
+  const originalConsoleError = console.error;
+  const suppressedPattern =
+    /Encountered two children with the same key|Raw mode is not supported/;
+
+  beforeEach(() => {
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === "string" && suppressedPattern.test(args[0]))
+        return;
+      originalConsoleError(...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+    vi.clearAllMocks();
+    runPromiseMock.mockReset();
+  });
+
+  describe("NewBranchForm", () => {
+    test("Ctrl+Enter from the Branch field fires onSubmit with the expected payload", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, "feature-x");
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            branch: "feature-x",
+            existing: false,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter while disabled (empty branch) is a silent no-op", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("plain Enter while Branch field is focused does not submit and does not change branch", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, "abc");
+        await sendKeys(rendered.stdin, ENTER);
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({ branch: "abc" }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter from the Prompt field submits without inserting a newline", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, "feature-x");
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, "my prompt text");
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            branch: "feature-x",
+            prompt: "my prompt text",
+            existing: false,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter from the Submit field fires onSubmit exactly once (no double-fire)", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, "feature-x");
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, TAB);
+        await tick(2);
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            branch: "feature-x",
+            existing: false,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("FromPRForm", () => {
+    test("Ctrl+Enter with a PR selected fires onSubmit with that PR's payload", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderFromPRForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            branch: "feature-from-pr",
+            pr: "123",
+            existing: false,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter on the refresh row is a silent no-op", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderFromPRForm(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, DOWN_ARROW);
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter with no PR selected (empty prList) is a silent no-op", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderFromPRForm(onSubmitMock, () => {}, []);
+
+      try {
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("plain Enter on the refresh row still triggers onRefresh", async () => {
+      const onRefreshMock = vi.fn();
+      const onSubmitMock = vi.fn();
+      const rendered = await renderFromPRForm(onSubmitMock, onRefreshMock);
+
+      try {
+        await sendKeys(rendered.stdin, DOWN_ARROW);
+        await sendKeys(rendered.stdin, ENTER);
+
+        expect(onRefreshMock).toHaveBeenCalledTimes(1);
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("ExistingBranchForm", () => {
+    test("Ctrl+Enter with a branch selected fires onSubmit with that branch's payload", async () => {
+      runPromiseMock.mockResolvedValueOnce(["feature-x"]);
+      const onSubmitMock = vi.fn();
+      const rendered = await renderExistingBranchForm(onSubmitMock);
+
+      try {
+        await tick(5);
+
+        expect(runPromiseMock).toHaveBeenCalledTimes(1);
+        await vi.waitFor(() => {
+          expect(rendered.output()).toContain("feature-x");
+        });
+
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            branch: "feature-x",
+            existing: true,
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter with no branch selected (empty branch list) is a silent no-op", async () => {
+      runPromiseMock.mockResolvedValueOnce([]);
+      const onSubmitMock = vi.fn();
+      const rendered = await renderExistingBranchForm(onSubmitMock);
+
+      try {
+        await tick(5);
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("UpModal", () => {
+    test("Ctrl+Enter from a non-submit field fires onSubmit with the expected payload", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderUpModal(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            noIde: expect.any(Boolean),
+            autoSwitch: expect.any(Boolean),
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter while disabled (profile filter has no match) is a silent no-op", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderUpModal(onSubmitMock);
+
+      try {
+        await sendKeys(rendered.stdin, "zzz", 5);
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("AddProjectModal", () => {
+    test("Ctrl+Enter with a valid git-repo path fires onSubmit with the expected payload", async () => {
+      runPromiseMock.mockResolvedValue(true);
+      const onSubmitMock = vi.fn();
+      const rendered = await renderAddProjectModal(onSubmitMock);
+
+      try {
+        await new Promise((r) => setTimeout(r, 150));
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: expect.any(String),
+            name: expect.any(String),
+            nameManuallyEdited: expect.any(Boolean),
+          }),
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("Ctrl+Enter with a non-git path is a silent no-op", async () => {
+      const onSubmitMock = vi.fn();
+      const rendered = await renderAddProjectModal(onSubmitMock);
+
+      try {
+        await new Promise((r) => setTimeout(r, 150));
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).not.toHaveBeenCalled();
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("plain Enter on the path field still advances to name", async () => {
+      runPromiseMock.mockResolvedValue(true);
+      const onSubmitMock = vi.fn();
+      const rendered = await renderAddProjectModal(onSubmitMock);
+
+      try {
+        await new Promise((r) => setTimeout(r, 150));
+        await sendKeys(rendered.stdin, ENTER);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(onSubmitMock).not.toHaveBeenCalled();
+        await sendKeys(rendered.stdin, CTRL_ENTER);
+
+        expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+});

--- a/tests/tui/keypress-harness.tsx
+++ b/tests/tui/keypress-harness.tsx
@@ -1,0 +1,89 @@
+import { PassThrough } from "node:stream";
+import type React from "react";
+
+export const CTRL_ENTER = "\x1b[13;5u";
+export const ENTER = "\r";
+export const UP_ARROW = "\x1b[A";
+export const DOWN_ARROW = "\x1b[B";
+export const TAB = "\t";
+export const SHIFT_TAB = "\x1b[Z";
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  ref: () => NodeJS.ReadStream;
+  unref: () => NodeJS.ReadStream;
+};
+
+function stripAnsi(value: string) {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value.charAt(i);
+    if (char === "\u001B" && value.charAt(i + 1) === "[") {
+      i += 2;
+      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
+        i += 1;
+      }
+      continue;
+    }
+    if (char !== "\r") {
+      output += char;
+    }
+  }
+  return output;
+}
+
+function createStdoutStdin() {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 100;
+  stdout.rows = 32;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => stdin;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+  return { stdout, stdin };
+}
+
+export async function tick(count = 1) {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+export async function renderWithInput(node: React.ReactElement) {
+  const { stdout, stdin } = createStdoutStdin();
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  const { render } = await import("ink");
+  const instance = render(node, {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await tick(2);
+
+  return {
+    stdin,
+    output: () => stripAnsi(chunks.join("")),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+export async function sendKeys(
+  stdin: NodeJS.ReadStream,
+  sequence: string,
+  ticks = 3,
+) {
+  stdin.write(sequence);
+  await tick(ticks);
+}


### PR DESCRIPTION
## What this does

Pressing **Ctrl+Enter** from any focused field in a form modal now submits the form, without tabbing to the Submit button. The shortcut is **additive** (the Submit button and its Tab-stop are preserved) and **undocumented** (no footer hint changes). When the form is not submittable, Ctrl+Enter is a silent no-op.

## Why

Power-user ergonomics: Tab-to-Submit adds a hop on every form submission. Ctrl+Enter is web-form muscle memory and is distinguishable from plain Enter via the kitty CSI-u sequence `\x1b[13;5u` (which ink parses to `{name:'return', ctrl:true}`).

## Scope

Wired across all five form-modals:

| Form | Modal | Slice |
|------|-------|-------|
| New Branch form | Open modal | 01 (foundation) |
| From PR form | Open modal | 02 |
| Existing Branch form | Open modal | 03 |
| Up modal | — | 04 |
| Add Project modal | — | 05 |

## How it works

**Shared foundation** (`form-controls.tsx`):
- `isSubmitShortcut(key)` predicate — returns true iff `key.ctrl && key.return`
- `SubmitButton` and `PromptArea` `key.return` handlers gated with `!key.ctrl` to prevent double-fire / newline insertion on Ctrl+Enter
- `ModeSelector` `key.return` gated so Ctrl+Enter is a no-op in the mode-pick step (out of scope for the shortcut)

**Per-form**: extract the submit closure into a named `doSubmit` (reusing the existing `handleSubmit` useCallback in AddProjectModal), wire the `isSubmitShortcut` branch in the top-level `useInput` right after the escape check, and gate any form-specific `key.return` consumers (`FromPRForm` refresh-row trigger, `AddProjectModal` path/name advance handlers) with `!key.ctrl`.

## Tests

16 keypress-simulation tests via a reusable TTY-enabled harness (`tests/tui/keypress-harness.tsx`) — a new pattern for this repo (existing modal tests were render/output-only). Covers:

- **Fires-submit** from a non-submit field (all 5 forms)
- **Disabled no-op** when the form is not submittable (all 5 forms)
- **Plain Enter regression guards** — Enter in PR refresh row still refreshes; Enter in AddProject path field still advances to name; Enter in Branch field doesn't submit
- **Highest-risk double-fire scenarios** — Ctrl+Enter from the Prompt field (newline-insertion gate) and from the Submit field (SubmitButton `!key.ctrl` gate, asserts exactly 1 call)

Full TUI suite: 295/295 pass. 5× flake check clean.

## Files changed

- `src/tui/components/form-controls.tsx` — `isSubmitShortcut` predicate + `SubmitButton` gate
- `src/tui/components/OpenModal.tsx` — `PromptArea`/`ModeSelector` gates; `NewBranchForm`/`FromPRForm`/`ExistingBranchForm` `doSubmit` + Ctrl+Enter wiring; `FromPRForm` refresh-row gate
- `src/tui/components/UpModal.tsx` — `doSubmit` + Ctrl+Enter wiring
- `src/tui/components/AddProjectModal.tsx` — path/name advance gates + Ctrl+Enter wiring (reuses `handleSubmit`)
- `tests/tui/keypress-harness.tsx` — reusable harness (TTY-enabled stdin, `CTRL_ENTER`/`ENTER`/`ARROW`/`TAB` constants, `renderWithInput`/`sendKeys`/`tick`)
- `tests/tui/ctrl-enter-submit.test.tsx` — 16 tests

No footer hints changed. No new comments. No out-of-scope files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using **Ctrl+Enter** to submit several TUI forms and modals.
  * Improved return-key behavior so Enter now advances through fields more predictably in project setup flows.

* **Bug Fixes**
  * Enter and Ctrl+Enter now behave consistently across modal forms, avoiding accidental submissions and double actions.
  * Submission is now blocked when required selections or inputs are missing.

* **Tests**
  * Added coverage for Ctrl+Enter submission and field navigation across key TUI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->