### PR TITLE
chore: migrate biome config to 2.5.1 schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -15,7 +15,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "javascript": {


### PR DESCRIPTION
Runs `biome migrate` to align `biome.json` with the biome 2.5.1 bump (#94):
- `$schema` 2.4.16 → 2.5.1
- deprecated `linter.rules.recommended: true` → `linter.rules.preset: "recommended"`

Resolves the schema-version mismatch warnings that biome 2.5.1 emitted against the old config. (The remaining local `biome check` error is from the untracked, gitignored `.claude/settings.local.json` — not part of this repo or CI.)