### PR TITLE
ci: typecheck in CI + fix startTui return type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run linter
         run: bun run lint
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Run tests
         run: bun run test
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "bun run src/index.ts",
     "test": "bun --bun node_modules/.bin/vitest run",
     "lint": "bunx biome check",
+    "typecheck": "tsc --noEmit",
     "format": "bunx biome check --write",
     "build": "bun build src/index.ts --compile --outfile dist/wct",
     "build:all": "bun run scripts/build-all.ts"

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -492,7 +492,7 @@ export function App() {
   );
 }
 
-export function startTui(): Promise<void> {
+export async function startTui(): Promise<void> {
   const instance = render(<App />, { alternateScreen: true });
-  return instance.waitUntilExit();
+  await instance.waitUntilExit();
 }


### PR DESCRIPTION
Adds a TypeScript typecheck to CI and fixes the one type error it surfaces.

## Changes
- **`src/tui/App.tsx`** — `startTui` declared `Promise<void>` but returned `instance.waitUntilExit()` (`Promise<unknown>` under ink's types). Made it `async` and `await` the call so it genuinely resolves to `void`.
- **`package.json`** — new `typecheck` script (`tsc --noEmit`).
- **`.github/workflows/test.yml`** — new `Typecheck` step after the linter.

## Why
CI previously ran biome + vitest + build but never type-checked, so this error (present on TS 5.9.3 and 7.0.1-rc alike) went undetected. CI now gates on `tsc --noEmit`.

## Validation
- `bun run typecheck` → clean (exit 0).
- 777 tests pass; build succeeds.

Independent of #101 — works on the current `^5` peer TypeScript and on 7.0.1-rc.