### PR TITLE
feat(tui): add mouse support to wct tui (scroll viewport + wheel + click)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .vscode
 .superpowers/
 .scratch
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ profiles:
 
 When `ide.fork_workspace` is enabled, `wct open` copies VS Code's workspace storage (state and configuration of installed extensions, UI layout, settings) from your main repo into the new worktree. This means each worktree opens with the same extensions, sidebar state, and editor layout as your main workspace — no manual reconfiguration needed. Requires that you've opened the main repo in VS Code at least once. Supported on macOS and Linux.
 
+## TUI
+
+`wct tui` opens an interactive sidebar for browsing repos and worktrees, switching tmux sessions, and managing worktrees from the keyboard. Use `↑`/`↓` to move, `←`/`→` to expand/collapse, and the on-screen hints at the bottom for the rest.
+
+### Mouse
+
+Mouse support is **on by default**:
+
+- **Wheel** scrolls the worktree viewport one row per tick. The selection stays put and may scroll out of view — the wheel never moves the cursor.
+- **Left-click** selects the row under the cursor. Click only selects; it never activates. All activation (switching sessions, expanding) stays on the keyboard.
+
+Mouse works in the **Navigate** and **Expanded** views only; modals and Search are mouse-free. In the Expanded view, clicking a row outside the expanded worktree's subtree returns to Navigate and selects that row.
+
+**Disabling it:** set `WCT_DISABLE_MOUSE=1` to turn the whole feature off. It's an environment variable rather than a `.wct.yaml` key because the TUI is a global, cross-repo view while config is per-project.
+
+**Text selection:** while mouse reporting is on, the terminal intercepts click-drag, so its native text selection is unavailable. Hold **Shift** while dragging (works in most terminals) to bypass the app and select/copy text normally.
+
+**tmux:** if you run tmux with `set -g mouse on`, both tmux and wct enable mouse reporting and can fight over events. `WCT_DISABLE_MOUSE=1` is the escape hatch.
+
 ## Development
 
 To install dependencies:

--- a/biome.json
+++ b/biome.json
@@ -15,9 +15,34 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "ink": {
+                "importNames": ["useInput"],
+                "message": "Use useGuardedInput (src/tui/hooks/useGuardedInput.ts) instead: raw useInput handlers receive SGR mouse escape chunks as printable input and paste them into text fields."
+              }
+            }
+          }
+        }
+      }
     }
   },
+  "overrides": [
+    {
+      "includes": ["src/tui/hooks/useGuardedInput.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "double"

--- a/docs/adr/0001-navigate-independent-scroll-viewport.md
+++ b/docs/adr/0001-navigate-independent-scroll-viewport.md
@@ -1,0 +1,27 @@
+---
+status: proposed
+---
+
+# Navigate/Expanded uses an independent scroll-offset viewport
+
+To support a mouse wheel that scrolls the worktree tree without moving the
+selection, `wct tui`'s Navigate and Expanded modes gain an **independent scroll
+offset** (the viewport top is tracked separately from `selectedIndex`). This
+deliberately diverges from the only other scroll model in the app —
+`getVisibleWindow` (`src/tui/components/ScrollableList.tsx`), used by the modals,
+which is **selection-anchored** (the visible window is a pure function of the
+selection, with no independent offset).
+
+We chose independent-offset because the conventional sidebar mental model is
+"wheel scrolls content, selection stays put," which a selection-anchored window
+cannot express (if the selection doesn't move, the window doesn't move). The
+trade-off accepted: two scroll models now coexist in one codebase, keyboard
+↑/↓ must become viewport-aware (auto-scroll the offset to keep the selection
+visible), and the windowing/hit-testing must share an explicit `rows[]` model
+because visual rows are not 1:1 with logical tree items.
+
+Rejected alternative: reuse `getVisibleWindow` and have the wheel move the
+selection. Simpler and no new state, but the wheel would not behave like a
+conventional scroll.
+
+See `.scratch/tui-mouse-support/PRD.md` §6.4 and §10.

--- a/docs/adr/0002-parse-mouse-from-ink-useinput.md
+++ b/docs/adr/0002-parse-mouse-from-ink-useinput.md
@@ -1,0 +1,31 @@
+---
+status: proposed
+---
+
+# Mouse input is parsed from Ink's `useInput` string, not a second stdin listener
+
+`wct tui` reads terminal SGR mouse events (`\x1b[<…M/m`) by parsing them out of
+the `input` string Ink already hands to the existing `useInput` handler — a
+`parseSgrMouse` guard at the top of the dispatcher that consumes and `return`s
+on any mouse sequence. It does **not** attach a second `stdin.on('data', …)`
+listener.
+
+Why: Ink 7.1.0 reads stdin via `stdin.addListener('readable', …)` plus a
+`while ((chunk = stdin.read()) !== null)` drain loop and a stateful
+`createInputParser()` (`node_modules/ink/build/components/App.js`,
+`input-parser.js`), re-emitting each parsed event on an internal EventEmitter.
+A second `data` listener flips the stream into flowing mode and **races Ink's
+own `read()` loop for the same chunks**. Most reference implementations
+(Gemini CLI, octofriend, zenobi-us/ink-mouse) use the second-listener pattern;
+Gemini only gets away with it because it ships a *forked* ink. Verified on the
+installed 7.1.0: a full SGR sequence survives intact as one `input` string
+(`'[<0;45;12M'`, one leading ESC stripped), so parsing from `useInput` is both
+correct and race-free, and Ink's `pending` buffer already reassembles
+chunk-split sequences.
+
+Trade-off: we depend on an Ink-internal detail (that an unrecognised CSI
+sequence is forwarded verbatim to `useInput`). Recorded here so a future
+contributor does not "clean this up" by adding a dedicated stdin listener and
+re-introduce the read-loop race.
+
+See `.scratch/tui-mouse-support/PRD.md` §6.2 and §10.

--- a/src/cli/root-command.ts
+++ b/src/cli/root-command.ts
@@ -258,7 +258,9 @@ const projectsCliCommand = Command.make("projects").pipe(
 );
 
 const tuiCliCommand = Command.make("tui", {}, () => tuiCommand()).pipe(
-  Command.withDescription("Interactive TUI sidebar for managing worktrees"),
+  Command.withDescription(
+    "Interactive TUI sidebar for managing worktrees. Mouse on by default (wheel scrolls, click selects); set WCT_DISABLE_MOUSE=1 to disable.",
+  ),
 );
 
 export const rootCommand = Command.make("wct").pipe(

--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -5,7 +5,8 @@ import type { CommandDef } from "./command-def";
 
 export const commandDef: CommandDef = {
   name: "tui",
-  description: "Interactive TUI sidebar for managing worktrees",
+  description:
+    "Interactive TUI sidebar for managing worktrees (mouse on by default; WCT_DISABLE_MOUSE=1 to disable)",
 };
 
 export function tuiCommand(): Effect.Effect<void, WctError, WctServices> {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -18,6 +18,7 @@ import { UpModal } from "./components/UpModal";
 import { useActionError } from "./hooks/useActionError";
 import { useGitHub } from "./hooks/useGitHub";
 import { useModalActions } from "./hooks/useModalActions";
+import { useMouse } from "./hooks/useMouse";
 import { useRefresh } from "./hooks/useRefresh";
 import { useRegistry } from "./hooks/useRegistry";
 import { useSessionActions } from "./hooks/useSessionActions";
@@ -26,6 +27,11 @@ import { useTmux } from "./hooks/useTmux";
 import { handleConfirmCloseInput } from "./input/confirm-close";
 import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
+import {
+  HEADER_OFFSET,
+  parseSgrMouse,
+  resolveMouseAction,
+} from "./input/mouse";
 import type { NavigateContext } from "./input/navigate";
 import { handleNavigateInput } from "./input/navigate";
 import {
@@ -41,12 +47,15 @@ import {
 } from "./tree-helpers";
 import { Mode, type PendingAction, type PRInfo } from "./types";
 
-/** Top chrome above the tree: the `wct` header line + a blank spacer line. */
-const TOP_CHROME_ROWS = 2;
+// Top chrome above the tree: the `wct` header line + a blank spacer line. Same
+// 2 rows the mouse hit-test skips, so it is sourced from a single constant to
+// keep windowing and hit-testing aligned.
+const TOP_CHROME_ROWS = HEADER_OFFSET;
 
 export function App() {
   const { exit } = useApp();
   const { columns: termCols, rows: termRows } = useWindowSize();
+  const { disableMouse } = useMouse();
   const { repos, loading, refresh: refreshRegistry } = useRegistry();
   const {
     prData,
@@ -448,7 +457,46 @@ export function App() {
     }
   }
 
+  function handleMouse(event: ReturnType<typeof parseSgrMouse>) {
+    if (!event) return;
+    const action = resolveMouseAction(event, {
+      mode,
+      rows,
+      effectiveScrollOffset,
+      viewportRows,
+      treeItems,
+      repos: filteredRepos,
+      expandedWorktreeKey,
+    });
+    switch (action.kind) {
+      case "none":
+        return;
+      case "scroll":
+        // Wheel scrolls the viewport only; the selection is untouched.
+        setScrollOffset((prev) =>
+          clampScrollOffset(prev + action.delta, rows.length, viewportRows),
+        );
+        return;
+      case "select":
+        setSelectedIndex(action.itemIndex);
+        return;
+      case "selectAndExitExpanded":
+        setMode(Mode.Navigate);
+        setSelectedIndex(action.itemIndex);
+        return;
+    }
+  }
+
   useInput((input, key) => {
+    // Parse mouse events out of the string Ink already forwards (no second
+    // stdin listener). Swallow ANY recognised mouse sequence in EVERY mode so
+    // no escape garble reaches the screen, even in modal/Search modes.
+    const mouse = parseSgrMouse(input);
+    if (mouse) {
+      handleMouse(mouse);
+      return;
+    }
+
     if (
       input === "q" &&
       mode.type !== "OpenModal" &&
@@ -460,6 +508,9 @@ export function App() {
       mode.type !== "ConfirmClose" &&
       mode.type !== "ConfirmCloseForce"
     ) {
+      // Disable mouse reporting BEFORE exit(): Ink's handleExit turns off raw
+      // mode before React unmount, so the unmount-cleanup disable is too late.
+      disableMouse();
       exit();
       return;
     }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -179,6 +179,7 @@ export function App() {
         expandedRepos,
         expandedWorktreeKey,
         pendingActions,
+        maxWidth: termCols,
       }),
     [
       treeItems,
@@ -186,6 +187,7 @@ export function App() {
       expandedRepos,
       expandedWorktreeKey,
       pendingActions,
+      termCols,
     ],
   );
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -29,12 +29,14 @@ import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
 import {
   HEADER_OFFSET,
+  isMouseSequence,
   parseSgrMouse,
   resolveMouseAction,
 } from "./input/mouse";
 import type { NavigateContext } from "./input/navigate";
 import { handleNavigateInput } from "./input/navigate";
 import {
+  adjustIndexForDetailCollapse,
   buildTreeItems,
   buildTreeRows,
   clampScrollOffset,
@@ -235,6 +237,15 @@ export function App() {
   const prevSelectionIdRef = useRef<string | null>(null);
   const prevSearchQueryRef = useRef(searchQuery);
 
+  // selectionChanged distinguishes a deliberate selection change (e.g. a
+  // mouse click) from a background refresh that only produced new object
+  // references with the same selectedIndex. It's a const computed once
+  // during render, from the ref's value as of the last commit — so every
+  // effect below that closes over it this render sees the same, consistent
+  // answer. The ref itself is written exactly once, in the trailing effect.
+  const prevSelectedIndexRef = useRef(selectedIndex);
+  const selectionChanged = selectedIndex !== prevSelectedIndexRef.current;
+
   useEffect(() => {
     const prevTree = prevTreeRef.current;
     const prevId = prevSelectionIdRef.current;
@@ -254,12 +265,16 @@ export function App() {
     const item = treeItems[selectedIndex];
     prevSelectionIdRef.current = item ? treeItemId(item, filteredRepos) : null;
 
+    // Skip identity recovery for a deliberate selection change (e.g. a mouse
+    // click that also collapsed Expanded) — otherwise it sees the new
+    // selection's identity mismatch the old one and "recovers" back to it.
     const recoveredIndex = resolveRecoveredSelectionIndex({
       prevTree,
       treeItems,
       prevSelectionId: prevId,
       selectedIndex,
       repos: filteredRepos,
+      skipIdentityRecovery: selectionChanged,
     });
     if (recoveredIndex !== null && recoveredIndex !== selectedIndex) {
       setSelectedIndex(recoveredIndex);
@@ -277,19 +292,31 @@ export function App() {
     searchQuery,
     rows,
     viewportRows,
+    selectionChanged,
   ]);
 
-  // Keyboard ↑/↓ are viewport-aware: after a navigation moves selectedIndex,
-  // nudge the scroll offset minimally to keep the selection on screen. Keyed on
-  // [selectedIndex, rows, viewportRows] but NOT scrollOffset, and uses a
-  // functional update so it never fights a future wheel scroll (slice 02).
+  // Keyboard ↑/↓ (and mouse clicks) are viewport-aware: after a DELIBERATE
+  // selection change, nudge the scroll offset minimally to keep the selection
+  // on screen. Gated on `selectionChanged` so a background refresh that gives
+  // `rows` a new reference (useRegistry always calls setRepos, even when
+  // content is unchanged) does not re-fire this and snap a wheel-scrolled
+  // viewport back to the selection. Keyed on [selectedIndex, rows,
+  // viewportRows] but NOT scrollOffset, and uses a functional update so it
+  // never fights a future wheel scroll (slice 02).
   useEffect(() => {
+    if (!selectionChanged) return;
     const rowIndex = firstRowForItem(rows, selectedIndex);
     if (rowIndex === null) return;
     setScrollOffset((prev) =>
       scrollToKeepVisible(rowIndex, prev, viewportRows),
     );
-  }, [selectedIndex, rows, viewportRows]);
+  }, [selectedIndex, rows, viewportRows, selectionChanged]);
+
+  // The only place that writes prevSelectedIndexRef, keeping it in sync with
+  // selectedIndex for the next render's selectionChanged computation.
+  useEffect(() => {
+    prevSelectedIndexRef.current = selectedIndex;
+  }, [selectedIndex]);
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
@@ -480,20 +507,36 @@ export function App() {
       case "select":
         setSelectedIndex(action.itemIndex);
         return;
-      case "selectAndExitExpanded":
+      case "selectAndExitExpanded": {
+        // Collapsing Expanded can remove the clicked item's detail rows (if
+        // the previously-expanded worktree had a PR/tmux detail row), which
+        // shifts every later item's index. Adjust the clicked itemIndex for
+        // that collapse the same way the keyboard left-arrow/escape path does
+        // (src/tui/input/expanded.ts) so the cursor lands on the row the user
+        // actually clicked, not a stale post-collapse index.
         setMode(Mode.Navigate);
-        setSelectedIndex(action.itemIndex);
+        setSelectedIndex(
+          adjustIndexForDetailCollapse(treeItems, action.itemIndex),
+        );
         return;
+      }
     }
   }
 
   useInput((input, key) => {
     // Parse mouse events out of the string Ink already forwards (no second
-    // stdin listener). Swallow ANY recognised mouse sequence in EVERY mode so
-    // no escape garble reaches the screen, even in modal/Search modes.
-    const mouse = parseSgrMouse(input);
-    if (mouse) {
-      handleMouse(mouse);
+    // stdin listener). Swallow ANY SGR mouse sequence in EVERY mode so no
+    // escape garble reaches the screen, even in modal/Search modes — this
+    // includes release/motion/extra-button sequences that `parseSgrMouse`
+    // resolves to `null` because they aren't actionable. A single click emits
+    // both a press AND a release sequence; without this shape-based guard the
+    // release half falls through to mode-specific handlers (e.g. corrupting
+    // the Search query with raw escape bytes).
+    if (isMouseSequence(input)) {
+      const mouse = parseSgrMouse(input);
+      if (mouse) {
+        handleMouse(mouse);
+      }
       return;
     }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,14 +1,6 @@
 // src/tui/App.tsx
 
-import {
-  Box,
-  type Key,
-  render,
-  Text,
-  useApp,
-  useInput,
-  useWindowSize,
-} from "ink";
+import { Box, type Key, render, Text, useApp, useWindowSize } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddProjectModal } from "./components/AddProjectModal";
 import { OpenModal } from "./components/OpenModal";
@@ -17,6 +9,7 @@ import { TreeView } from "./components/TreeView";
 import { UpModal } from "./components/UpModal";
 import { useActionError } from "./hooks/useActionError";
 import { useGitHub } from "./hooks/useGitHub";
+import { useGuardedInput } from "./hooks/useGuardedInput";
 import { useModalActions } from "./hooks/useModalActions";
 import { useMouse } from "./hooks/useMouse";
 import { useRefresh } from "./hooks/useRefresh";
@@ -29,8 +22,7 @@ import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
 import {
   HEADER_OFFSET,
-  isMouseSequence,
-  parseSgrMouse,
+  type MouseEvent,
   resolveMouseAction,
 } from "./input/mouse";
 import type { NavigateContext } from "./input/navigate";
@@ -489,8 +481,7 @@ export function App() {
     }
   }
 
-  function handleMouse(event: ReturnType<typeof parseSgrMouse>) {
-    if (!event) return;
+  function handleMouse(event: MouseEvent) {
     const action = resolveMouseAction(event, {
       mode,
       rows,
@@ -528,73 +519,67 @@ export function App() {
     }
   }
 
-  useInput((input, key) => {
-    // Parse mouse events out of the string Ink already forwards (no second
-    // stdin listener). Swallow ANY SGR mouse sequence in EVERY mode so no
-    // escape garble reaches the screen, even in modal/Search modes — this
-    // includes release/motion/extra-button sequences that `parseSgrMouse`
-    // resolves to `null` because they aren't actionable. A single click emits
-    // both a press AND a release sequence; without this shape-based guard the
-    // release half falls through to mode-specific handlers (e.g. corrupting
-    // the Search query with raw escape bytes).
-    if (isMouseSequence(input)) {
-      const mouse = parseSgrMouse(input);
-      if (mouse) {
-        handleMouse(mouse);
-      }
-      return;
-    }
-
-    if (
-      input === "q" &&
-      mode.type !== "OpenModal" &&
-      mode.type !== "UpModal" &&
-      mode.type !== "AddProjectModal" &&
-      mode.type !== "Search" &&
-      mode.type !== "ConfirmKill" &&
-      mode.type !== "ConfirmDown" &&
-      mode.type !== "ConfirmClose" &&
-      mode.type !== "ConfirmCloseForce"
-    ) {
-      // Disable mouse reporting BEFORE exit(): Ink's handleExit turns off raw
-      // mode before React unmount, so the unmount-cleanup disable is too late.
-      disableMouse();
-      exit();
-      return;
-    }
-
-    switch (mode.type) {
-      case "Navigate":
-        return handleNavigateInput(navCtx, input, key);
-      case "Search":
-        return handleSearchInput(input, key);
-      case "OpenModal":
-      case "UpModal":
-      case "AddProjectModal":
+  // useGuardedInput parses mouse events out of the string Ink already forwards
+  // (no second stdin listener, ADR 0002) and swallows ANY SGR mouse sequence
+  // in EVERY mode — including release/motion/extra-button sequences, and
+  // multi-sequence strings from Ink's paste-fallback path (normal stdin
+  // delivery is one sequence per event) — so no escape garble ever reaches
+  // the handler below (or any other useGuardedInput handler, e.g. the modals'
+  // text inputs). Actionable events arrive via onMouseEvent, in order.
+  useGuardedInput(
+    (input, key) => {
+      if (
+        input === "q" &&
+        mode.type !== "OpenModal" &&
+        mode.type !== "UpModal" &&
+        mode.type !== "AddProjectModal" &&
+        mode.type !== "Search" &&
+        mode.type !== "ConfirmKill" &&
+        mode.type !== "ConfirmDown" &&
+        mode.type !== "ConfirmClose" &&
+        mode.type !== "ConfirmCloseForce"
+      ) {
+        // Disable mouse reporting BEFORE exit(): Ink's handleExit turns off raw
+        // mode before React unmount, so the unmount-cleanup disable is too late.
+        disableMouse();
+        exit();
         return;
-      case "Expanded":
-        return handleExpandedInput(expCtx, input, key);
-      case "ConfirmKill":
-        return handleConfirmKillInput(input, key);
-      case "ConfirmDown":
-        return handleConfirmDownInput(input, key);
-      case "ConfirmClose":
-      case "ConfirmCloseForce":
-        return handleConfirmCloseInput(
-          {
-            mode,
-            returnMode: confirmCloseReturnModeRef.current,
-            returnSelectedIndex: confirmCloseReturnSelectedIndexRef.current,
-            setMode,
-            setSelectedIndex,
-            executeClose: (...args) =>
-              void sessionActions.executeClose(...args),
-          },
-          input,
-          key,
-        );
-    }
-  });
+      }
+
+      switch (mode.type) {
+        case "Navigate":
+          return handleNavigateInput(navCtx, input, key);
+        case "Search":
+          return handleSearchInput(input, key);
+        case "OpenModal":
+        case "UpModal":
+        case "AddProjectModal":
+          return;
+        case "Expanded":
+          return handleExpandedInput(expCtx, input, key);
+        case "ConfirmKill":
+          return handleConfirmKillInput(input, key);
+        case "ConfirmDown":
+          return handleConfirmDownInput(input, key);
+        case "ConfirmClose":
+        case "ConfirmCloseForce":
+          return handleConfirmCloseInput(
+            {
+              mode,
+              returnMode: confirmCloseReturnModeRef.current,
+              returnSelectedIndex: confirmCloseReturnSelectedIndexRef.current,
+              setMode,
+              setSelectedIndex,
+              executeClose: (...args) =>
+                void sessionActions.executeClose(...args),
+            },
+            input,
+            key,
+          );
+      }
+    },
+    { onMouseEvent: handleMouse },
+  );
 
   if (loading) {
     return (

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -259,6 +259,11 @@ export function App() {
     if (searchQueryChanged) {
       // Search transitions intentionally reset the cursor to the first match.
       prevSelectionIdRef.current = null;
+      // Reset the scroll explicitly: when the cursor was already at index 0
+      // (e.g. after a wheel scroll), setSelectedIndex(0) is a no-op, so
+      // `selectionChanged` stays false and the keep-visible effect below never
+      // fires — leaving the first match scrolled off-screen without this.
+      setScrollOffset(0);
       return;
     }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -4,7 +4,7 @@ import { Box, type Key, render, Text, useApp, useWindowSize } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddProjectModal } from "./components/AddProjectModal";
 import { OpenModal } from "./components/OpenModal";
-import { StatusBar } from "./components/StatusBar";
+import { StatusBar, statusBarRowCount } from "./components/StatusBar";
 import { TreeView } from "./components/TreeView";
 import { UpModal } from "./components/UpModal";
 import { useActionError } from "./hooks/useActionError";
@@ -40,6 +40,7 @@ import {
   treeItemId,
 } from "./tree-helpers";
 import { Mode, type PendingAction, type PRInfo } from "./types";
+import { toSingleLine } from "./utils/truncate";
 
 // Top chrome above the tree: the `wct` header line + a blank spacer line. Same
 // 2 rows the mouse hit-test skips, so it is sourced from a single constant to
@@ -191,36 +192,30 @@ export function App() {
     ],
   );
 
-  // The 3 true modals do not scroll the tree — rendering it in full keeps the
-  // modal on-screen. The interactive layout (Navigate/Expanded/Search) windows
-  // the tree under the StatusBar + optional error lines.
-  const isTrueModal =
-    mode.type === "OpenModal" ||
-    mode.type === "UpModal" ||
-    mode.type === "AddProjectModal";
+  // Bottom chrome: optional tmux/action error line (mutually exclusive, so at
+  // most one row) + the StatusBar's rows — counted by statusBarRowCount, the
+  // helper co-located with StatusBar's render branches so the budget cannot
+  // drift from what it renders. Every chrome line renders with wrap="truncate"
+  // AND is collapsed to a single line (toSingleLine), so each one is exactly
+  // one terminal row at any width and for any message — otherwise the budget
+  // would under-count, and the overflowing layout would misalign mouse
+  // hit-testing.
+  //
+  // True modals (OpenModal/UpModal/AddProjectModal) replace the StatusBar but
+  // budget the SAME virtual row count: viewportRows must not change when a
+  // modal opens, or the clamp/keep-visible effects would rewrite a
+  // wheel-scrolled offset the user expects back on cancel. The modal being
+  // taller than the budgeted chrome is absorbed by the tree box's
+  // overflowY="hidden" clipping (see the render below), which keeps the modal
+  // fully on-screen without inflating the viewport.
+  const bottomChromeRows =
+    statusBarRowCount(mode, Boolean(repoError)) +
+    (tmuxError || actionError ? 1 : 0);
 
-  // Bottom chrome in the interactive layout: optional tmux/action error line
-  // (mutually exclusive) + StatusBar (1 divider + optional repoError line + 2
-  // hint lines). Search renders an extra query line in place of one hint, but
-  // the line count stays at 3 either way. StatusBar only renders the repoError
-  // line in its default Navigate/Expanded branch (Confirm/Search return early),
-  // so only budget for it there. Every chrome line renders with
-  // wrap="truncate" (here and in StatusBar), so each one is exactly one
-  // terminal row at any width — otherwise a narrow terminal would wrap a hint
-  // or error line, the budget would under-count, and the overflowing layout
-  // would misalign mouse hit-testing.
-  const bottomChromeRows = isTrueModal
-    ? 0
-    : 1 + // divider
-      2 + // two hint lines (or query + hint in Search)
-      (repoError && (mode.type === "Navigate" || mode.type === "Expanded")
-        ? 1
-        : 0) +
-      ((tmuxError && !actionError) || actionError ? 1 : 0);
-
-  const viewportRows = isTrueModal
-    ? Math.max(1, rows.length)
-    : Math.max(1, termRows - TOP_CHROME_ROWS - bottomChromeRows);
+  const viewportRows = Math.max(
+    1,
+    termRows - TOP_CHROME_ROWS - bottomChromeRows,
+  );
 
   const effectiveScrollOffset = clampScrollOffset(
     scrollOffset,
@@ -231,6 +226,18 @@ export function App() {
   // Identity-based selection recovery: when the tree structure changes
   // (background refresh, async worktree add/remove), find the previously-
   // selected item by stable identity instead of blindly clamping by length.
+  //
+  // INVARIANT for prevSelectionIdRef: the recovery effect treats it as "the
+  // selected item's identity as of the last commit" and normally rewrites it
+  // exactly once per commit. Any handler that BOTH reshapes the tree AND
+  // moves the selection to a different item in the same commit must pre-write
+  // the ref with the NEW selection's identity before calling setSelectedIndex
+  // (see selectAndExitExpanded in handleMouse): when the new index collides
+  // with the current one, setSelectedIndex is a no-op, selectionChanged stays
+  // false, and recovery would otherwise chase the OLD identity through the
+  // reshaped tree and snap the cursor back. Handlers that only move the
+  // selection (no reshape) or preserve the selected item's identity are safe
+  // without it.
   const prevTreeRef = useRef(treeItems);
   const prevSelectionIdRef = useRef<string | null>(null);
   const prevSearchQueryRef = useRef(searchQuery);
@@ -606,6 +613,19 @@ export function App() {
   // text inputs). Actionable events arrive via onMouseEvent, in order.
   useGuardedInput(
     (input, key) => {
+      // Ctrl+C exits from EVERY mode (parity with Ink's default), but through
+      // the same disable-mouse-first sequence as `q`: startTui renders with
+      // exitOnCtrlC: false precisely so Ctrl+C reaches this handler instead
+      // of Ink's own \x03 shortcut, whose handleExit turns off raw mode
+      // before React unmount — too late for the unmount-cleanup disable, so
+      // mouse reports emitted in that window would echo as escape garbage on
+      // the shell prompt after exit.
+      if (key.ctrl && input === "c") {
+        disableMouse();
+        exit();
+        return;
+      }
+
       if (
         input === "q" &&
         mode.type !== "OpenModal" &&
@@ -670,85 +690,118 @@ export function App() {
 
   return (
     <Box flexDirection="column" height={termRows}>
-      <Text bold>wct</Text>
-      <Text> </Text>
-      <Box flexDirection="column" flexGrow={1}>
-        <TreeView
-          repos={filteredRepos}
-          sessions={sessions}
-          expandedRepos={expandedRepos}
-          selectedIndex={selectedIndex}
-          items={treeItems}
-          pendingActions={pendingActions}
-          prData={prData}
-          panes={panes}
-          expandedWorktreeKey={expandedWorktreeKey}
-          maxWidth={termCols}
-          refreshingProjects={refreshingProjects}
-          errors={githubErrors}
-          scrollOffset={effectiveScrollOffset}
-          viewportRows={viewportRows}
-        />
+      {/* Every sibling of the tree box is flexShrink={0}: when the content
+          exceeds termRows, the tree box must be the ONLY thing Yoga shrinks —
+          otherwise the header/spacer lines get squeezed to zero height and
+          later rows paint over them. */}
+      <Box flexDirection="column" flexShrink={0}>
+        <Text bold>wct</Text>
+        <Text> </Text>
       </Box>
-      {mode.type === "OpenModal" ? (
-        <OpenModal
-          visible
-          width={Math.min(termCols, 60)}
-          defaultBase={openModalBase ?? ""}
-          profileNames={openModalProfiles}
-          repoProject={openModalRepoProject}
-          repoPath={openModalRepoPath}
-          ideDefaults={openModalIdeDefaults}
-          prList={openModalPRList}
-          isRefreshing={refreshingProjects.has(openModalRepoProject)}
-          onRefresh={openModalOnRefresh}
-          onSubmit={modalActions.handleOpen}
-          onCancel={() => setMode(Mode.Navigate)}
-        />
-      ) : mode.type === "UpModal" ? (
-        <UpModal
-          visible
-          width={Math.min(termCols, 60)}
-          profileNames={mode.profileNames}
-          ideDefaults={mode.ideDefaults}
-          onSubmit={modalActions.handleUpSubmit}
-          onCancel={() => {
-            setSelectedIndex(upModalReturnSelectedIndexRef.current);
-            setMode(upModalReturnModeRef.current);
-          }}
-        />
-      ) : mode.type === "AddProjectModal" ? (
-        <AddProjectModal
-          visible
-          width={Math.min(termCols, 60)}
-          onSubmit={modalActions.handleAddProject}
-          onCancel={() => setMode(Mode.Navigate)}
-        />
-      ) : (
-        <Box flexDirection="column">
-          {tmuxError && !actionError ? (
-            <Text color="yellow" wrap="truncate">
-              {tmuxError}
-            </Text>
-          ) : null}
-          {actionError ? (
-            <Text color="red" wrap="truncate">
-              {actionError}
-            </Text>
-          ) : null}
-          <StatusBar
-            {...statusBarProps}
-            searchQuery={searchQuery}
-            hasClient={tmuxClient !== null}
-            repoError={repoError}
+      {/* overflowY="hidden" + flexShrink is what lets a true modal exceed the
+          budgeted bottom-chrome rows: Yoga shrinks THIS box and the excess
+          tree rows clip cleanly at its bottom edge, instead of the
+          overflowing frame painting over the modal. The inner flexShrink={0}
+          wrapper keeps the rows at their natural height so they overflow (and
+          clip) rather than being squeezed into interleaved garbage. In the
+          interactive layout the tree content equals the budget exactly, so
+          nothing is ever clipped there. */}
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={1}
+        overflowY="hidden"
+      >
+        <Box flexDirection="column" flexShrink={0}>
+          <TreeView
+            repos={filteredRepos}
+            sessions={sessions}
+            expandedRepos={expandedRepos}
+            selectedIndex={selectedIndex}
+            items={treeItems}
+            rows={rows}
+            pendingActions={pendingActions}
+            prData={prData}
+            panes={panes}
+            expandedWorktreeKey={expandedWorktreeKey}
+            maxWidth={termCols}
+            refreshingProjects={refreshingProjects}
+            errors={githubErrors}
+            scrollOffset={effectiveScrollOffset}
+            viewportRows={viewportRows}
           />
         </Box>
-      )}
+      </Box>
+      {/* flexShrink={0} pins the bottom area (modal or status chrome) to its
+          natural height so the tree box above is the only child Yoga shrinks. */}
+      <Box flexDirection="column" flexShrink={0}>
+        {mode.type === "OpenModal" ? (
+          <OpenModal
+            visible
+            width={Math.min(termCols, 60)}
+            defaultBase={openModalBase ?? ""}
+            profileNames={openModalProfiles}
+            repoProject={openModalRepoProject}
+            repoPath={openModalRepoPath}
+            ideDefaults={openModalIdeDefaults}
+            prList={openModalPRList}
+            isRefreshing={refreshingProjects.has(openModalRepoProject)}
+            onRefresh={openModalOnRefresh}
+            onSubmit={modalActions.handleOpen}
+            onCancel={() => setMode(Mode.Navigate)}
+          />
+        ) : mode.type === "UpModal" ? (
+          <UpModal
+            visible
+            width={Math.min(termCols, 60)}
+            profileNames={mode.profileNames}
+            ideDefaults={mode.ideDefaults}
+            onSubmit={modalActions.handleUpSubmit}
+            onCancel={() => {
+              setSelectedIndex(upModalReturnSelectedIndexRef.current);
+              setMode(upModalReturnModeRef.current);
+            }}
+          />
+        ) : mode.type === "AddProjectModal" ? (
+          <AddProjectModal
+            visible
+            width={Math.min(termCols, 60)}
+            onSubmit={modalActions.handleAddProject}
+            onCancel={() => setMode(Mode.Navigate)}
+          />
+        ) : (
+          <Box flexDirection="column">
+            {tmuxError && !actionError ? (
+              <Text color="yellow" wrap="truncate">
+                {toSingleLine(tmuxError)}
+              </Text>
+            ) : null}
+            {actionError ? (
+              <Text color="red" wrap="truncate">
+                {toSingleLine(actionError)}
+              </Text>
+            ) : null}
+            <StatusBar
+              {...statusBarProps}
+              searchQuery={searchQuery}
+              hasClient={tmuxClient !== null}
+              repoError={repoError}
+            />
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }
 
 export async function startTui(): Promise<void> {
-  const instance = render(<App />, { alternateScreen: true });
+  // exitOnCtrlC stays OFF: the guarded input dispatcher in App owns Ctrl+C so
+  // it can write MOUSE_DISABLE before Ink turns raw mode off (Ink's built-in
+  // \x03 shortcut disables raw mode before React unmount, which would leak
+  // mouse reports onto the shell — the same ordering bug the `q` path avoids).
+  const instance = render(<App />, {
+    alternateScreen: true,
+    exitOnCtrlC: false,
+  });
   await instance.waitUntilExit();
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -30,12 +30,19 @@ import type { NavigateContext } from "./input/navigate";
 import { handleNavigateInput } from "./input/navigate";
 import {
   buildTreeItems,
+  buildTreeRows,
+  clampScrollOffset,
   findOwningWorktreeIndex,
+  firstRowForItem,
   resolveRecoveredSelectionIndex,
   resolveStatusBarProps,
+  scrollToKeepVisible,
   treeItemId,
 } from "./tree-helpers";
 import { Mode, type PendingAction, type PRInfo } from "./types";
+
+/** Top chrome above the tree: the `wct` header line + a blank spacer line. */
+const TOP_CHROME_ROWS = 2;
 
 export function App() {
   const { exit } = useApp();
@@ -64,6 +71,7 @@ export function App() {
   const [expandedRepos, setExpandedRepos] = useState<Set<string>>(new Set());
   const [didInitialExpand, setDidInitialExpand] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
   const [openModalBase, setOpenModalBase] = useState<string | undefined>();
   const [openModalProfiles, setOpenModalProfiles] = useState<string[]>([]);
   const [openModalRepoProject, setOpenModalRepoProject] = useState("");
@@ -147,6 +155,70 @@ export function App() {
     ],
   );
 
+  const statusBarProps = resolveStatusBarProps({
+    mode,
+    items: treeItems,
+    selectedIndex,
+    repos: filteredRepos,
+  });
+
+  const repoError = statusBarProps.selectedProject
+    ? githubErrors.get(statusBarProps.selectedProject)
+    : undefined;
+
+  // The shared visual-row model drives both windowing here and the row-by-row
+  // render in TreeView. Logical items are not 1:1 with terminal rows.
+  const rows = useMemo(
+    () =>
+      buildTreeRows({
+        items: treeItems,
+        repos: filteredRepos,
+        expandedRepos,
+        expandedWorktreeKey,
+        pendingActions,
+      }),
+    [
+      treeItems,
+      filteredRepos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions,
+    ],
+  );
+
+  // The 3 true modals do not scroll the tree — rendering it in full keeps the
+  // modal on-screen. The interactive layout (Navigate/Expanded/Search) windows
+  // the tree under the StatusBar + optional error lines.
+  const isTrueModal =
+    mode.type === "OpenModal" ||
+    mode.type === "UpModal" ||
+    mode.type === "AddProjectModal";
+
+  // Bottom chrome in the interactive layout: optional tmux/action error line
+  // (mutually exclusive) + StatusBar (1 divider + optional repoError line + 2
+  // hint lines). Search renders an extra query line in place of one hint, but
+  // the line count stays at 3 either way. StatusBar only renders the repoError
+  // line in its default Navigate/Expanded branch (Confirm/Search return early),
+  // so only budget for it there.
+  const bottomChromeRows = isTrueModal
+    ? 0
+    : 1 + // divider
+      2 + // two hint lines (or query + hint in Search)
+      (repoError && (mode.type === "Navigate" || mode.type === "Expanded")
+        ? 1
+        : 0) +
+      ((tmuxError && !actionError) || actionError ? 1 : 0);
+
+  const viewportRows = isTrueModal
+    ? Math.max(1, rows.length)
+    : Math.max(1, termRows - TOP_CHROME_ROWS - bottomChromeRows);
+
+  const effectiveScrollOffset = clampScrollOffset(
+    scrollOffset,
+    rows.length,
+    viewportRows,
+  );
+
   // Identity-based selection recovery: when the tree structure changes
   // (background refresh, async worktree add/remove), find the previously-
   // selected item by stable identity instead of blindly clamping by length.
@@ -183,14 +255,32 @@ export function App() {
     if (recoveredIndex !== null && recoveredIndex !== selectedIndex) {
       setSelectedIndex(recoveredIndex);
     }
-  }, [treeItems, selectedIndex, filteredRepos, searchQuery]);
 
-  const statusBarProps = resolveStatusBarProps({
-    mode,
-    items: treeItems,
+    // Keep the scroll offset valid after a background refresh so it can't
+    // desync from the selection (e.g. rows removed below the window).
+    setScrollOffset((prev) =>
+      clampScrollOffset(prev, rows.length, viewportRows),
+    );
+  }, [
+    treeItems,
     selectedIndex,
-    repos: filteredRepos,
-  });
+    filteredRepos,
+    searchQuery,
+    rows,
+    viewportRows,
+  ]);
+
+  // Keyboard ↑/↓ are viewport-aware: after a navigation moves selectedIndex,
+  // nudge the scroll offset minimally to keep the selection on screen. Keyed on
+  // [selectedIndex, rows, viewportRows] but NOT scrollOffset, and uses a
+  // functional update so it never fights a future wheel scroll (slice 02).
+  useEffect(() => {
+    const rowIndex = firstRowForItem(rows, selectedIndex);
+    if (rowIndex === null) return;
+    setScrollOffset((prev) =>
+      scrollToKeepVisible(rowIndex, prev, viewportRows),
+    );
+  }, [selectedIndex, rows, viewportRows]);
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
@@ -434,6 +524,8 @@ export function App() {
           maxWidth={termCols}
           refreshingProjects={refreshingProjects}
           errors={githubErrors}
+          scrollOffset={effectiveScrollOffset}
+          viewportRows={viewportRows}
         />
       </Box>
       {mode.type === "OpenModal" ? (
@@ -480,11 +572,7 @@ export function App() {
             {...statusBarProps}
             searchQuery={searchQuery}
             hasClient={tmuxClient !== null}
-            repoError={
-              statusBarProps.selectedProject
-                ? githubErrors.get(statusBarProps.selectedProject)
-                : undefined
-            }
+            repoError={repoError}
           />
         </Box>
       )}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -204,7 +204,11 @@ export function App() {
   // hint lines). Search renders an extra query line in place of one hint, but
   // the line count stays at 3 either way. StatusBar only renders the repoError
   // line in its default Navigate/Expanded branch (Confirm/Search return early),
-  // so only budget for it there.
+  // so only budget for it there. Every chrome line renders with
+  // wrap="truncate" (here and in StatusBar), so each one is exactly one
+  // terminal row at any width — otherwise a narrow terminal would wrap a hint
+  // or error line, the budget would under-count, and the overflowing layout
+  // would misalign mouse hit-testing.
   const bottomChromeRows = isTrueModal
     ? 0
     : 1 + // divider
@@ -239,6 +243,17 @@ export function App() {
   // answer. The ref itself is written exactly once, in the trailing effect.
   const prevSelectedIndexRef = useRef(selectedIndex);
   const selectionChanged = selectedIndex !== prevSelectedIndexRef.current;
+
+  // viewportShrank mirrors selectionChanged for the viewport dimension: an
+  // action/repo error line appearing or the terminal being resized shorter
+  // shrinks viewportRows without any selection change. The clamp in the
+  // recovery effect below can only ever DECREASE the offset (and a shrink
+  // raises the max offset, so it does nothing), so without this signal a
+  // selection sitting on the last visible row would silently fall below the
+  // window with no path to bring it back until the next navigation key.
+  const prevViewportRowsRef = useRef(viewportRows);
+  const prevViewportRows = prevViewportRowsRef.current;
+  const viewportShrank = viewportRows < prevViewportRows;
 
   useEffect(() => {
     const prevTree = prevTreeRef.current;
@@ -299,23 +314,41 @@ export function App() {
   // on screen. Gated on `selectionChanged` so a background refresh that gives
   // `rows` a new reference (useRegistry always calls setRepos, even when
   // content is unchanged) does not re-fire this and snap a wheel-scrolled
-  // viewport back to the selection. Keyed on [selectedIndex, rows,
-  // viewportRows] but NOT scrollOffset, and uses a functional update so it
-  // never fights a future wheel scroll (slice 02).
+  // viewport back to the selection. A viewport SHRINK also re-fires it — but
+  // only re-anchors when the shrink actually hid a previously-visible
+  // selection, so a wheel-scrolled viewport whose selection was already
+  // off-screen stays put. Keyed on [selectedIndex, rows, viewportRows] but
+  // NOT scrollOffset, and uses a functional update so it never fights a
+  // future wheel scroll (slice 02).
   useEffect(() => {
-    if (!selectionChanged) return;
+    if (!selectionChanged && !viewportShrank) return;
     const rowIndex = firstRowForItem(rows, selectedIndex);
     if (rowIndex === null) return;
-    setScrollOffset((prev) =>
-      scrollToKeepVisible(rowIndex, prev, viewportRows),
-    );
-  }, [selectedIndex, rows, viewportRows, selectionChanged]);
+    setScrollOffset((prev) => {
+      if (!selectionChanged) {
+        const wasVisible =
+          rowIndex >= prev && rowIndex < prev + prevViewportRows;
+        if (!wasVisible) return prev;
+      }
+      return scrollToKeepVisible(rowIndex, prev, viewportRows);
+    });
+  }, [
+    selectedIndex,
+    rows,
+    viewportRows,
+    selectionChanged,
+    viewportShrank,
+    prevViewportRows,
+  ]);
 
-  // The only place that writes prevSelectedIndexRef, keeping it in sync with
-  // selectedIndex for the next render's selectionChanged computation.
+  // The only place these refs are written, keeping them in sync for the next
+  // render's selectionChanged/viewportShrank computations.
   useEffect(() => {
     prevSelectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);
+  useEffect(() => {
+    prevViewportRowsRef.current = viewportRows;
+  }, [viewportRows]);
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
@@ -512,6 +545,19 @@ export function App() {
         // that collapse the same way the keyboard left-arrow/escape path does
         // (src/tui/input/expanded.ts) so the cursor lands on the row the user
         // actually clicked, not a stale post-collapse index.
+        //
+        // The adjusted index can equal the CURRENT selectedIndex (the clicked
+        // row's post-collapse position collides with the cursor's pre-collapse
+        // one, e.g. rows [A, PR detail, B(selected), C(clicked)]). Then
+        // setSelectedIndex is a no-op, selectionChanged stays false, and the
+        // identity-recovery effect would treat the collapse as a background
+        // tree change and snap the cursor back to the old item. Pre-store the
+        // clicked item's identity (stable across the collapse) so recovery
+        // sees the clicked row as already-current and stays put.
+        const clicked = treeItems[action.itemIndex];
+        prevSelectionIdRef.current = clicked
+          ? treeItemId(clicked, filteredRepos)
+          : null;
         setMode(Mode.Navigate);
         setSelectedIndex(
           adjustIndexForDetailCollapse(treeItems, action.itemIndex),
@@ -651,9 +697,15 @@ export function App() {
       ) : (
         <Box flexDirection="column">
           {tmuxError && !actionError ? (
-            <Text color="yellow">{tmuxError}</Text>
+            <Text color="yellow" wrap="truncate">
+              {tmuxError}
+            </Text>
           ) : null}
-          {actionError ? <Text color="red">{actionError}</Text> : null}
+          {actionError ? (
+            <Text color="red" wrap="truncate">
+              {actionError}
+            </Text>
+          ) : null}
           <StatusBar
             {...statusBarProps}
             searchQuery={searchQuery}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -506,7 +506,14 @@ export function App() {
     } else if (key.return) {
       setMode(Mode.Navigate);
     } else if (input && !key.ctrl && !key.meta) {
-      setSearchQuery((q) => q + input);
+      // Ink's bracketed-paste fallback can deliver a multi-line string as ONE
+      // input event. StatusBar budgets the query as exactly one terminal row
+      // and wrap="truncate" cannot remove embedded newlines, so an
+      // un-collapsed paste would render extra chrome rows and desync mouse
+      // hit-testing. Collapse every CR/LF run (with surrounding indentation)
+      // to a single space — NOT toSingleLine(), whose trim would drop a
+      // legitimate lone-space keystroke.
+      setSearchQuery((q) => q + input.replace(/[ \t]*[\r\n]\s*/g, " "));
     }
   }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -244,16 +244,31 @@ export function App() {
   const prevSelectedIndexRef = useRef(selectedIndex);
   const selectionChanged = selectedIndex !== prevSelectedIndexRef.current;
 
-  // viewportShrank mirrors selectionChanged for the viewport dimension: an
-  // action/repo error line appearing or the terminal being resized shorter
-  // shrinks viewportRows without any selection change. The clamp in the
-  // recovery effect below can only ever DECREASE the offset (and a shrink
-  // raises the max offset, so it does nothing), so without this signal a
-  // selection sitting on the last visible row would silently fall below the
-  // window with no path to bring it back until the next navigation key.
+  // prevSelectionWasVisibleRef mirrors selectionChanged for PASSIVE layout
+  // changes — ones that move the selection's visual row or the window without
+  // touching selectedIndex: the viewport shrinking (an action/repo error line
+  // appearing, the terminal resized shorter) or rows above the selection
+  // reflowing (a PR title wrapping differently after a width change, a check
+  // rollup arriving, phantom rows appearing). The clamp in the recovery
+  // effect below can only ever DECREASE the offset, so without this signal a
+  // selection sitting on a visible row could silently leave the window with
+  // no path back until the next navigation key. Tracked as "was the selection
+  // visible last commit" rather than one signal per cause so every passive
+  // cause is covered, while a wheel-scrolled viewport whose selection was
+  // already off-screen stays put.
+  const selectionRowIndex = firstRowForItem(rows, selectedIndex);
+  const selectionVisible =
+    selectionRowIndex !== null &&
+    selectionRowIndex >= effectiveScrollOffset &&
+    selectionRowIndex < effectiveScrollOffset + viewportRows;
+  const prevSelectionWasVisibleRef = useRef(selectionVisible);
+  // Last commit's row/viewport values, so the keep-visible effect can tell a
+  // REAL passive layout change apart from merely having re-run: its deps also
+  // re-fire it on the falling edge of selectionChanged (true → false on the
+  // commit after a deliberate change), where re-anchoring would undo a wheel
+  // tick that just hid the still-"was visible" selection.
+  const prevSelectionRowIndexRef = useRef(selectionRowIndex);
   const prevViewportRowsRef = useRef(viewportRows);
-  const prevViewportRows = prevViewportRowsRef.current;
-  const viewportShrank = viewportRows < prevViewportRows;
 
   useEffect(() => {
     const prevTree = prevTreeRef.current;
@@ -273,6 +288,13 @@ export function App() {
       // `selectionChanged` stays false and the keep-visible effect below never
       // fires — leaving the first match scrolled off-screen without this.
       setScrollOffset(0);
+      // Also suppress the keep-visible effect for THIS commit (this effect
+      // runs first, so the write is seen by its read below): the stale
+      // selectedIndex now indexes the FILTERED rows, so its visual row
+      // "moves" spuriously and a still-visible old selection would hijack
+      // the reset for one frame. The unconditional trailing write restores
+      // the real visibility at the end of the commit.
+      prevSelectionWasVisibleRef.current = false;
       return;
     }
 
@@ -311,44 +333,52 @@ export function App() {
 
   // Keyboard ↑/↓ (and mouse clicks) are viewport-aware: after a DELIBERATE
   // selection change, nudge the scroll offset minimally to keep the selection
-  // on screen. Gated on `selectionChanged` so a background refresh that gives
-  // `rows` a new reference (useRegistry always calls setRepos, even when
-  // content is unchanged) does not re-fire this and snap a wheel-scrolled
-  // viewport back to the selection. A viewport SHRINK also re-fires it — but
-  // only re-anchors when the shrink actually hid a previously-visible
-  // selection, so a wheel-scrolled viewport whose selection was already
-  // off-screen stays put. Keyed on [selectedIndex, rows, viewportRows] but
-  // NOT scrollOffset, and uses a functional update so it never fights a
-  // future wheel scroll (slice 02).
+  // on screen. A PASSIVE layout change (the row moved or the viewport
+  // resized) that hid a previously-visible selection re-anchors too (see
+  // prevSelectionWasVisibleRef above); since scrollToKeepVisible is a no-op
+  // while the selection is still visible, that gate is exactly "re-anchor
+  // only when the change hid it". Keyed on the selection's VISUAL row and the
+  // viewport height — values, not the `rows` reference — so a background
+  // refresh that only produces new object references (useRegistry always
+  // calls setRepos, even when content is unchanged) cannot re-fire this and
+  // snap a wheel-scrolled viewport back to the selection. NOT keyed on
+  // scrollOffset, and uses a functional update, so it never fights a future
+  // wheel scroll (slice 02).
   useEffect(() => {
-    if (!selectionChanged && !viewportShrank) return;
-    const rowIndex = firstRowForItem(rows, selectedIndex);
-    if (rowIndex === null) return;
-    setScrollOffset((prev) => {
-      if (!selectionChanged) {
-        const wasVisible =
-          rowIndex >= prev && rowIndex < prev + prevViewportRows;
-        if (!wasVisible) return prev;
-      }
-      return scrollToKeepVisible(rowIndex, prev, viewportRows);
-    });
-  }, [
-    selectedIndex,
-    rows,
-    viewportRows,
-    selectionChanged,
-    viewportShrank,
-    prevViewportRows,
-  ]);
+    // All three refs are read BEFORE the trailing effects below rewrite them,
+    // so they are last commit's values. A passive re-anchor requires the row
+    // or viewport to have ACTUALLY changed — a run where neither did (the
+    // falling edge of selectionChanged, with only the wheel's scrollOffset
+    // different) must leave the viewport alone.
+    const rowMoved = selectionRowIndex !== prevSelectionRowIndexRef.current;
+    const viewportResized = viewportRows !== prevViewportRowsRef.current;
+    const passiveLayoutChange =
+      prevSelectionWasVisibleRef.current && (rowMoved || viewportResized);
+    if (!selectionChanged && !passiveLayoutChange) return;
+    if (selectionRowIndex === null) return;
+    setScrollOffset((prev) =>
+      scrollToKeepVisible(selectionRowIndex, prev, viewportRows),
+    );
+  }, [selectionRowIndex, viewportRows, selectionChanged]);
 
-  // The only place these refs are written, keeping them in sync for the next
-  // render's selectionChanged/viewportShrank computations.
+  // The trailing writes keeping the prev-* refs one commit behind for the
+  // selectionChanged computation and the keep-visible effect above. The
+  // visibility ref alone has a second writer (the searchQueryChanged branch
+  // suppressing one commit) and so must be unconditionally rewritten here —
+  // a keyed write would skip commits where visibility didn't change and
+  // leave that suppression stuck.
   useEffect(() => {
     prevSelectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);
   useEffect(() => {
+    prevSelectionRowIndexRef.current = selectionRowIndex;
+  }, [selectionRowIndex]);
+  useEffect(() => {
     prevViewportRowsRef.current = viewportRows;
   }, [viewportRows]);
+  useEffect(() => {
+    prevSelectionWasVisibleRef.current = selectionVisible;
+  });
 
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);

--- a/src/tui/components/AddProjectModal.tsx
+++ b/src/tui/components/AddProjectModal.tsx
@@ -1,8 +1,9 @@
 import * as path from "node:path";
 import { Effect, FileSystem } from "effect";
-import { Box, Text, useInput } from "ink";
+import { Box, Text } from "ink";
 import { useCallback, useEffect, useState } from "react";
 import { useBlink } from "../hooks/useBlink";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import { runTuiSilentPromise } from "../runtime";
 import { isSubmitShortcut, SubmitButton } from "./form-controls";
 import { Modal } from "./Modal";
@@ -101,7 +102,7 @@ export function AddProjectModal({
     onSubmit({ path: expanded, name, nameManuallyEdited: manuallyEdited });
   }, [isGitRepo, pathValue, nameValue, nameAutoFilled, onSubmit]);
 
-  useInput(
+  useGuardedInput(
     (_input, key) => {
       if (key.escape) {
         onCancel();
@@ -134,7 +135,7 @@ export function AddProjectModal({
   );
 
   // Name field input handling
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (key.backspace) {
         setNameValue((prev) => prev.slice(0, -1));

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -13,6 +13,14 @@ interface Props {
    * continuation line — the label piece indented to align under the first.
    */
   pieceIndex?: number;
+  /**
+   * The precomputed wrapped label line for `pieceIndex`, carried on the
+   * `TreeRow` by `buildTreeRows` so the render consumes exactly the lines the
+   * row model counted (and never re-wraps per render). When absent (direct
+   * component use outside the row model), the line is derived here through
+   * the same shared `wrapPrLabel` helper.
+   */
+  prLine?: string;
 }
 
 function rollupIcon(
@@ -50,6 +58,7 @@ export function DetailRow({
   isSelected,
   maxWidth,
   pieceIndex = 0,
+  prLine,
 }: Props) {
   const { detailKind, label } = item;
   const prefix = isSelected ? "▸ " : "  ";
@@ -81,17 +90,19 @@ export function DetailRow({
       const iconColor = rollupColor(rollupState);
       const hasIcon = rollupState !== null;
       // The full title is shown, wrapping onto extra lines rather than being
-      // truncated. `buildTreeRows` emits one continuation row per wrapped line
-      // via this same helper, so counted rows == rendered lines and mouse
-      // hit-testing stays aligned.
-      const lines = wrapPrLabel(label, maxWidth, hasIcon);
+      // truncated. The wrapped line for this piece normally arrives
+      // precomputed on the TreeRow (`prLine`), so counted rows == rendered
+      // lines by construction and nothing re-wraps per render; the fallback
+      // goes through the same shared helper `buildTreeRows` uses.
+      const line =
+        prLine ?? wrapPrLabel(label, maxWidth, hasIcon)[pieceIndex] ?? "";
 
       if (pieceIndex > 0) {
         return (
           <Box>
             <Text>{" ".repeat(prLabelStart(hasIcon))}</Text>
             <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
-              {lines[pieceIndex] ?? ""}
+              {line}
             </Text>
           </Box>
         );
@@ -110,7 +121,7 @@ export function DetailRow({
           </Text>
           {icon ? <Text color={iconColor}>{icon} </Text> : null}
           <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
-            {lines[0] ?? ""}
+            {line}
           </Text>
         </Box>
       );

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { PR_INDENT, prLabelStart, wrapPrLabel } from "../pr-layout";
 import type { TreeItem } from "../types";
 import { truncateBranch, truncateWithPrefix } from "../utils/truncate";
 
@@ -6,6 +7,12 @@ interface Props {
   item: Extract<TreeItem, { type: "detail" }>;
   isSelected: boolean;
   maxWidth: number;
+  /**
+   * Which wrapped terminal line of the label to render. 0 is the primary line
+   * (indent + selector + icon + first label piece); values > 0 render a PR
+   * continuation line — the label piece indented to align under the first.
+   */
+  pieceIndex?: number;
 }
 
 function rollupIcon(
@@ -38,7 +45,12 @@ function rollupColor(
   }
 }
 
-export function DetailRow({ item, isSelected, maxWidth }: Props) {
+export function DetailRow({
+  item,
+  isSelected,
+  maxWidth,
+  pieceIndex = 0,
+}: Props) {
   const { detailKind, label } = item;
   const prefix = isSelected ? "▸ " : "  ";
   const indent =
@@ -67,15 +79,38 @@ export function DetailRow({ item, isSelected, maxWidth }: Props) {
       const { rollupState } = item.meta;
       const icon = rollupIcon(rollupState);
       const iconColor = rollupColor(rollupState);
+      const hasIcon = rollupState !== null;
+      // The full title is shown, wrapping onto extra lines rather than being
+      // truncated. `buildTreeRows` emits one continuation row per wrapped line
+      // via this same helper, so counted rows == rendered lines and mouse
+      // hit-testing stays aligned.
+      const lines = wrapPrLabel(label, maxWidth, hasIcon);
+
+      if (pieceIndex > 0) {
+        return (
+          <Box>
+            <Text>{" ".repeat(prLabelStart(hasIcon))}</Text>
+            <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+              {lines[pieceIndex] ?? ""}
+            </Text>
+          </Box>
+        );
+      }
+
+      // The rendered leading chrome MUST equal prLabelStart(hasIcon): the
+      // indent is PR_INDENT columns, `prefix` is PR_SELECTOR (2) wide, and the
+      // icon element `{icon} ` is PR_ICON (2) wide when shown. If these drift,
+      // the label budget stops matching the render and the terminal soft-wraps,
+      // desyncing the row count — hence the indent derives from the constant.
       return (
         <Box>
-          <Text>{indent}</Text>
+          <Text>{" ".repeat(PR_INDENT)}</Text>
           <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
             {prefix}
           </Text>
           {icon ? <Text color={iconColor}>{icon} </Text> : null}
           <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
-            {label}
+            {lines[0] ?? ""}
           </Text>
         </Box>
       );

--- a/src/tui/components/DetailRow.tsx
+++ b/src/tui/components/DetailRow.tsx
@@ -97,11 +97,20 @@ export function DetailRow({
       const line =
         prLine ?? wrapPrLabel(label, maxWidth, hasIcon)[pieceIndex] ?? "";
 
+      // wrap="truncate-end" on the label pieces is a backstop for the row
+      // model: wrapPrLabel budgets lines by display width, and if its
+      // measurement ever disagrees with Ink's, an over-wide piece must clip a
+      // glyph — soft-wrapping would add a terminal row buildTreeRows did not
+      // count and desync mouse hit-testing.
       if (pieceIndex > 0) {
         return (
           <Box>
             <Text>{" ".repeat(prLabelStart(hasIcon))}</Text>
-            <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+            <Text
+              color={isSelected ? "cyan" : undefined}
+              bold={isSelected}
+              wrap="truncate-end"
+            >
               {line}
             </Text>
           </Box>
@@ -120,7 +129,11 @@ export function DetailRow({
             {prefix}
           </Text>
           {icon ? <Text color={iconColor}>{icon} </Text> : null}
-          <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+          <Text
+            color={isSelected ? "cyan" : undefined}
+            bold={isSelected}
+            wrap="truncate-end"
+          >
             {line}
           </Text>
         </Box>

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -1,7 +1,8 @@
-import { Box, Text, useInput } from "ink";
+import { Box, Text } from "ink";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { WorktreeService } from "../../services/worktree-service";
 import { useBlink } from "../hooks/useBlink";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import {
   type SessionIdeDefaults,
   useSessionOptionsState,
@@ -61,7 +62,7 @@ function ModeSelector({
     { label: "Existing Branch", step: "existingBranch" },
   ];
 
-  useInput(
+  useGuardedInput(
     (_input, key) => {
       if (key.upArrow) setSelected((s) => Math.max(0, s - 1));
       if (key.downArrow)
@@ -109,7 +110,7 @@ function BracketInput({
   const cursorVisible = useBlink();
   const displayValue = value || (!isFocused || !cursorVisible ? " " : "");
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (!isFocused) return;
       if (key.backspace) {
@@ -144,7 +145,7 @@ function PromptArea({
 }) {
   const cursorVisible = useBlink();
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (!isFocused) return;
       if (key.backspace) {
@@ -242,7 +243,7 @@ export function NewBranchForm({
     });
   };
 
-  useInput(
+  useGuardedInput(
     (_input, key) => {
       if (key.escape) {
         onBack();
@@ -423,7 +424,7 @@ export function FromPRForm({
     });
   };
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (key.escape) {
         onBack();
@@ -638,7 +639,7 @@ export function ExistingBranchForm({
     });
   };
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (key.escape) {
         onBack();

--- a/src/tui/components/PathInput.tsx
+++ b/src/tui/components/PathInput.tsx
@@ -1,7 +1,8 @@
 import { Effect, FileSystem } from "effect";
-import { Text, useInput } from "ink";
+import { Text } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useBlink } from "../hooks/useBlink";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import { runTuiSilentPromise } from "../runtime";
 import { getVisibleWindow, type ListItem } from "./ScrollableList";
 import { TitledBox } from "./TitledBox";
@@ -114,7 +115,7 @@ export function PathInput({
     }
   }, [filtered.length, selectedCompletionIndex]);
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (key.downArrow) {
         if (filtered.length === 0) return;

--- a/src/tui/components/RepoEmptyRow.tsx
+++ b/src/tui/components/RepoEmptyRow.tsx
@@ -1,0 +1,15 @@
+import { Box, Text } from "ink";
+
+/**
+ * The `(no worktrees)` line rendered beneath an expanded repo with zero
+ * worktrees. Split out of `RepoNode` so the visual-row model is terminal-row
+ * accurate: one React element per terminal row.
+ */
+export function RepoEmptyRow() {
+  return (
+    <Box>
+      <Text>{"    "}</Text>
+      <Text dimColor>(no worktrees)</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/RepoNode.tsx
+++ b/src/tui/components/RepoNode.tsx
@@ -6,7 +6,6 @@ interface Props {
   expanded: boolean;
   isSelected: boolean;
   isChildSelected: boolean;
-  worktreeCount: number;
   maxWidth: number;
   isRefreshing?: boolean;
   hasError?: boolean;
@@ -17,7 +16,6 @@ export function RepoNode({
   expanded,
   isSelected,
   isChildSelected,
-  worktreeCount,
   maxWidth,
   isRefreshing,
   hasError,
@@ -35,21 +33,13 @@ export function RepoNode({
   );
 
   return (
-    <Box flexDirection="column">
-      <Box>
-        <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
-        <Text color={isSelected ? "cyan" : "yellow"} bold={active}>
-          {arrow} {displayProject}
-        </Text>
-        {isRefreshing ? <Text dimColor> ↻</Text> : null}
-        {hasError ? <Text color="yellow"> ⚠</Text> : null}
-      </Box>
-      {expanded && worktreeCount === 0 ? (
-        <Box>
-          <Text>{"    "}</Text>
-          <Text dimColor>(no worktrees)</Text>
-        </Box>
-      ) : null}
+    <Box>
+      <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+      <Text color={isSelected ? "cyan" : "yellow"} bold={active}>
+        {arrow} {displayProject}
+      </Text>
+      {isRefreshing ? <Text dimColor> ↻</Text> : null}
+      {hasError ? <Text color="yellow"> ⚠</Text> : null}
     </Box>
   );
 }

--- a/src/tui/components/SessionOptionsSection.tsx
+++ b/src/tui/components/SessionOptionsSection.tsx
@@ -1,5 +1,6 @@
-import { Box, useInput } from "ink";
+import { Box } from "ink";
 import { useEffect, useMemo, useState } from "react";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import { SubmitButton, ToggleRow } from "./form-controls";
 import { filterItems, ScrollableList } from "./ScrollableList";
 import {
@@ -72,7 +73,7 @@ export function SessionOptionsSection({
     );
   }, [profileNames, filteredProfiles, selectedProfileIndex, onProfileChange]);
 
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if (key.upArrow) {
         setSelectedProfileIndex((prev) =>

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -85,6 +85,11 @@ export function StatusBar({
   const { columns: cols } = useWindowSize();
   const divider = "─".repeat(Math.max(1, cols));
 
+  // Every line below renders with wrap="truncate": App.tsx budgets
+  // bottomChromeRows assuming each chrome line occupies exactly one terminal
+  // row, so a hint/error line wrapping in a narrow terminal would overflow
+  // the viewport and misalign mouse hit-testing.
+
   if (
     mode.type === "ConfirmKill" ||
     mode.type === "ConfirmDown" ||
@@ -95,10 +100,12 @@ export function StatusBar({
     return (
       <Box flexDirection="column">
         <Text dimColor>{divider}</Text>
-        <Text color="red" bold>
+        <Text color="red" bold wrap="truncate">
           {line1}
         </Text>
-        <Text dimColor>{line2}</Text>
+        <Text dimColor wrap="truncate">
+          {line2}
+        </Text>
       </Box>
     );
   }
@@ -107,8 +114,12 @@ export function StatusBar({
     return (
       <Box flexDirection="column">
         <Text dimColor>{divider}</Text>
-        <Text color="cyan">/{searchQuery}</Text>
-        <Text dimColor>{getHints(mode, undefined, hasClient)[1]}</Text>
+        <Text color="cyan" wrap="truncate">
+          /{searchQuery}
+        </Text>
+        <Text dimColor wrap="truncate">
+          {getHints(mode, undefined, hasClient)[1]}
+        </Text>
       </Box>
     );
   }
@@ -117,9 +128,17 @@ export function StatusBar({
   return (
     <Box flexDirection="column">
       <Text dimColor>{divider}</Text>
-      {repoError ? <Text color="yellow">⚠ {repoError}</Text> : null}
-      <Text dimColor>{line1}</Text>
-      <Text dimColor>{line2}</Text>
+      {repoError ? (
+        <Text color="yellow" wrap="truncate">
+          ⚠ {repoError}
+        </Text>
+      ) : null}
+      <Text dimColor wrap="truncate">
+        {line1}
+      </Text>
+      <Text dimColor wrap="truncate">
+        {line2}
+      </Text>
     </Box>
   );
 }

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 // src/tui/components/StatusBar.tsx
 import { Box, Text, useWindowSize } from "ink";
+import type { ComponentProps } from "react";
 import type { Mode } from "../types";
 import { toSingleLine } from "../utils/truncate";
 
@@ -107,6 +108,18 @@ export function statusBarRowCount(mode: Mode, hasRepoError: boolean): number {
   }
 }
 
+/**
+ * A single bottom-chrome line. App.tsx budgets bottomChromeRows assuming each
+ * chrome line occupies EXACTLY one terminal row (see statusBarRowCount), so a
+ * line wrapping in a narrow terminal would overflow the viewport and misalign
+ * mouse hit-testing. Rendering every line through this wrapper — never a raw
+ * <Text> — enforces wrap="truncate" structurally: the prop is applied AFTER
+ * the spread, so no call site can override it.
+ */
+function ChromeLine(props: ComponentProps<typeof Text>) {
+  return <Text {...props} wrap="truncate" />;
+}
+
 export function StatusBar({
   mode,
   searchQuery,
@@ -117,11 +130,6 @@ export function StatusBar({
   const { columns: cols } = useWindowSize();
   const divider = "─".repeat(Math.max(1, cols));
 
-  // Every line below renders with wrap="truncate": App.tsx budgets
-  // bottomChromeRows assuming each chrome line occupies exactly one terminal
-  // row, so a hint/error line wrapping in a narrow terminal would overflow
-  // the viewport and misalign mouse hit-testing.
-
   if (
     mode.type === "ConfirmKill" ||
     mode.type === "ConfirmDown" ||
@@ -131,13 +139,11 @@ export function StatusBar({
     const [line1, line2] = getHints(mode, selectedPaneRow, hasClient);
     return (
       <Box flexDirection="column">
-        <Text dimColor>{divider}</Text>
-        <Text color="red" bold wrap="truncate">
+        <ChromeLine dimColor>{divider}</ChromeLine>
+        <ChromeLine color="red" bold>
           {line1}
-        </Text>
-        <Text dimColor wrap="truncate">
-          {line2}
-        </Text>
+        </ChromeLine>
+        <ChromeLine dimColor>{line2}</ChromeLine>
       </Box>
     );
   }
@@ -145,13 +151,11 @@ export function StatusBar({
   if (mode.type === "Search") {
     return (
       <Box flexDirection="column">
-        <Text dimColor>{divider}</Text>
-        <Text color="cyan" wrap="truncate">
-          /{searchQuery}
-        </Text>
-        <Text dimColor wrap="truncate">
+        <ChromeLine dimColor>{divider}</ChromeLine>
+        <ChromeLine color="cyan">/{searchQuery}</ChromeLine>
+        <ChromeLine dimColor>
           {getHints(mode, undefined, hasClient)[1]}
-        </Text>
+        </ChromeLine>
       </Box>
     );
   }
@@ -159,18 +163,12 @@ export function StatusBar({
   const [line1, line2] = getHints(mode, selectedPaneRow, hasClient);
   return (
     <Box flexDirection="column">
-      <Text dimColor>{divider}</Text>
+      <ChromeLine dimColor>{divider}</ChromeLine>
       {repoError ? (
-        <Text color="yellow" wrap="truncate">
-          ⚠ {toSingleLine(repoError)}
-        </Text>
+        <ChromeLine color="yellow">⚠ {toSingleLine(repoError)}</ChromeLine>
       ) : null}
-      <Text dimColor wrap="truncate">
-        {line1}
-      </Text>
-      <Text dimColor wrap="truncate">
-        {line2}
-      </Text>
+      <ChromeLine dimColor>{line1}</ChromeLine>
+      <ChromeLine dimColor>{line2}</ChromeLine>
     </Box>
   );
 }

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 // src/tui/components/StatusBar.tsx
 import { Box, Text, useWindowSize } from "ink";
 import type { Mode } from "../types";
+import { toSingleLine } from "../utils/truncate";
 
 interface Props {
   mode: Mode;
@@ -75,6 +76,37 @@ function getHints(
   }
 }
 
+/**
+ * The number of terminal rows StatusBar renders for a mode — the single
+ * source App.tsx's viewport budget consumes, co-located with the render
+ * branches below so the two cannot drift. The count is a pure function of the
+ * mode branch and repoError presence: every line renders with wrap="truncate"
+ * (and the divider is width-repeated), so width never changes the row count,
+ * and searchQuery/selectedPaneRow/hasClient only change text, never lines.
+ *
+ * True-modal modes (OpenModal/UpModal/AddProjectModal) do not render
+ * StatusBar at all — the modal replaces the bottom chrome — but they return
+ * the default-branch count anyway: App budgets the tree viewport with this
+ * VIRTUAL count so opening a modal does not change viewportRows (which would
+ * clamp/re-anchor the scroll state); the modal's extra height is absorbed by
+ * the tree box's overflow clipping instead.
+ */
+export function statusBarRowCount(mode: Mode, hasRepoError: boolean): number {
+  switch (mode.type) {
+    // divider + confirm question + hint line
+    case "ConfirmKill":
+    case "ConfirmDown":
+    case "ConfirmClose":
+    case "ConfirmCloseForce":
+    // divider + query line + hint line
+    case "Search":
+      return 3;
+    // divider + optional repoError + two hint lines
+    default:
+      return 3 + (hasRepoError ? 1 : 0);
+  }
+}
+
 export function StatusBar({
   mode,
   searchQuery,
@@ -130,7 +162,7 @@ export function StatusBar({
       <Text dimColor>{divider}</Text>
       {repoError ? (
         <Text color="yellow" wrap="truncate">
-          ⚠ {repoError}
+          ⚠ {toSingleLine(repoError)}
         </Text>
       ) : null}
       <Text dimColor wrap="truncate">

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -79,7 +79,14 @@ export function TreeView({
         pendingActions,
         maxWidth,
       }),
-    [items, repos, expandedRepos, expandedWorktreeKey, pendingActions, maxWidth],
+    [
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions,
+      maxWidth,
+    ],
   );
 
   const selectedItem = items[selectedIndex];

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { formatSessionName } from "../../services/tmux";
 import { formatSync } from "../../services/worktree-service";
 import type { RepoInfo } from "../hooks/useRegistry";
-import { buildTreeRows, type TreeRow } from "../tree-helpers";
+import type { TreeRow } from "../tree-helpers";
 import {
   type PaneInfo,
   type PendingAction,
@@ -24,6 +24,13 @@ interface Props {
   expandedRepos: Set<string>;
   selectedIndex: number;
   items: TreeItem[];
+  /**
+   * The visual-row model to render, built ONCE by the owner (App.tsx) with
+   * `buildTreeRows` and shared with windowing and mouse hit-testing — TreeView
+   * never rebuilds it, so the rendered rows and the hit-test rows cannot
+   * diverge.
+   */
+  rows: TreeRow[];
   pendingActions: Map<string, PendingAction>;
   prData: Map<string, PRInfo>;
   panes: Map<string, PaneInfo[]>;
@@ -54,6 +61,7 @@ export function TreeView({
   expandedRepos,
   selectedIndex,
   items,
+  rows,
   pendingActions,
   prData,
   panes,
@@ -67,26 +75,6 @@ export function TreeView({
   const sessionMap = useMemo(
     () => new Map(sessions.map((s) => [s.name, s])),
     [sessions],
-  );
-
-  const rows = useMemo(
-    () =>
-      buildTreeRows({
-        items,
-        repos,
-        expandedRepos,
-        expandedWorktreeKey,
-        pendingActions,
-        maxWidth,
-      }),
-    [
-      items,
-      repos,
-      expandedRepos,
-      expandedWorktreeKey,
-      pendingActions,
-      maxWidth,
-    ],
   );
 
   const selectedItem = items[selectedIndex];
@@ -174,9 +162,9 @@ function renderRow(row: TreeRow, ctx: RenderRowContext): React.ReactNode {
     case "worktree":
       return renderWorktreeRow(row.itemIndex, ctx);
     case "detail":
-      return renderDetailRow(row.itemIndex, ctx, 0);
+      return renderDetailRow(row.itemIndex, ctx, 0, row.prLine);
     case "detail-pr-cont":
-      return renderDetailRow(row.itemIndex, ctx, row.pieceIndex);
+      return renderDetailRow(row.itemIndex, ctx, row.pieceIndex, row.prLine);
   }
 }
 
@@ -254,6 +242,7 @@ function renderDetailRow(
   idx: number,
   ctx: RenderRowContext,
   pieceIndex: number,
+  prLine?: string,
 ): React.ReactNode {
   const item = ctx.items[idx];
   if (item?.type !== "detail") return null;
@@ -271,6 +260,7 @@ function renderDetailRow(
       isSelected={idx === ctx.selectedIndex}
       maxWidth={ctx.maxWidth}
       pieceIndex={pieceIndex}
+      prLine={prLine}
     />
   );
 }

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { formatSessionName } from "../../services/tmux";
 import { formatSync } from "../../services/worktree-service";
 import type { RepoInfo } from "../hooks/useRegistry";
+import { buildTreeRows, type TreeRow } from "../tree-helpers";
 import {
   type PaneInfo,
   type PendingAction,
@@ -12,8 +13,10 @@ import {
   type TreeItem,
 } from "../types";
 import { DetailRow } from "./DetailRow";
+import { RepoEmptyRow } from "./RepoEmptyRow";
 import { RepoNode } from "./RepoNode";
 import { WorktreeItem } from "./WorktreeItem";
+import { WorktreeStatsRow } from "./WorktreeStatsRow";
 
 interface Props {
   repos: RepoInfo[];
@@ -28,6 +31,10 @@ interface Props {
   maxWidth: number;
   refreshingProjects?: Set<string>;
   errors?: Map<string, string>;
+  /** First visual row to render. Defaults to 0 (no scrolling). */
+  scrollOffset?: number;
+  /** Number of visual rows to render. Defaults to rendering all rows. */
+  viewportRows?: number;
 }
 
 export function getDetailRowKey(
@@ -54,164 +61,197 @@ export function TreeView({
   maxWidth,
   refreshingProjects,
   errors,
+  scrollOffset = 0,
+  viewportRows,
 }: Props) {
   const sessionMap = useMemo(
     () => new Map(sessions.map((s) => [s.name, s])),
     [sessions],
   );
 
-  const { phantomsByProject } = useMemo(() => {
-    const keys = new Set<string>();
-    for (const repo of repos) {
-      for (const wt of repo.worktrees) {
-        keys.add(pendingKey(repo.project, wt.branch));
-      }
-    }
-    const phantoms = new Map<string, PendingAction[]>();
-    for (const [key, action] of pendingActions) {
-      if (action.type === "opening" && !keys.has(key)) {
-        const existing = phantoms.get(action.project) ?? [];
-        existing.push(action);
-        phantoms.set(action.project, existing);
-      }
-    }
-    return { phantomsByProject: phantoms };
-  }, [repos, pendingActions]);
+  const rows = useMemo(
+    () =>
+      buildTreeRows({
+        items,
+        repos,
+        expandedRepos,
+        expandedWorktreeKey,
+        pendingActions,
+      }),
+    [items, repos, expandedRepos, expandedWorktreeKey, pendingActions],
+  );
 
-  const elements: React.ReactNode[] = [];
   const selectedItem = items[selectedIndex];
 
-  for (let idx = 0; idx < items.length; idx++) {
-    const item = items[idx];
-    if (!item) continue;
+  const visibleRows =
+    viewportRows === undefined
+      ? rows
+      : rows.slice(scrollOffset, scrollOffset + viewportRows);
 
-    const repo = repos[item.repoIndex];
-    if (!repo) continue;
+  const elements: React.ReactNode[] = [];
 
-    if (item.type === "repo") {
-      const childSelected =
-        idx !== selectedIndex &&
-        !!selectedItem &&
-        selectedItem.type !== "repo" &&
-        selectedItem.repoIndex === item.repoIndex;
-
-      elements.push(
-        <RepoNode
-          key={`repo-${repo.id}`}
-          project={repo.project}
-          expanded={expandedRepos.has(repo.id)}
-          isSelected={idx === selectedIndex}
-          isChildSelected={childSelected}
-          worktreeCount={repo.worktrees.length}
-          maxWidth={maxWidth}
-          isRefreshing={refreshingProjects?.has(repo.project)}
-          hasError={errors?.has(repo.project)}
-        />,
-      );
-      continue;
-    }
-
-    if (item.type === "detail") {
-      elements.push(
-        <DetailRow
-          key={getDetailRowKey(repo.id, item)}
-          item={item}
-          isSelected={idx === selectedIndex}
-          maxWidth={maxWidth}
-        />,
-      );
-      continue;
-    }
-
-    const worktreeIndex = item.worktreeIndex;
-    if (worktreeIndex === undefined) continue;
-
-    const wt = repo.worktrees[worktreeIndex];
-    if (!wt) continue;
-
-    const sessionName = formatSessionName(basename(wt.path));
-    const session = sessionMap.get(sessionName);
-    const wtKey = pendingKey(repo.project, wt.branch);
-    const pending = pendingActions.get(wtKey);
-
-    const wtPr = prData.get(wtKey);
-    const wtPanes = panes.get(sessionName);
-    const hasExpandableData = !!wtPr || (wtPanes && wtPanes.length > 0);
-
-    const wtChildSelected =
-      idx !== selectedIndex &&
-      !!selectedItem &&
-      selectedItem.type === "detail" &&
-      selectedItem.repoIndex === item.repoIndex &&
-      selectedItem.worktreeIndex === worktreeIndex;
-
-    elements.push(
-      <WorktreeItem
-        key={`wt-${repo.id}-${wt.branch}`}
-        branch={wt.branch}
-        hasSession={!!session}
-        isAttached={session?.attached ?? false}
-        sync={formatSync(wt.sync)}
-        changedFiles={wt.changedFiles}
-        isSelected={idx === selectedIndex}
-        isChildSelected={wtChildSelected}
-        pendingStatus={pending?.type}
-        isExpanded={expandedWorktreeKey === wtKey}
-        hasExpandableData={!!hasExpandableData}
-        maxWidth={maxWidth}
-      />,
-    );
-
-    const nextItem = items[idx + 1];
-    const isLastWorktreeForRepo =
-      !nextItem ||
-      nextItem.type === "repo" ||
-      nextItem.repoIndex !== item.repoIndex;
-
-    if (isLastWorktreeForRepo) {
-      const phantoms = phantomsByProject.get(repo.project);
-      if (phantoms) {
-        for (const phantom of phantoms) {
-          elements.push(
-            <WorktreeItem
-              key={`phantom-${repo.id}-${phantom.branch}`}
-              branch={phantom.branch}
-              hasSession={false}
-              isAttached={false}
-              sync=""
-              changedFiles={0}
-              isSelected={false}
-              pendingStatus="opening"
-              maxWidth={maxWidth}
-            />,
-          );
-        }
-      }
-    }
-  }
-
-  // Phantoms for expanded repos with no worktrees
-  for (const repo of repos) {
-    if (!expandedRepos.has(repo.id)) continue;
-    if (repo.worktrees.length > 0) continue;
-    const phantoms = phantomsByProject.get(repo.project);
-    if (!phantoms) continue;
-    for (const phantom of phantoms) {
-      elements.push(
-        <WorktreeItem
-          key={`phantom-${repo.id}-${phantom.branch}`}
-          branch={phantom.branch}
-          hasSession={false}
-          isAttached={false}
-          sync=""
-          changedFiles={0}
-          isSelected={false}
-          pendingStatus="opening"
-          maxWidth={maxWidth}
-        />,
-      );
-    }
+  for (let i = 0; i < visibleRows.length; i++) {
+    const row = visibleRows[i];
+    if (!row) continue;
+    const element = renderRow(row, {
+      repos,
+      items,
+      selectedIndex,
+      selectedItem,
+      expandedRepos,
+      expandedWorktreeKey,
+      sessionMap,
+      prData,
+      panes,
+      pendingActions,
+      maxWidth,
+      refreshingProjects,
+      errors,
+    });
+    if (element) elements.push(element);
   }
 
   return <Box flexDirection="column">{elements}</Box>;
+}
+
+interface RenderRowContext {
+  repos: RepoInfo[];
+  items: TreeItem[];
+  selectedIndex: number;
+  selectedItem: TreeItem | undefined;
+  expandedRepos: Set<string>;
+  expandedWorktreeKey: string | null;
+  sessionMap: Map<string, { name: string; attached: boolean }>;
+  prData: Map<string, PRInfo>;
+  panes: Map<string, PaneInfo[]>;
+  pendingActions: Map<string, PendingAction>;
+  maxWidth: number;
+  refreshingProjects?: Set<string>;
+  errors?: Map<string, string>;
+}
+
+function renderRow(row: TreeRow, ctx: RenderRowContext): React.ReactNode {
+  switch (row.kind) {
+    case "repo-empty":
+      return <RepoEmptyRow key={`repo-empty-${row.repoIndex}`} />;
+    case "phantom": {
+      const repo = ctx.repos[row.repoIndex];
+      if (!repo) return null;
+      return (
+        <WorktreeItem
+          key={`phantom-${repo.id}-${row.branch}`}
+          branch={row.branch}
+          hasSession={false}
+          isAttached={false}
+          isSelected={false}
+          pendingStatus="opening"
+          maxWidth={ctx.maxWidth}
+        />
+      );
+    }
+    case "worktree-stats": {
+      const repo = ctx.repos[row.repoIndex];
+      const wt = repo?.worktrees[row.worktreeIndex];
+      if (!repo || !wt) return null;
+      return (
+        <WorktreeStatsRow
+          key={`wt-stats-${repo.id}-${wt.branch}`}
+          sync={formatSync(wt.sync)}
+          changedFiles={wt.changedFiles}
+        />
+      );
+    }
+    case "repo":
+      return renderRepoRow(row.itemIndex, ctx);
+    case "worktree":
+      return renderWorktreeRow(row.itemIndex, ctx);
+    case "detail":
+      return renderDetailRow(row.itemIndex, ctx);
+  }
+}
+
+function renderRepoRow(idx: number, ctx: RenderRowContext): React.ReactNode {
+  const item = ctx.items[idx];
+  if (item?.type !== "repo") return null;
+  const repo = ctx.repos[item.repoIndex];
+  if (!repo) return null;
+
+  const childSelected =
+    idx !== ctx.selectedIndex &&
+    !!ctx.selectedItem &&
+    ctx.selectedItem.type !== "repo" &&
+    ctx.selectedItem.repoIndex === item.repoIndex;
+
+  return (
+    <RepoNode
+      key={`repo-${repo.id}`}
+      project={repo.project}
+      expanded={ctx.expandedRepos.has(repo.id)}
+      isSelected={idx === ctx.selectedIndex}
+      isChildSelected={childSelected}
+      maxWidth={ctx.maxWidth}
+      isRefreshing={ctx.refreshingProjects?.has(repo.project)}
+      hasError={ctx.errors?.has(repo.project)}
+    />
+  );
+}
+
+function renderWorktreeRow(
+  idx: number,
+  ctx: RenderRowContext,
+): React.ReactNode {
+  const item = ctx.items[idx];
+  if (item?.type !== "worktree") return null;
+  const repo = ctx.repos[item.repoIndex];
+  if (!repo) return null;
+
+  const wt = repo.worktrees[item.worktreeIndex];
+  if (!wt) return null;
+
+  const sessionName = formatSessionName(basename(wt.path));
+  const session = ctx.sessionMap.get(sessionName);
+  const wtKey = pendingKey(repo.project, wt.branch);
+  const pending = ctx.pendingActions.get(wtKey);
+
+  const wtPr = ctx.prData.get(wtKey);
+  const wtPanes = ctx.panes.get(sessionName);
+  const hasExpandableData = !!wtPr || (wtPanes && wtPanes.length > 0);
+
+  const wtChildSelected =
+    idx !== ctx.selectedIndex &&
+    !!ctx.selectedItem &&
+    ctx.selectedItem.type === "detail" &&
+    ctx.selectedItem.repoIndex === item.repoIndex &&
+    ctx.selectedItem.worktreeIndex === item.worktreeIndex;
+
+  return (
+    <WorktreeItem
+      key={`wt-${repo.id}-${wt.branch}`}
+      branch={wt.branch}
+      hasSession={!!session}
+      isAttached={session?.attached ?? false}
+      isSelected={idx === ctx.selectedIndex}
+      isChildSelected={wtChildSelected}
+      pendingStatus={pending?.type}
+      isExpanded={ctx.expandedWorktreeKey === wtKey}
+      hasExpandableData={!!hasExpandableData}
+      maxWidth={ctx.maxWidth}
+    />
+  );
+}
+
+function renderDetailRow(idx: number, ctx: RenderRowContext): React.ReactNode {
+  const item = ctx.items[idx];
+  if (item?.type !== "detail") return null;
+  const repo = ctx.repos[item.repoIndex];
+  if (!repo) return null;
+
+  return (
+    <DetailRow
+      key={getDetailRowKey(repo.id, item)}
+      item={item}
+      isSelected={idx === ctx.selectedIndex}
+      maxWidth={ctx.maxWidth}
+    />
+  );
 }

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -77,8 +77,9 @@ export function TreeView({
         expandedRepos,
         expandedWorktreeKey,
         pendingActions,
+        maxWidth,
       }),
-    [items, repos, expandedRepos, expandedWorktreeKey, pendingActions],
+    [items, repos, expandedRepos, expandedWorktreeKey, pendingActions, maxWidth],
   );
 
   const selectedItem = items[selectedIndex];
@@ -166,7 +167,9 @@ function renderRow(row: TreeRow, ctx: RenderRowContext): React.ReactNode {
     case "worktree":
       return renderWorktreeRow(row.itemIndex, ctx);
     case "detail":
-      return renderDetailRow(row.itemIndex, ctx);
+      return renderDetailRow(row.itemIndex, ctx, 0);
+    case "detail-pr-cont":
+      return renderDetailRow(row.itemIndex, ctx, row.pieceIndex);
   }
 }
 
@@ -240,7 +243,11 @@ function renderWorktreeRow(
   );
 }
 
-function renderDetailRow(idx: number, ctx: RenderRowContext): React.ReactNode {
+function renderDetailRow(
+  idx: number,
+  ctx: RenderRowContext,
+  pieceIndex: number,
+): React.ReactNode {
   const item = ctx.items[idx];
   if (item?.type !== "detail") return null;
   const repo = ctx.repos[item.repoIndex];
@@ -248,10 +255,15 @@ function renderDetailRow(idx: number, ctx: RenderRowContext): React.ReactNode {
 
   return (
     <DetailRow
-      key={getDetailRowKey(repo.id, item)}
+      key={
+        pieceIndex > 0
+          ? `${getDetailRowKey(repo.id, item)}-cont-${pieceIndex}`
+          : getDetailRowKey(repo.id, item)
+      }
       item={item}
       isSelected={idx === ctx.selectedIndex}
       maxWidth={ctx.maxWidth}
+      pieceIndex={pieceIndex}
     />
   );
 }

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -1,5 +1,6 @@
-import { Box, Text, useInput } from "ink";
+import { Box, Text } from "ink";
 import { useEffect, useMemo, useState } from "react";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import {
   type SessionIdeDefaults,
   useSessionOptionsState,
@@ -80,7 +81,7 @@ export function UpModal({
     if (visible) setFocusIndex(0);
   }, [visible]);
 
-  useInput(
+  useGuardedInput(
     (_input, key) => {
       if (key.escape) {
         onCancel();

--- a/src/tui/components/WorktreeItem.tsx
+++ b/src/tui/components/WorktreeItem.tsx
@@ -5,8 +5,6 @@ interface Props {
   branch: string;
   hasSession: boolean;
   isAttached: boolean;
-  sync: string;
-  changedFiles: number;
   isSelected: boolean;
   isChildSelected?: boolean;
   pendingStatus?: "opening" | "closing" | "starting" | "stopping";
@@ -23,8 +21,6 @@ export function WorktreeItem({
   branch,
   hasSession,
   isAttached,
-  sync,
-  changedFiles,
   isSelected,
   isChildSelected,
   pendingStatus,
@@ -77,7 +73,6 @@ export function WorktreeItem({
         mainSuffix.length,
     ),
   );
-  const hasStats = (sync && sync !== "\u2713") || changedFiles > 0;
 
   if (pendingStatus === "opening") {
     return (
@@ -115,33 +110,20 @@ export function WorktreeItem({
   }
 
   return (
-    <Box flexDirection="column">
-      <Box>
-        <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
-        {expandIcon ? <Text dimColor>{expandIcon}</Text> : null}
-        <Text color={indicatorColor}>
-          {indicator}
-          {pendingStatus === "starting" ? (
-            <Text dimColor> starting...</Text>
-          ) : null}
-        </Text>
-        <Text color={isSelected ? "cyan" : undefined} bold={active}>
-          {" "}
-          {mainDisplayBranch}
-        </Text>
-        <Text dimColor>{attached}</Text>
-      </Box>
-      {isExpanded && hasStats ? (
-        <Box>
-          <Text>{"        "}</Text>
-          {sync && sync !== "\u2713" ? <Text dimColor>{sync}</Text> : null}
-          {changedFiles > 0 ? (
-            <Text color="yellow">
-              {sync && sync !== "\u2713" ? " " : ""}~{changedFiles}
-            </Text>
-          ) : null}
-        </Box>
-      ) : null}
+    <Box>
+      <Text color={isSelected ? "cyan" : undefined}>{prefix}</Text>
+      {expandIcon ? <Text dimColor>{expandIcon}</Text> : null}
+      <Text color={indicatorColor}>
+        {indicator}
+        {pendingStatus === "starting" ? (
+          <Text dimColor> starting...</Text>
+        ) : null}
+      </Text>
+      <Text color={isSelected ? "cyan" : undefined} bold={active}>
+        {" "}
+        {mainDisplayBranch}
+      </Text>
+      <Text dimColor>{attached}</Text>
     </Box>
   );
 }

--- a/src/tui/components/WorktreeStatsRow.tsx
+++ b/src/tui/components/WorktreeStatsRow.tsx
@@ -1,0 +1,26 @@
+import { Box, Text } from "ink";
+
+interface Props {
+  sync: string;
+  changedFiles: number;
+}
+
+/**
+ * The secondary stats line rendered beneath an expanded worktree row (e.g.
+ * `↑1 ~3`). Split out of `WorktreeItem` so the visual-row model is terminal-row
+ * accurate: one React element per terminal row.
+ */
+export function WorktreeStatsRow({ sync, changedFiles }: Props) {
+  const hasSync = sync && sync !== "✓";
+  return (
+    <Box>
+      <Text>{"        "}</Text>
+      {hasSync ? <Text dimColor>{sync}</Text> : null}
+      {changedFiles > 0 ? (
+        <Text color="yellow">
+          {hasSync ? " " : ""}~{changedFiles}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/tui/components/form-controls.tsx
+++ b/src/tui/components/form-controls.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, useInput } from "ink";
+import { Box, Text } from "ink";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 
 export function isSubmitShortcut(key: {
   ctrl?: boolean;
@@ -18,7 +19,7 @@ export function ToggleRow({
   isFocused: boolean;
   onToggle: () => void;
 }) {
-  useInput(
+  useGuardedInput(
     (input) => {
       if (input === " ") onToggle();
     },
@@ -45,7 +46,7 @@ export function SubmitButton({
   disabled?: boolean;
   onSubmit: () => void;
 }) {
-  useInput(
+  useGuardedInput(
     (input, key) => {
       if ((key.return && !key.ctrl) || input === " ") onSubmit();
     },

--- a/src/tui/hooks/useGuardedInput.ts
+++ b/src/tui/hooks/useGuardedInput.ts
@@ -71,12 +71,27 @@ export function useGuardedInput(
         return;
       }
       if (x10PayloadRemaining.current > 0) {
-        // Payload bytes may arrive in one event or split across several;
-        // anything longer than the remaining payload is not X10 payload
-        // (drop the counter rather than eat a real keystroke's tail), and an
-        // empty `input` is a special key (arrow/escape), never payload bytes.
-        if (input.length > 0 && input.length <= x10PayloadRemaining.current) {
-          x10PayloadRemaining.current -= input.length;
+        // Payload bytes may arrive in one event or split across several.
+        // Count RAW bytes, not string length: coordinate bytes for col/row
+        // > 95 are ≥ 0x80, and stdin's UTF-8 decode (Ink setEncoding's
+        // string_decoder) transforms them two ways. A byte run that happens
+        // to BE valid UTF-8 merges into one multi-byte character —
+        // `input.length` would undercount, leave the counter armed, and eat
+        // the next real keystroke; `Buffer.byteLength` recovers the raw
+        // count exactly. A byte that is NOT valid UTF-8 (e.g. a lone
+        // continuation byte — any col ≥ 96 with an ASCII row) becomes
+        // U+FFFD, which weighs 3 UTF-8 bytes for what was ONE raw byte —
+        // uncorrected, the inflated count overshoots the counter and the
+        // payload garbage falls through to the handler, so count each
+        // replacement char as the single raw byte it stands in for.
+        // Anything still longer than the remaining payload is not X10
+        // payload (drop the counter and let the handler have it — a real
+        // keystroke, never payload), and an empty `input` is a special key
+        // (arrow/escape), never payload bytes.
+        const replacements = input.split("�").length - 1;
+        const bytes = Buffer.byteLength(input, "utf8") - 2 * replacements;
+        if (bytes > 0 && bytes <= x10PayloadRemaining.current) {
+          x10PayloadRemaining.current -= bytes;
           return;
         }
         x10PayloadRemaining.current = 0;

--- a/src/tui/hooks/useGuardedInput.ts
+++ b/src/tui/hooks/useGuardedInput.ts
@@ -1,0 +1,63 @@
+// This hook is the single allowed `useInput` call site — the biome.json
+// override for this file switches off the repo-wide noRestrictedImports rule.
+import { type Key, useInput } from "ink";
+import {
+  isMouseSequence,
+  type MouseEvent,
+  parseSgrMouse,
+  splitMouseSequences,
+} from "../input/mouse";
+
+export interface GuardedInputOptions {
+  /** Same as Ink's `useInput` option. Defaults to `true`. */
+  isActive?: boolean;
+  /**
+   * Called for each ACTIONABLE mouse event parsed out of a swallowed input
+   * string, in order. Ink 7.1 delivers ONE SGR sequence per `useInput` event
+   * (its parser splits stdin chunks and strips the leading ESC per event),
+   * so this normally fires at most once per call; iterating a multi-sequence
+   * string is defense-in-depth for Ink's bracketed-paste fallback and any
+   * future delivery change. Only App.tsx's dispatcher passes this; every
+   * other consumer just needs the sequences swallowed.
+   */
+  onMouseEvent?: (event: MouseEvent) => void;
+}
+
+/**
+ * The ONLY way `wct tui` components may listen to Ink input. Wraps Ink's
+ * `useInput` and swallows every SGR mouse escape sequence before it can
+ * reach `handler` as printable input — Ink dispatches every input event to
+ * ALL active `useInput` hooks (one sequence per event on the normal stdin
+ * path; multi-sequence strings only via the bracketed-paste fallback), so a
+ * guard living only in App.tsx's dispatcher leaves every modal/text-input
+ * handler pasting raw `[<0;12;38M…` bytes into its field — that per-hook gap
+ * was the real cause of the screenshot garble (three per-sequence events
+ * appended in order). Centralising the guard here keeps the invariant true
+ * for handlers added in the future; a biome `noRestrictedImports` rule
+ * forbids importing `useInput` from "ink" anywhere else (this file carries
+ * the sole override).
+ *
+ * Mouse parsing stays on Ink's own read loop — no second stdin listener
+ * (ADR 0002: docs/adr/0002-parse-mouse-from-ink-useinput.md).
+ */
+export function useGuardedInput(
+  handler: (input: string, key: Key) => void,
+  options: GuardedInputOptions = {},
+): void {
+  const { isActive = true, onMouseEvent } = options;
+  useInput(
+    (input, key) => {
+      if (isMouseSequence(input)) {
+        if (onMouseEvent) {
+          for (const sequence of splitMouseSequences(input)) {
+            const event = parseSgrMouse(sequence);
+            if (event) onMouseEvent(event);
+          }
+        }
+        return;
+      }
+      handler(input, key);
+    },
+    { isActive },
+  );
+}

--- a/src/tui/hooks/useGuardedInput.ts
+++ b/src/tui/hooks/useGuardedInput.ts
@@ -1,11 +1,14 @@
 // This hook is the single allowed `useInput` call site — the biome.json
 // override for this file switches off the repo-wide noRestrictedImports rule.
 import { type Key, useInput } from "ink";
+import { useRef } from "react";
 import {
   isMouseSequence,
+  isX10MousePrefix,
   type MouseEvent,
   parseSgrMouse,
   splitMouseSequences,
+  X10_PAYLOAD_BYTES,
 } from "../input/mouse";
 
 export interface GuardedInputOptions {
@@ -45,6 +48,13 @@ export function useGuardedInput(
   options: GuardedInputOptions = {},
 ): void {
   const { isActive = true, onMouseEvent } = options;
+  // Legacy X10 reports (terminal honors ?1000 but not ?1006) split into an
+  // `ESC [ M` event plus a separate 3-raw-byte payload event that has no
+  // recognisable mouse shape — so seeing the prefix arms a byte-counted
+  // swallow of the payload that follows. Per-hook state: Ink dispatches every
+  // event to every active hook, so each instance sees the same stream and
+  // arms/drains its own counter identically.
+  const x10PayloadRemaining = useRef(0);
   useInput(
     (input, key) => {
       if (isMouseSequence(input)) {
@@ -55,6 +65,21 @@ export function useGuardedInput(
           }
         }
         return;
+      }
+      if (isX10MousePrefix(input)) {
+        x10PayloadRemaining.current = X10_PAYLOAD_BYTES;
+        return;
+      }
+      if (x10PayloadRemaining.current > 0) {
+        // Payload bytes may arrive in one event or split across several;
+        // anything longer than the remaining payload is not X10 payload
+        // (drop the counter rather than eat a real keystroke's tail), and an
+        // empty `input` is a special key (arrow/escape), never payload bytes.
+        if (input.length > 0 && input.length <= x10PayloadRemaining.current) {
+          x10PayloadRemaining.current -= input.length;
+          return;
+        }
+        x10PayloadRemaining.current = 0;
       }
       handler(input, key);
     },

--- a/src/tui/hooks/useMouse.ts
+++ b/src/tui/hooks/useMouse.ts
@@ -37,7 +37,10 @@ export type MouseController = ReturnType<typeof createMouseController>;
 /**
  * Enable mouse reporting for the lifetime of the TUI and guarantee the terminal
  * is restored on every exit path. Mirrors `useRefresh`: a plain React hook over
- * Node/Ink primitives, no Effect service.
+ * Node/Ink primitives, no Effect service. This is a DELIBERATE, lifecycle-only
+ * exception to the repo's effect-first guideline — enabling/disabling mouse
+ * reporting is pure terminal-lifecycle plumbing tied to React mount/unmount
+ * and Ink's exit sequencing, with no business logic to lift into Effect.
  *
  * Returns `disableMouse()` — call it on the `q` quit path *before* `exit()`,
  * because Ink's `handleExit` turns off raw mode before React unmount runs, so

--- a/src/tui/hooks/useMouse.ts
+++ b/src/tui/hooks/useMouse.ts
@@ -1,0 +1,100 @@
+import { useStdout } from "ink";
+import { useEffect, useRef } from "react";
+
+/** Enable SGR mouse reporting: button press/release (?1000) + SGR coords (?1006). */
+export const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h";
+/** Disable in REVERSE order (?1006 then ?1000) so ?1006 unwinds first. */
+export const MOUSE_DISABLE = "\x1b[?1006l\x1b[?1000l";
+
+interface MouseWriter {
+  write: (data: string) => void;
+}
+
+/**
+ * Stateful, idempotent enable/disable of mouse reporting on a single stdout
+ * stream. The `enabled` flag makes `disable()` safe to call repeatedly (React
+ * unmount, the `q` path, and any signal handler can all fire it harmlessly).
+ */
+export function createMouseController(stdout: MouseWriter) {
+  let enabled = false;
+  return {
+    isEnabled: () => enabled,
+    enable() {
+      if (enabled) return;
+      enabled = true;
+      stdout.write(MOUSE_ENABLE);
+    },
+    disable() {
+      if (!enabled) return;
+      enabled = false;
+      stdout.write(MOUSE_DISABLE);
+    },
+  };
+}
+
+export type MouseController = ReturnType<typeof createMouseController>;
+
+/**
+ * Enable mouse reporting for the lifetime of the TUI and guarantee the terminal
+ * is restored on every exit path. Mirrors `useRefresh`: a plain React hook over
+ * Node/Ink primitives, no Effect service.
+ *
+ * Returns `disableMouse()` — call it on the `q` quit path *before* `exit()`,
+ * because Ink's `handleExit` turns off raw mode before React unmount runs, so
+ * the unmount-cleanup disable would be too late to avoid echoed bytes.
+ *
+ * `WCT_DISABLE_MOUSE` (any non-empty value) makes the hook a complete no-op.
+ */
+export function useMouse(): { disableMouse: () => void } {
+  const { stdout } = useStdout();
+  const controllerRef = useRef<MouseController | null>(null);
+
+  if (controllerRef.current === null) {
+    const writer: MouseWriter = {
+      write: (data) => {
+        const target = stdout ?? process.stdout;
+        target.write(data);
+      },
+    };
+    controllerRef.current = createMouseController(writer);
+  }
+
+  useEffect(() => {
+    if (process.env.WCT_DISABLE_MOUSE) {
+      // Complete no-op: never enable, never register handlers.
+      return;
+    }
+
+    const controller = controllerRef.current;
+    if (!controller) return;
+    controller.enable();
+
+    // Synchronous restore for explicit-exit paths. Idempotent via the `enabled`
+    // guard, so firing more than once (e.g. exit after the `q` disable) is
+    // harmless.
+    //
+    // We deliberately do NOT register per-signal handlers
+    // (process.on("SIGINT"/"SIGTERM"/"SIGHUP", …)). Ink tears down on signals
+    // via signal-exit (ink.js:255 `signalExit(this.unmount)`), which only
+    // re-raises the signal — and thus runs Ink's unmount — when it is the SOLE
+    // owner of that signal: `process.listeners(sig).length === emitter.count`.
+    // Adding our own listener breaks that invariant, so signal-exit bails: Ink
+    // never unmounts (alt-screen/cursor/raw-mode left broken) and the signal is
+    // never re-raised, hanging the process (notably on SIGHUP, which nothing
+    // else owns). Instead we rely on the existing path — signal-exit →
+    // Ink.unmount → React unmount → this effect's cleanup disable() — to write
+    // the disable bytes while Ink restores the terminal. The "exit" event is
+    // NOT signal-counted by signal-exit, so process.once("exit") is safe.
+    const restore = () => controller.disable();
+    process.once("exit", restore);
+
+    return () => {
+      controller.disable();
+      process.removeListener("exit", restore);
+    };
+  }, []);
+
+  return {
+    disableMouse: () => controllerRef.current?.disable(),
+  };
+}

--- a/src/tui/hooks/useSessionActions.ts
+++ b/src/tui/hooks/useSessionActions.ts
@@ -14,7 +14,7 @@ import {
   resolveSessionHandoff,
   resolveStartActionMessage,
 } from "../session-utils";
-import { resolveSelectedWorktreeIndex } from "../tree-helpers";
+import { isInertTreeItem, resolveSelectedWorktreeIndex } from "../tree-helpers";
 import { Mode, type PendingAction, pendingKey, type TreeItem } from "../types";
 import type { RepoInfo } from "./useRegistry";
 import type { TmuxClientDiscovery, TmuxSessionInfo } from "./useTmux";
@@ -51,8 +51,7 @@ export function createNavigateTree(deps: SessionActionDeps) {
     deps.setSelectedIndex((prev) => {
       let next = prev + direction;
       while (next >= 0 && next < deps.treeItems.length) {
-        const item = deps.treeItems[next];
-        if (item?.type === "detail" && item.detailKind === "pane-header") {
+        if (isInertTreeItem(deps.treeItems[next])) {
           next += direction;
           continue;
         }

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -1,5 +1,9 @@
 import type { RepoInfo } from "../hooks/useRegistry";
-import { isWithinExpandedSubtree, type TreeRow } from "../tree-helpers";
+import {
+  isInertTreeItem,
+  isWithinExpandedSubtree,
+  type TreeRow,
+} from "../tree-helpers";
 import type { Mode, TreeItem } from "../types";
 
 /**
@@ -32,6 +36,30 @@ const SGR_CHUNK = /^(?:\x1b?\[<\d+;\d+;\d+[Mm])+$/;
 /** Global matcher used to split a mouse-only chunk into single sequences. */
 // biome-ignore lint/suspicious/noControlCharactersInRegex: see SGR above
 const SGR_SPLIT = /\x1b?\[<\d+;\d+;\d+[Mm]/g;
+
+/**
+ * Legacy X10 mouse-report prefix (`ESC [ M`). `MOUSE_ENABLE` requests ?1000
+ * (report clicks) and ?1006 (SGR encoding) together; a terminal that honors
+ * ?1000 but ignores ?1006 (PuTTY < 0.77, urxvt < 9.25, old mosh) reports in
+ * X10 encoding instead: `ESC [ M` followed by exactly 3 raw bytes (button+32,
+ * col+32, row+32). Ink's input parser terminates the CSI at the `M` final
+ * byte, so the prefix arrives as its own `useInput` event (leading ESC
+ * stripped) and the 3 coordinate bytes — often printable characters — arrive
+ * as a SEPARATE event that `isMouseSequence` cannot recognise by shape. The
+ * guard uses this predicate to swallow the prefix AND arm a 3-byte swallow
+ * for the bytes that follow, so a click on such a terminal cannot type junk
+ * into Search or a modal text field. X10 events are only swallowed, never
+ * acted on: acting requires SGR.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: see SGR above
+const X10_PREFIX = /^\x1b?\[M$/;
+
+/** Bytes of X10 payload (button, col, row) that follow an `ESC [ M` prefix. */
+export const X10_PAYLOAD_BYTES = 3;
+
+export function isX10MousePrefix(input: string): boolean {
+  return X10_PREFIX.test(input);
+}
 
 export type MouseEvent =
   | { kind: "wheel"; dir: 1 | -1 }
@@ -100,7 +128,10 @@ export function parseSgrMouse(input: string): MouseEvent | null {
   const row = Number(m[3]); // 1-based
   const isRelease = m[4] === "m";
   if ((cb & 64) === 64) {
-    // wheel: 64 = up, 65 = down (up → -1, down → +1)
+    // wheel: the low 2 bits distinguish 64 = up, 65 = down, 66 = wheel-left,
+    // 67 = wheel-right (tilt wheel / horizontal trackpad swipe). Horizontal
+    // ticks must be ignored, not decoded by bit 0 as vertical scrolling.
+    if ((cb & 3) >= 2) return null;
     return { kind: "wheel", dir: (cb & 1) === 0 ? -1 : 1 };
   }
   if (cb & 32) return null; // motion/drag — ignored in v1
@@ -168,11 +199,9 @@ export function resolveMouseAction(
     return { kind: "none" }; // phantom row / padding
   }
 
-  // Pane headers are inert separators the keyboard can never land on
-  // (createNavigateTree skips them with this exact predicate); mirror that so
-  // a click cannot select a row that follow-up keys treat inconsistently.
-  const item = ctx.treeItems[itemIndex];
-  if (item?.type === "detail" && item.detailKind === "pane-header") {
+  // Inert rows (pane headers) are skipped by keyboard navigation via the same
+  // shared predicate, so a click cannot select a row arrow keys refuse.
+  if (isInertTreeItem(ctx.treeItems[itemIndex])) {
     return { kind: "none" };
   }
 

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -13,6 +13,26 @@ export const HEADER_OFFSET = 2;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: the ESC (\x1b) byte is the literal start of an SGR mouse sequence and must be matched
 const SGR = /^\x1b?\[<(\d+);(\d+);(\d+)([Mm])$/;
 
+/**
+ * One or more concatenated SGR sequences. On the normal stdin path Ink 7.1
+ * delivers exactly ONE sequence per `useInput` call: its input parser
+ * (ink/build/input-parser.js) splits each complete CSI sequence in a chunk
+ * into its own event ('<', digits, ';' are parameter bytes, 'M'/'m' finals;
+ * truncated tails are held pending and reassembled), and use-input.js strips
+ * the leading ESC of EACH event. The only path that can hand `useInput` a
+ * multi-sequence (or inner-ESC) string is Ink's bracketed-paste fallback
+ * (`emitInput(event.paste)` when no paste listener is registered) carrying
+ * mouse-shaped pasted text. Accepting one-or-more sequences here is
+ * defense-in-depth for that path — and for any future change in Ink's
+ * delivery model — NOT a description of normal stdin behaviour.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: see SGR above
+const SGR_CHUNK = /^(?:\x1b?\[<\d+;\d+;\d+[Mm])+$/;
+
+/** Global matcher used to split a mouse-only chunk into single sequences. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: see SGR above
+const SGR_SPLIT = /\x1b?\[<\d+;\d+;\d+[Mm]/g;
+
 export type MouseEvent =
   | { kind: "wheel"; dir: 1 | -1 }
   | {
@@ -33,11 +53,35 @@ export type MouseEvent =
  * mouse sequence." Falling through the dispatcher guard would let those bytes
  * reach mode-specific handlers (e.g. Search's text input), corrupting state.
  *
- * Matches the same anchored SGR shape as `parseSgrMouse`'s regex; kept as a
- * separate, pure predicate so `parseSgrMouse` itself stays unchanged.
+ * Also true for a string of several concatenated sequences (see `SGR_CHUNK` —
+ * normal stdin delivery is one sequence per event; the multi-sequence form
+ * only occurs via Ink's paste fallback and is handled as defense-in-depth).
+ * Semantics: input is swallowed as mouse only when it is ENTIRELY mouse
+ * sequences. A mixed string like `a[<0;5;5M` is NOT swallowed — swallowing
+ * it would drop the user's keystroke. Accepted trade-off: a bracketed paste
+ * whose text is exactly one-or-more mouse-shaped tokens (someone literally
+ * pasting `[<0;12;38M` into a text field) is swallowed as mouse input; that
+ * case is vanishingly rare and inherent to shape-based guarding.
+ *
+ * Kept as a separate, pure predicate so `parseSgrMouse` stays single-sequence.
  */
 export function isMouseSequence(input: string): boolean {
-  return SGR.test(input);
+  return SGR_CHUNK.test(input);
+}
+
+/**
+ * Split a mouse-only string into its individual SGR sequences, in order,
+ * each consumable by `parseSgrMouse`. On the normal stdin path Ink already
+ * delivers one sequence per event, so this usually yields a single element;
+ * if a multi-sequence string ever arrives (paste fallback, or a future Ink
+ * delivery change) dispatch iterates ALL of them — e.g. two wheel ticks must
+ * scroll twice, never just the first. Returns `[]` for anything
+ * `isMouseSequence` rejects (mixed or non-mouse input is a keyboard concern,
+ * not ours).
+ */
+export function splitMouseSequences(input: string): string[] {
+  if (!isMouseSequence(input)) return [];
+  return input.match(SGR_SPLIT) ?? [];
 }
 
 /**

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -1,0 +1,126 @@
+import type { RepoInfo } from "../hooks/useRegistry";
+import { isWithinExpandedSubtree, type TreeRow } from "../tree-helpers";
+import type { Mode, TreeItem } from "../types";
+
+/**
+ * Rows of fixed chrome above the tree viewport: the `wct` header line + a blank
+ * spacer line. A 1-based SGR mouse `row` maps to a viewport row by subtracting
+ * this offset (and the 1-based → 0-based conversion).
+ */
+export const HEADER_OFFSET = 2;
+
+/** SGR extended mouse event (DECSET ?1006). ESC is already stripped by Ink. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: the ESC (\x1b) byte is the literal start of an SGR mouse sequence and must be matched
+const SGR = /^\x1b?\[<(\d+);(\d+);(\d+)([Mm])$/;
+
+export type MouseEvent =
+  | { kind: "wheel"; dir: 1 | -1 }
+  | {
+      kind: "press";
+      button: "left" | "middle" | "right";
+      col: number;
+      row: number;
+    };
+
+/**
+ * Parse a single SGR mouse sequence out of the string Ink forwards to
+ * `useInput`. Returns `null` for anything that is not a recognised mouse event
+ * we act on (release, motion/drag, malformed input).
+ *
+ * The button is decoded with a BITMASK — never `Cb % 4`, which turns wheel-up
+ * (Cb 64) into button 0 and misfires clicks on scroll (Ink PR #955 bug).
+ */
+export function parseSgrMouse(input: string): MouseEvent | null {
+  const m = SGR.exec(input);
+  if (!m) return null;
+  const cb = Number(m[1]);
+  const col = Number(m[2]); // 1-based
+  const row = Number(m[3]); // 1-based
+  const isRelease = m[4] === "m";
+  if ((cb & 64) === 64) {
+    // wheel: 64 = up, 65 = down (up → -1, down → +1)
+    return { kind: "wheel", dir: (cb & 1) === 0 ? -1 : 1 };
+  }
+  if (cb & 32) return null; // motion/drag — ignored in v1
+  if (isRelease) return null; // act on press only
+  // Additional buttons (8+: back/forward on multi-button mice) set bit 7 and
+  // would otherwise misdecode as a left press via `(cb & 3) === 0`. Ignore them.
+  if (cb & 0x80) return null;
+  const button = (cb & 3) === 0 ? "left" : (cb & 3) === 1 ? "middle" : "right";
+  return { kind: "press", button, col, row };
+}
+
+export interface MouseActionContext {
+  mode: Mode;
+  rows: TreeRow[];
+  /** The CLAMPED offset the render is sliced with — never the raw scrollOffset. */
+  effectiveScrollOffset: number;
+  viewportRows: number;
+  treeItems: TreeItem[];
+  repos: RepoInfo[];
+  expandedWorktreeKey: string | null;
+}
+
+export type MouseAction =
+  | { kind: "none" }
+  | { kind: "scroll"; delta: 1 | -1 }
+  | { kind: "select"; itemIndex: number }
+  | { kind: "selectAndExitExpanded"; itemIndex: number };
+
+/**
+ * Resolve a parsed mouse event into a pure description of what should happen,
+ * testable without React. Only Navigate and Expanded mode act on mouse; every
+ * other mode (modals, Search, confirmations) resolves to `none` (the event is
+ * still swallowed upstream so no escape garble reaches the screen).
+ *
+ * - Wheel → scroll only; the selection is untouched and may scroll out of view.
+ * - Left-click → hit-test the row under the cursor and select it. In Expanded
+ *   mode, a click within the expanded worktree's subtree stays; a click outside
+ *   exits to Navigate. Non-left buttons and clicks on chrome/phantom rows are
+ *   `none`.
+ */
+export function resolveMouseAction(
+  event: MouseEvent,
+  ctx: MouseActionContext,
+): MouseAction {
+  if (ctx.mode.type !== "Navigate" && ctx.mode.type !== "Expanded") {
+    return { kind: "none" };
+  }
+
+  if (event.kind === "wheel") {
+    return { kind: "scroll", delta: event.dir };
+  }
+
+  if (event.button !== "left") {
+    return { kind: "none" };
+  }
+
+  // Hit-test: map the 1-based SGR row to a visible row, then to its item.
+  const viewportRow = event.row - 1 - HEADER_OFFSET;
+  if (viewportRow < 0 || viewportRow >= ctx.viewportRows) {
+    return { kind: "none" }; // header / StatusBar / below the viewport
+  }
+  const row = ctx.rows[ctx.effectiveScrollOffset + viewportRow];
+  const itemIndex = row?.itemIndex;
+  if (itemIndex == null) {
+    return { kind: "none" }; // phantom row / padding
+  }
+
+  if (ctx.mode.type === "Navigate") {
+    return { kind: "select", itemIndex };
+  }
+
+  // Expanded: stay if the click landed within the expanded worktree's subtree,
+  // otherwise exit to Navigate and select the clicked row.
+  if (
+    isWithinExpandedSubtree(
+      ctx.treeItems,
+      itemIndex,
+      ctx.expandedWorktreeKey,
+      ctx.repos,
+    )
+  ) {
+    return { kind: "select", itemIndex };
+  }
+  return { kind: "selectAndExitExpanded", itemIndex };
+}

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -94,8 +94,8 @@ export type MouseAction =
  * - Wheel → scroll only; the selection is untouched and may scroll out of view.
  * - Left-click → hit-test the row under the cursor and select it. In Expanded
  *   mode, a click within the expanded worktree's subtree stays; a click outside
- *   exits to Navigate. Non-left buttons and clicks on chrome/phantom rows are
- *   `none`.
+ *   exits to Navigate. Non-left buttons and clicks on chrome/phantom rows or
+ *   inert pane-header rows (which keyboard navigation also skips) are `none`.
  */
 export function resolveMouseAction(
   event: MouseEvent,
@@ -122,6 +122,14 @@ export function resolveMouseAction(
   const itemIndex = row?.itemIndex;
   if (itemIndex == null) {
     return { kind: "none" }; // phantom row / padding
+  }
+
+  // Pane headers are inert separators the keyboard can never land on
+  // (createNavigateTree skips them with this exact predicate); mirror that so
+  // a click cannot select a row that follow-up keys treat inconsistently.
+  const item = ctx.treeItems[itemIndex];
+  if (item?.type === "detail" && item.detailKind === "pane-header") {
+    return { kind: "none" };
   }
 
   if (ctx.mode.type === "Navigate") {

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -23,6 +23,24 @@ export type MouseEvent =
     };
 
 /**
+ * True for ANY SGR mouse escape sequence — press, release, motion/drag, and
+ * extra-button events alike — regardless of whether `parseSgrMouse` resolves
+ * it to an actionable `MouseEvent`. Used by the `useInput` dispatcher guard to
+ * swallow every mouse sequence (ADR 0002 / PRD §6.6): a click emits BOTH a
+ * press and a release sequence, and `parseSgrMouse` intentionally returns
+ * `null` for the release half (and for motion/extra-button events) because
+ * those are not actionable — but non-actionable is not the same as "not a
+ * mouse sequence." Falling through the dispatcher guard would let those bytes
+ * reach mode-specific handlers (e.g. Search's text input), corrupting state.
+ *
+ * Matches the same anchored SGR shape as `parseSgrMouse`'s regex; kept as a
+ * separate, pure predicate so `parseSgrMouse` itself stays unchanged.
+ */
+export function isMouseSequence(input: string): boolean {
+  return SGR.test(input);
+}
+
+/**
  * Parse a single SGR mouse sequence out of the string Ink forwards to
  * `useInput`. Returns `null` for anything that is not a recognised mouse event
  * we act on (release, motion/drag, malformed input).

--- a/src/tui/pr-layout.ts
+++ b/src/tui/pr-layout.ts
@@ -1,0 +1,84 @@
+// src/tui/pr-layout.ts
+//
+// PR detail rows are the ONE tree line allowed to wrap onto multiple terminal
+// rows (the title is shown in full, never truncated). The visual-row model in
+// `tree-helpers` is otherwise 1:1 with terminal rows, so a wrapped PR would
+// shift every row below it and desync mouse hit-testing. To keep them aligned,
+// BOTH the row model (`buildTreeRows`) and the renderer (`DetailRow`) wrap the
+// label through this single pure helper — same input, same line breaks, so the
+// counted rows and the rendered lines can never diverge.
+//
+// Column width is approximated by code-point count (matching the truncate
+// helpers). That is exact for the ASCII text PR titles almost always contain,
+// but a double-width glyph (CJK/emoji) renders wider than its code-point count,
+// so Ink could soft-wrap a piece we counted as one line and re-introduce a
+// smaller version of the desync. Fixing that needs a wcwidth measurement, which
+// would pull in a dependency the project forbids (effect + platform-bun only),
+// so it is a deliberately accepted limitation, not an oversight.
+
+/** Leading indent columns of a PR detail line. */
+export const PR_INDENT = 6;
+/** Selector-prefix columns ("▸ " / "  "). */
+export const PR_SELECTOR = 2;
+/** Rollup-icon columns ("✓ ") when a rollup state is present. */
+export const PR_ICON = 2;
+
+/**
+ * Columns consumed before the PR label on its first line. Continuation lines
+ * are indented by this same amount so the wrapped text aligns under the label.
+ * DetailRow renders exactly this much leading chrome (indent + selector + icon),
+ * so `maxWidth - prLabelStart` is the true per-line budget for the label.
+ */
+export function prLabelStart(hasIcon: boolean): number {
+  return PR_INDENT + PR_SELECTOR + (hasIcon ? PR_ICON : 0);
+}
+
+/**
+ * Greedy word-wrap `text` into lines no wider than `width` columns. A word
+ * longer than `width` is hard-broken on code-point boundaries (never splitting
+ * a surrogate pair into lone halves). Code-point count is treated as column
+ * width, matching the truncate helpers. Always returns at least one (possibly
+ * empty) line.
+ */
+function wrapWords(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const lines: string[] = [];
+  let current = "";
+  for (const word of text.split(" ")) {
+    // Code points, so a hard break never severs a surrogate pair.
+    let chars = [...word];
+    while (chars.length > width) {
+      if (current !== "") {
+        lines.push(current);
+        current = "";
+      }
+      lines.push(chars.slice(0, width).join(""));
+      chars = chars.slice(width);
+    }
+    const w = chars.join("");
+    const wLen = chars.length;
+    if (current === "") {
+      current = w;
+    } else if ([...current].length + 1 + wLen <= width) {
+      current += ` ${w}`;
+    } else {
+      lines.push(current);
+      current = w;
+    }
+  }
+  lines.push(current);
+  return lines;
+}
+
+/**
+ * Split a PR label into the terminal lines it occupies at `maxWidth`. Line 0 is
+ * rendered after the indent/selector/icon; any further lines are continuation
+ * lines indented by `prLabelStart` to align under line 0's label.
+ */
+export function wrapPrLabel(
+  label: string,
+  maxWidth: number,
+  hasIcon: boolean,
+): string[] {
+  return wrapWords(label, Math.max(1, maxWidth - prLabelStart(hasIcon)));
+}

--- a/src/tui/pr-layout.ts
+++ b/src/tui/pr-layout.ts
@@ -8,13 +8,15 @@
 // label through this single pure helper — same input, same line breaks, so the
 // counted rows and the rendered lines can never diverge.
 //
-// Column width is approximated by code-point count (matching the truncate
-// helpers). That is exact for the ASCII text PR titles almost always contain,
-// but a double-width glyph (CJK/emoji) renders wider than its code-point count,
-// so Ink could soft-wrap a piece we counted as one line and re-introduce a
-// smaller version of the desync. Fixing that needs a wcwidth measurement, which
-// would pull in a dependency the project forbids (effect + platform-bun only),
-// so it is a deliberately accepted limitation, not an oversight.
+// Column width is measured as terminal display width (`utils/display-width`):
+// CJK and emoji glyphs count two columns, matching how Ink (via
+// `string-width`) decides whether a line soft-wraps. That measurement is
+// biased to never undercount, so a line this helper emits is never wider than
+// its budget under Ink's measurement — and DetailRow renders label lines with
+// wrap="truncate-end" as a backstop, so even a measurement disagreement could
+// only clip a glyph, never add a terminal row.
+
+import { displayWidth, graphemeWidths } from "./utils/display-width";
 
 /** Leading indent columns of a PR detail line. */
 export const PR_INDENT = 6;
@@ -34,36 +36,51 @@ export function prLabelStart(hasIcon: boolean): number {
 }
 
 /**
- * Greedy word-wrap `text` into lines no wider than `width` columns. A word
- * longer than `width` is hard-broken on code-point boundaries (never splitting
- * a surrogate pair into lone halves). Code-point count is treated as column
- * width, matching the truncate helpers. Always returns at least one (possibly
- * empty) line.
+ * Greedy word-wrap `text` into lines no wider than `width` display columns
+ * (CJK/emoji glyphs count 2). A word wider than `width` is hard-broken on
+ * grapheme boundaries — never splitting a surrogate pair or an emoji ZWJ
+ * sequence. Always returns at least one (possibly empty) line.
  */
 function wrapWords(text: string, width: number): string[] {
   if (width <= 0) return [text];
   const lines: string[] = [];
   let current = "";
+  let currentWidth = 0;
   for (const word of text.split(" ")) {
-    // Code points, so a hard break never severs a surrogate pair.
-    let chars = [...word];
-    while (chars.length > width) {
+    let w = word;
+    let wordWidth = displayWidth(word);
+    if (wordWidth > width) {
+      // Hard-break: flush the current line, emit full-width pieces, and carry
+      // the final piece forward as this iteration's word.
       if (current !== "") {
         lines.push(current);
         current = "";
+        currentWidth = 0;
       }
-      lines.push(chars.slice(0, width).join(""));
-      chars = chars.slice(width);
+      let piece = "";
+      let pieceWidth = 0;
+      for (const [grapheme, graphemeW] of graphemeWidths(word)) {
+        if (piece !== "" && pieceWidth + graphemeW > width) {
+          lines.push(piece);
+          piece = "";
+          pieceWidth = 0;
+        }
+        piece += grapheme;
+        pieceWidth += graphemeW;
+      }
+      w = piece;
+      wordWidth = pieceWidth;
     }
-    const w = chars.join("");
-    const wLen = chars.length;
     if (current === "") {
       current = w;
-    } else if ([...current].length + 1 + wLen <= width) {
+      currentWidth = wordWidth;
+    } else if (currentWidth + 1 + wordWidth <= width) {
       current += ` ${w}`;
+      currentWidth += 1 + wordWidth;
     } else {
       lines.push(current);
       current = w;
+      currentWidth = wordWidth;
     }
   }
   lines.push(current);

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -3,6 +3,7 @@
 import { basename } from "node:path";
 import { formatSessionName } from "../services/tmux";
 import { formatSync } from "../services/worktree-service";
+import { wrapPrLabel } from "./pr-layout";
 import type { RepoInfo } from "./hooks/useRegistry";
 import {
   Mode,
@@ -28,6 +29,12 @@ interface BuildTreeRowsOptions {
   expandedRepos: Set<string>;
   expandedWorktreeKey: string | null;
   pendingActions: Map<string, PendingAction>;
+  /**
+   * Terminal width in columns, used to count how many terminal lines a PR
+   * detail label wraps onto. Defaults to `Infinity` (no wrapping) so callers
+   * and tests that don't model wrapping keep a 1:1 row-per-detail mapping.
+   */
+  maxWidth?: number;
 }
 
 /**
@@ -38,6 +45,8 @@ interface BuildTreeRowsOptions {
  *
  * `itemIndex` maps each visual row back to its logical item index in `items`
  * (or `null` for secondary/phantom rows that are not independently selectable).
+ * A wrapped PR's continuation rows carry the PR's own `itemIndex` so a click on
+ * any wrapped line still selects the PR.
  * `kind` carries enough information for `TreeView` to render the row directly,
  * so the row model is the single source of truth for both windowing and the
  * render itself.
@@ -53,6 +62,7 @@ export type TreeRow =
       worktreeIndex: number;
     }
   | { itemIndex: number; kind: "detail" }
+  | { itemIndex: number; kind: "detail-pr-cont"; pieceIndex: number }
   | { itemIndex: null; kind: "phantom"; repoIndex: number; branch: string };
 
 interface ResolveSelectedPaneOptions {
@@ -247,6 +257,7 @@ export function buildTreeRows({
   expandedRepos,
   expandedWorktreeKey,
   pendingActions,
+  maxWidth = Number.POSITIVE_INFINITY,
 }: BuildTreeRowsOptions): TreeRow[] {
   const rows: TreeRow[] = [];
   const phantoms = phantomsByProject(repos, pendingActions);
@@ -296,6 +307,21 @@ export function buildTreeRows({
 
     if (item.type === "detail") {
       rows.push({ itemIndex: idx, kind: "detail" });
+      // A PR label is shown in full and may wrap onto extra terminal lines.
+      // Emit one continuation row per wrapped line (all carrying the PR's own
+      // itemIndex) so the row model stays 1:1 with terminal rows and clicks on
+      // wrapped text still hit the PR. pane/pane-header labels are truncated to
+      // a single line, so only PR rows can wrap.
+      if (item.detailKind === "pr") {
+        const lineCount = wrapPrLabel(
+          item.label,
+          maxWidth,
+          item.meta.rollupState !== null,
+        ).length;
+        for (let piece = 1; piece < lineCount; piece++) {
+          rows.push({ itemIndex: idx, kind: "detail-pr-cont", pieceIndex: piece });
+        }
+      }
       emitPhantomsIfRepoBlockEnds(idx, item.repoIndex, repo.project);
       continue;
     }

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -2,10 +2,12 @@
 
 import { basename } from "node:path";
 import { formatSessionName } from "../services/tmux";
+import { formatSync } from "../services/worktree-service";
 import type { RepoInfo } from "./hooks/useRegistry";
 import {
   Mode,
   type PaneInfo,
+  type PendingAction,
   type PRInfo,
   pendingKey,
   type TreeItem,
@@ -19,6 +21,39 @@ interface BuildTreeOptions {
   panes: Map<string, PaneInfo[]>;
   jumpToPane: (paneId: string) => void;
 }
+
+interface BuildTreeRowsOptions {
+  items: TreeItem[];
+  repos: RepoInfo[];
+  expandedRepos: Set<string>;
+  expandedWorktreeKey: string | null;
+  pendingActions: Map<string, PendingAction>;
+}
+
+/**
+ * A single *visual terminal row*. Logical tree items are not 1:1 with terminal
+ * rows: an expanded worktree with stats emits a second row, an expanded repo
+ * with zero worktrees emits a `(no worktrees)` row, and phantom "opening…" rows
+ * are not present in `items` at all.
+ *
+ * `itemIndex` maps each visual row back to its logical item index in `items`
+ * (or `null` for secondary/phantom rows that are not independently selectable).
+ * `kind` carries enough information for `TreeView` to render the row directly,
+ * so the row model is the single source of truth for both windowing and the
+ * render itself.
+ */
+export type TreeRow =
+  | { itemIndex: number; kind: "repo" }
+  | { itemIndex: null; kind: "repo-empty"; repoIndex: number }
+  | { itemIndex: number; kind: "worktree" }
+  | {
+      itemIndex: null;
+      kind: "worktree-stats";
+      repoIndex: number;
+      worktreeIndex: number;
+    }
+  | { itemIndex: number; kind: "detail" }
+  | { itemIndex: null; kind: "phantom"; repoIndex: number; branch: string };
 
 interface ResolveSelectedPaneOptions {
   repos: RepoInfo[];
@@ -162,6 +197,230 @@ export function buildTreeItems({
     }
   }
   return items;
+}
+
+/**
+ * Phantom "opening…" rows, grouped by project. These are pending `open` actions
+ * for branches that do not yet exist as worktrees in `repos`. Mirrors the
+ * computation `TreeView` performs so the row model matches the render exactly.
+ */
+function phantomsByProject(
+  repos: RepoInfo[],
+  pendingActions: Map<string, PendingAction>,
+): Map<string, PendingAction[]> {
+  const keys = new Set<string>();
+  for (const repo of repos) {
+    for (const wt of repo.worktrees) {
+      keys.add(pendingKey(repo.project, wt.branch));
+    }
+  }
+  const phantoms = new Map<string, PendingAction[]>();
+  for (const [key, action] of pendingActions) {
+    if (action.type === "opening" && !keys.has(key)) {
+      const existing = phantoms.get(action.project) ?? [];
+      existing.push(action);
+      phantoms.set(action.project, existing);
+    }
+  }
+  return phantoms;
+}
+
+/**
+ * Build the visual-row model — one entry per *terminal row* — from the logical
+ * `items` list. This is the shared primitive that drives both windowing (slice
+ * by scroll offset) and, in a later slice, hit-testing (click row → item).
+ *
+ * The row order replicates `TreeView`'s render exactly:
+ * - a repo row, optionally followed by a `(no worktrees)` row when expanded
+ *   with zero worktrees;
+ * - a worktree row, optionally followed by a stats row when expanded with
+ *   sync/changed-file stats;
+ * - detail rows;
+ * - phantom "opening…" rows for a *populated* repo are emitted after that
+ *   repo's last worktree row block;
+ * - phantom rows for *empty* expanded repos are appended at the very bottom of
+ *   the whole tree (matching the rendering quirk in `TreeView`).
+ */
+export function buildTreeRows({
+  items,
+  repos,
+  expandedRepos,
+  expandedWorktreeKey,
+  pendingActions,
+}: BuildTreeRowsOptions): TreeRow[] {
+  const rows: TreeRow[] = [];
+  const phantoms = phantomsByProject(repos, pendingActions);
+
+  for (let idx = 0; idx < items.length; idx++) {
+    const item = items[idx];
+    if (!item) continue;
+
+    const repo = repos[item.repoIndex];
+    if (!repo) continue;
+
+    if (item.type === "repo") {
+      rows.push({ itemIndex: idx, kind: "repo" });
+      if (expandedRepos.has(repo.id) && repo.worktrees.length === 0) {
+        rows.push({
+          itemIndex: null,
+          kind: "repo-empty",
+          repoIndex: item.repoIndex,
+        });
+      }
+      continue;
+    }
+
+    if (item.type === "detail") {
+      rows.push({ itemIndex: idx, kind: "detail" });
+      continue;
+    }
+
+    // worktree
+    const worktreeIndex = item.worktreeIndex;
+    const wt = repo.worktrees[worktreeIndex];
+    if (!wt) continue;
+
+    rows.push({ itemIndex: idx, kind: "worktree" });
+
+    const wtKey = pendingKey(repo.project, wt.branch);
+    const isExpanded = expandedWorktreeKey === wtKey;
+    const pending = pendingActions.get(wtKey);
+    // opening/closing/stopping worktrees render as a single line (no stats
+    // row); `starting` falls through to the normal render and can show stats.
+    const isPending =
+      pending?.type === "opening" ||
+      pending?.type === "closing" ||
+      pending?.type === "stopping";
+    const sync = formatSync(wt.sync);
+    const hasStats = (sync !== "" && sync !== "✓") || wt.changedFiles > 0;
+    if (isExpanded && hasStats && !isPending) {
+      rows.push({
+        itemIndex: null,
+        kind: "worktree-stats",
+        repoIndex: item.repoIndex,
+        worktreeIndex,
+      });
+    }
+
+    // Phantom "opening…" rows for a populated repo follow the repo's last
+    // worktree-row block (and any detail rows belonging to it).
+    const nextItem = items[idx + 1];
+    const isLastWorktreeForRepo =
+      !nextItem ||
+      nextItem.type === "repo" ||
+      nextItem.repoIndex !== item.repoIndex;
+    if (isLastWorktreeForRepo) {
+      const projectPhantoms = phantoms.get(repo.project);
+      if (projectPhantoms) {
+        for (const phantom of projectPhantoms) {
+          rows.push({
+            itemIndex: null,
+            kind: "phantom",
+            repoIndex: item.repoIndex,
+            branch: phantom.branch,
+          });
+        }
+      }
+    }
+  }
+
+  // Phantom rows for expanded repos with no worktrees are appended at the very
+  // bottom of the whole tree (a rendering quirk in `TreeView`).
+  for (let ri = 0; ri < repos.length; ri++) {
+    const repo = repos[ri];
+    if (!repo) continue;
+    if (!expandedRepos.has(repo.id)) continue;
+    if (repo.worktrees.length > 0) continue;
+    const projectPhantoms = phantoms.get(repo.project);
+    if (!projectPhantoms) continue;
+    for (const phantom of projectPhantoms) {
+      rows.push({
+        itemIndex: null,
+        kind: "phantom",
+        repoIndex: ri,
+        branch: phantom.branch,
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Find the index of the first visual row that maps to the given logical
+ * `itemIndex`, or `null` if no row maps to it.
+ */
+export function firstRowForItem(
+  rows: TreeRow[],
+  itemIndex: number,
+): number | null {
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i]?.itemIndex === itemIndex) {
+      return i;
+    }
+  }
+  return null;
+}
+
+/**
+ * Clamp a scroll offset to the valid range `[0, max(0, rowsLength -
+ * viewportRows)]`. When the tree fits the viewport the offset is forced to 0.
+ */
+export function clampScrollOffset(
+  offset: number,
+  rowsLength: number,
+  viewportRows: number,
+): number {
+  const max = Math.max(0, rowsLength - viewportRows);
+  if (offset < 0) return 0;
+  if (offset > max) return max;
+  return offset;
+}
+
+/**
+ * Minimally nudge the scroll offset so the visual row at `rowIndex` stays
+ * within the window `[offset, offset + viewportRows - 1]`:
+ * - if it is above the window, set the offset to that row;
+ * - if it is below the window, set `offset = rowIndex - viewportRows + 1`;
+ * - otherwise leave the offset unchanged.
+ *
+ * Nudge only — never re-center.
+ */
+export function scrollToKeepVisible(
+  rowIndex: number,
+  offset: number,
+  viewportRows: number,
+): number {
+  if (viewportRows <= 0) return offset;
+  if (rowIndex < offset) {
+    return rowIndex;
+  }
+  if (rowIndex > offset + viewportRows - 1) {
+    return rowIndex - viewportRows + 1;
+  }
+  return offset;
+}
+
+/**
+ * Resolve the owning worktree key for an item (a worktree row's own key, or a
+ * detail row's owning-worktree key) and compare it to `expandedWorktreeKey`.
+ * Used by the click handler to decide whether a click stays in Expanded mode.
+ */
+export function isWithinExpandedSubtree(
+  items: TreeItem[],
+  itemIndex: number,
+  expandedWorktreeKey: string | null,
+  repos: RepoInfo[],
+): boolean {
+  if (!expandedWorktreeKey) return false;
+  const worktreeIndex = findOwningWorktreeIndex(items, itemIndex);
+  if (worktreeIndex === null) return false;
+  const worktree = items[worktreeIndex];
+  if (worktree?.type !== "worktree") return false;
+  const repo = repos[worktree.repoIndex];
+  const wt = repo?.worktrees[worktree.worktreeIndex];
+  if (!repo || !wt) return false;
+  return pendingKey(repo.project, wt.branch) === expandedWorktreeKey;
 }
 
 /**

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -61,8 +61,13 @@ export type TreeRow =
       repoIndex: number;
       worktreeIndex: number;
     }
-  | { itemIndex: number; kind: "detail" }
-  | { itemIndex: number; kind: "detail-pr-cont"; pieceIndex: number }
+  | { itemIndex: number; kind: "detail"; prLine?: string }
+  | {
+      itemIndex: number;
+      kind: "detail-pr-cont";
+      pieceIndex: number;
+      prLine: string;
+    }
   | { itemIndex: null; kind: "phantom"; repoIndex: number; branch: string };
 
 interface ResolveSelectedPaneOptions {
@@ -306,25 +311,31 @@ export function buildTreeRows({
     }
 
     if (item.type === "detail") {
-      rows.push({ itemIndex: idx, kind: "detail" });
       // A PR label is shown in full and may wrap onto extra terminal lines.
       // Emit one continuation row per wrapped line (all carrying the PR's own
       // itemIndex) so the row model stays 1:1 with terminal rows and clicks on
-      // wrapped text still hit the PR. pane/pane-header labels are truncated to
-      // a single line, so only PR rows can wrap.
+      // wrapped text still hit the PR. Each row carries its own wrapped line
+      // text (`prLine`), so the render consumes exactly the lines this model
+      // counted — the count and the rendered text cannot diverge, and
+      // DetailRow never re-wraps. pane/pane-header labels are truncated to a
+      // single line, so only PR rows can wrap.
       if (item.detailKind === "pr") {
-        const lineCount = wrapPrLabel(
+        const lines = wrapPrLabel(
           item.label,
           maxWidth,
           item.meta.rollupState !== null,
-        ).length;
-        for (let piece = 1; piece < lineCount; piece++) {
+        );
+        rows.push({ itemIndex: idx, kind: "detail", prLine: lines[0] ?? "" });
+        for (let piece = 1; piece < lines.length; piece++) {
           rows.push({
             itemIndex: idx,
             kind: "detail-pr-cont",
             pieceIndex: piece,
+            prLine: lines[piece] ?? "",
           });
         }
+      } else {
+        rows.push({ itemIndex: idx, kind: "detail" });
       }
       emitPhantomsIfRepoBlockEnds(idx, item.repoIndex, repo.project);
       continue;
@@ -438,6 +449,17 @@ export function scrollToKeepVisible(
     return rowIndex - viewportRows + 1;
   }
   return offset;
+}
+
+/**
+ * Pane headers are inert separators the cursor can never land on. The SINGLE
+ * predicate shared by keyboard navigation (`createNavigateTree` skips inert
+ * items) and mouse hit-testing (`resolveMouseAction` refuses to select them),
+ * so a click can never select a row that follow-up keys treat inconsistently.
+ * Add any future inert row kind here, never at the call sites.
+ */
+export function isInertTreeItem(item: TreeItem | undefined): boolean {
+  return item?.type === "detail" && item.detailKind === "pane-header";
 }
 
 /**

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -251,6 +251,30 @@ export function buildTreeRows({
   const rows: TreeRow[] = [];
   const phantoms = phantomsByProject(repos, pendingActions);
 
+  // Phantom "opening…" rows for a populated repo follow the repo's LAST
+  // row-emitting item — the final worktree row block including any trailing
+  // detail rows — so an expanded last worktree cannot swallow them.
+  const emitPhantomsIfRepoBlockEnds = (
+    idx: number,
+    repoIndex: number,
+    project: string,
+  ) => {
+    const nextItem = items[idx + 1];
+    const isLastItemForRepo =
+      !nextItem || nextItem.type === "repo" || nextItem.repoIndex !== repoIndex;
+    if (!isLastItemForRepo) return;
+    const projectPhantoms = phantoms.get(project);
+    if (!projectPhantoms) return;
+    for (const phantom of projectPhantoms) {
+      rows.push({
+        itemIndex: null,
+        kind: "phantom",
+        repoIndex,
+        branch: phantom.branch,
+      });
+    }
+  };
+
   for (let idx = 0; idx < items.length; idx++) {
     const item = items[idx];
     if (!item) continue;
@@ -272,6 +296,7 @@ export function buildTreeRows({
 
     if (item.type === "detail") {
       rows.push({ itemIndex: idx, kind: "detail" });
+      emitPhantomsIfRepoBlockEnds(idx, item.repoIndex, repo.project);
       continue;
     }
 
@@ -302,26 +327,10 @@ export function buildTreeRows({
       });
     }
 
-    // Phantom "opening…" rows for a populated repo follow the repo's last
-    // worktree-row block (and any detail rows belonging to it).
-    const nextItem = items[idx + 1];
-    const isLastWorktreeForRepo =
-      !nextItem ||
-      nextItem.type === "repo" ||
-      nextItem.repoIndex !== item.repoIndex;
-    if (isLastWorktreeForRepo) {
-      const projectPhantoms = phantoms.get(repo.project);
-      if (projectPhantoms) {
-        for (const phantom of projectPhantoms) {
-          rows.push({
-            itemIndex: null,
-            kind: "phantom",
-            repoIndex: item.repoIndex,
-            branch: phantom.branch,
-          });
-        }
-      }
-    }
+    // Phantom "opening…" rows follow the repo's last worktree-row block. When
+    // detail rows trail this worktree, the detail branch above emits them
+    // after the last detail row instead.
+    emitPhantomsIfRepoBlockEnds(idx, item.repoIndex, repo.project);
   }
 
   // Phantom rows for expanded repos with no worktrees are appended at the very

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -3,8 +3,8 @@
 import { basename } from "node:path";
 import { formatSessionName } from "../services/tmux";
 import { formatSync } from "../services/worktree-service";
-import { wrapPrLabel } from "./pr-layout";
 import type { RepoInfo } from "./hooks/useRegistry";
+import { wrapPrLabel } from "./pr-layout";
 import {
   Mode,
   type PaneInfo,
@@ -319,7 +319,11 @@ export function buildTreeRows({
           item.meta.rollupState !== null,
         ).length;
         for (let piece = 1; piece < lineCount; piece++) {
-          rows.push({ itemIndex: idx, kind: "detail-pr-cont", pieceIndex: piece });
+          rows.push({
+            itemIndex: idx,
+            kind: "detail-pr-cont",
+            pieceIndex: piece,
+          });
         }
       }
       emitPhantomsIfRepoBlockEnds(idx, item.repoIndex, repo.project);

--- a/src/tui/utils/display-width.ts
+++ b/src/tui/utils/display-width.ts
@@ -1,0 +1,79 @@
+// src/tui/utils/display-width.ts
+//
+// Terminal display-width measurement for TUI layout math. Ink decides whether
+// a line soft-wraps by measuring it with `string-width` (grapheme
+// segmentation + East Asian Width + emoji detection), so layout code that
+// budgets in "columns" must measure the same way — counting code points
+// undercounts CJK and emoji glyphs, which render two columns wide.
+//
+// The project forbids new runtime dependencies, so this is a small inline
+// approximation with a deliberate safety bias: it never UNDERcounts relative
+// to `string-width`. It may overcount rare clusters (a letter followed by a
+// combining mark counts 2 here, 1 in `string-width`), which only makes
+// callers wrap or truncate a column early — cosmetic, never a row desync.
+
+const segmenter = new Intl.Segmenter();
+
+/**
+ * East Asian Fullwidth/Wide code points (mirrors the well-known
+ * `is-fullwidth-code-point` range list).
+ */
+function isFullwidthCodePoint(cp: number): boolean {
+  return (
+    cp >= 0x1100 &&
+    (cp <= 0x115f || // Hangul Jamo
+      cp === 0x2329 || // LEFT-POINTING ANGLE BRACKET
+      cp === 0x232a || // RIGHT-POINTING ANGLE BRACKET
+      // CJK Radicals Supplement .. Enclosed CJK Letters and Months
+      (cp >= 0x2e80 && cp <= 0x3247 && cp !== 0x303f) ||
+      (cp >= 0x3250 && cp <= 0x4dbf) || // Enclosed CJK .. CJK Ext A, Yijing
+      (cp >= 0x4e00 && cp <= 0xa4c6) || // CJK Unified Ideographs .. Yi Radicals
+      (cp >= 0xa960 && cp <= 0xa97c) || // Hangul Jamo Extended-A
+      (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+      (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+      (cp >= 0xfe10 && cp <= 0xfe19) || // Vertical Forms
+      (cp >= 0xfe30 && cp <= 0xfe6b) || // CJK Compatibility Forms
+      (cp >= 0xff01 && cp <= 0xff60) || // Fullwidth Forms
+      (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth Signs
+      (cp >= 0x1b000 && cp <= 0x1b001) || // Kana Supplement
+      (cp >= 0x1f200 && cp <= 0x1f251) || // Enclosed Ideographic Supplement
+      (cp >= 0x20000 && cp <= 0x3fffd)) // CJK Extension B and beyond
+  );
+}
+
+/** Default-emoji-presentation code points render two columns wide. */
+const EMOJI_PRESENTATION = /^\p{Emoji_Presentation}$/u;
+
+/** Columns one grapheme cluster occupies. */
+function graphemeWidth(segment: string): number {
+  const codePoints = [...segment];
+  // Multi-code-point cluster: ZWJ emoji, flag, keycap, VS16 sequence, or a
+  // base letter + combining marks. All render at most two columns; counting 2
+  // overcounts only the combining-mark case, which is the safe direction.
+  if (codePoints.length > 1) return 2;
+  const cp = segment.codePointAt(0) ?? 0;
+  if (cp <= 0x1f || (cp >= 0x7f && cp <= 0x9f)) return 0; // control chars
+  if (isFullwidthCodePoint(cp) || EMOJI_PRESENTATION.test(segment)) return 2;
+  return 1;
+}
+
+/**
+ * Grapheme clusters of `text` with the column width of each — for callers
+ * that break lines and must never split a surrogate pair or emoji sequence.
+ */
+export function graphemeWidths(text: string): Array<[string, number]> {
+  const result: Array<[string, number]> = [];
+  for (const { segment } of segmenter.segment(text)) {
+    result.push([segment, graphemeWidth(segment)]);
+  }
+  return result;
+}
+
+/** Terminal columns `text` occupies when rendered on one line. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const { segment } of segmenter.segment(text)) {
+    width += graphemeWidth(segment);
+  }
+  return width;
+}

--- a/src/tui/utils/truncate.ts
+++ b/src/tui/utils/truncate.ts
@@ -1,9 +1,28 @@
-const ELLIPSIS = "…";
+import { displayWidth, graphemeWidths } from "./display-width";
 
+const ELLIPSIS = "…"; // 1 display column
+
+/**
+ * Truncate `text` to at most `available` terminal display columns, appending
+ * an ellipsis when anything was cut. Widths are measured like Ink measures
+ * them (CJK/emoji glyphs count 2 columns; see `display-width`): tree rows are
+ * budgeted as exactly ONE visual row by `buildTreeRows`, so a label that
+ * renders wider than its budget would soft-wrap and desync the viewport and
+ * mouse hit-testing for every row below it. Cutting happens on grapheme
+ * boundaries — never splitting a surrogate pair or emoji ZWJ sequence.
+ */
 export function truncateBranch(text: string, available: number): string {
-  if (text.length <= available) return text;
+  if (displayWidth(text) <= available) return text;
   if (available <= 0) return "";
-  return `${text.slice(0, available - ELLIPSIS.length)}${ELLIPSIS}`;
+  const budget = available - 1; // reserve the ellipsis column
+  let out = "";
+  let width = 0;
+  for (const [grapheme, graphemeW] of graphemeWidths(text)) {
+    if (width + graphemeW > budget) break;
+    out += grapheme;
+    width += graphemeW;
+  }
+  return `${out}${ELLIPSIS}`;
 }
 
 /**
@@ -24,8 +43,9 @@ export function truncateWithPrefix(
   rest: string,
   available: number,
 ): string {
-  if (prefix.length + rest.length <= available) return prefix + rest;
-  if (available <= prefix.length + ELLIPSIS.length)
+  const prefixWidth = displayWidth(prefix);
+  if (prefixWidth + displayWidth(rest) <= available) return prefix + rest;
+  if (available <= prefixWidth + 1)
     return truncateBranch(prefix + rest, available);
-  return prefix + truncateBranch(rest, available - prefix.length);
+  return prefix + truncateBranch(rest, available - prefixWidth);
 }

--- a/src/tui/utils/truncate.ts
+++ b/src/tui/utils/truncate.ts
@@ -6,6 +6,19 @@ export function truncateBranch(text: string, available: number): string {
   return `${text.slice(0, available - ELLIPSIS.length)}${ELLIPSIS}`;
 }
 
+/**
+ * Collapse a possibly multi-line string onto one line by squashing every
+ * newline run (with surrounding indentation) to a single space. The TUI's
+ * bottom-chrome budget counts each error line as EXACTLY one terminal row and
+ * relies on wrap="truncate" for width — but truncation does not remove
+ * embedded newlines, and stderr-derived messages (git's "fatal: …\nhint: …")
+ * regularly contain them; an un-collapsed message renders extra rows,
+ * overflows the fixed-height layout, and desyncs mouse hit-testing.
+ */
+export function toSingleLine(text: string): string {
+  return text.replace(/[ \t]*\r?\n[\s]*/g, " ").trim();
+}
+
 export function truncateWithPrefix(
   prefix: string,
   rest: string,

--- a/tests/tui/app-harness.tsx
+++ b/tests/tui/app-harness.tsx
@@ -26,6 +26,7 @@ import { PassThrough } from "node:stream";
 import type React from "react";
 import { vi } from "vitest";
 import type { Worktree } from "../../src/services/worktree-service";
+import { HEADER_OFFSET } from "../../src/tui/input/mouse";
 
 const runtimeMock = vi.hoisted(() => ({
   runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
@@ -170,6 +171,24 @@ export function makeWorktree(repoPath: string, branch: string): Worktree {
   };
 }
 
+/**
+ * Register a single repo ("repo-1" / project "alpha") whose tree is tall
+ * enough to scroll: `main` plus `n` `feature/<i>` worktrees. Configures BOTH
+ * the worktree and registry fixtures so callers can't drift apart on which
+ * halves they set up.
+ */
+export function setTallWorktrees(repoPath: string, n: number): void {
+  worktreeFixtures.byRepoPath.set(repoPath, [
+    makeWorktree(repoPath, "main"),
+    ...Array.from({ length: n }, (_, i) =>
+      makeWorktree(repoPath, `feature/${i}`),
+    ),
+  ]);
+  registryItems.items = [
+    { id: "repo-1", repo_path: repoPath, project: "alpha" },
+  ];
+}
+
 export function stripAnsi(value: string): string {
   let output = "";
   for (let i = 0; i < value.length; i += 1) {
@@ -281,9 +300,9 @@ export function sgrWheel(dir: 1 | -1): string {
   return `\x1b[<${cb};1;1M`;
 }
 
-// Mirrors App.tsx's TOP_CHROME_ROWS (== HEADER_OFFSET): the `wct` header line
-// + a blank spacer line above the tree viewport.
-export const HEADER_OFFSET = 2;
+// HEADER_OFFSET (== App.tsx's TOP_CHROME_ROWS) is imported from the
+// production module so the mapping stays aligned if the chrome layout changes.
+export { HEADER_OFFSET };
 
 export function sgrRowFor(viewportRow: number): number {
   return viewportRow + 1 + HEADER_OFFSET;

--- a/tests/tui/app-harness.tsx
+++ b/tests/tui/app-harness.tsx
@@ -1,0 +1,295 @@
+// Shared mocking strategy + Ink render harness for the suites that render the
+// REAL exported `App` from `src/tui/App.tsx` through Ink's actual input
+// pipeline (tests/tui/app-mouse-wiring.test.tsx and
+// tests/tui/app-review-fixes.test.tsx). Centralising the service mocks here
+// keeps the mocked service shapes in sync between those suites.
+//
+// Mocking strategy mirrors the established pattern in this test suite
+// (tests/tui/use-tmux.test.ts, tests/tui/session-actions.test.ts,
+// tests/tui/modal-actions.test.ts): mock each `XService.use(selector)` to
+// call `selector` synchronously against a controllable fake service object
+// (so it returns a plain Promise, not a real Effect), and mock
+// `tuiRuntime.runPromise`/`runSync` as a transparent pass-through. Since the
+// `.use()` mocks already resolve the "effect" argument to a real Promise or
+// plain value before it reaches `runPromise`, the pass-through is enough —
+// the one caller that does NOT go through a `.use()` seam (`loadConfig` in
+// `getIdeDefaults`) is wrapped in a try/catch with a safe fallback in the
+// real code, so passing it through unresolved is harmless.
+//
+// The `vi.mock` calls below execute when a test file imports this module —
+// BEFORE that file's `await import("../../src/tui/App")` — so every mock is
+// registered before any mocked service module is first loaded. The fixture
+// objects are wrapped in `vi.hoisted` so the factories may reference them
+// regardless of whether Vitest's hoisting transform rewrites this file.
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import type React from "react";
+import { vi } from "vitest";
+import type { Worktree } from "../../src/services/worktree-service";
+
+const runtimeMock = vi.hoisted(() => ({
+  runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
+  // The `.use()` mocks below already resolve the "effect" argument to a
+  // plain value before it reaches here, so this is a transparent pass-through
+  // (like runPromise), not a stub that discards its argument.
+  runSync: vi.fn((effect: unknown) => effect),
+}));
+
+vi.mock("../../src/tui/runtime", () => ({
+  tuiRuntime: runtimeMock,
+  runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
+}));
+
+// --- RegistryService: repos controllable per test via registryItems. ---
+const registryItems = vi.hoisted(() => ({
+  items: [] as Array<{ id: string; repo_path: string; project: string }>,
+}));
+
+vi.mock("../../src/services/registry-service", () => ({
+  RegistryService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listRepos: () => Promise.resolve(registryItems.items),
+      }),
+  },
+}));
+
+// --- WorktreeService: worktrees keyed by repoPath, controllable per test. ---
+const worktreeFixtures = vi.hoisted(() => ({
+  byRepoPath: new Map<string, Worktree[]>(),
+}));
+
+vi.mock("../../src/services/worktree-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/worktree-service")
+  >("../../src/services/worktree-service");
+  return {
+    ...actual,
+    WorktreeService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listWorktrees: (repoPath: string) =>
+            Promise.resolve(worktreeFixtures.byRepoPath.get(repoPath) ?? []),
+          getDefaultBranch: () => Promise.resolve("main"),
+          getChangedFileCount: () => Promise.resolve(0),
+          getAheadBehind: () =>
+            Promise.resolve({ ahead: 0, behind: 0 }) as Promise<{
+              ahead: number;
+              behind: number;
+            } | null>,
+        }),
+    },
+  };
+});
+
+// --- TmuxService: no client, no sessions — App renders without tmux. ---
+vi.mock("../../src/services/tmux", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/tmux")
+  >("../../src/services/tmux");
+  return {
+    ...actual,
+    TmuxService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listClients: () => Promise.resolve([]),
+          listSessions: () => Promise.resolve(null),
+          listPanes: () => Promise.resolve([]),
+        }),
+    },
+  };
+});
+
+// --- GitHubService + PrCacheService: no PRs by default. useGitHub never
+// fetches on a fresh App mount for the current repo (its mount effect reads
+// `repos`, which is always `[]` on the very first render — before
+// useRegistry's async listRepos() resolves — and its callback identity never
+// changes, so it doesn't re-run once repos populate). The one REAL,
+// keyboard-reachable path that calls GitHubService.listPrs is pressing "r" in
+// Navigate mode (src/tui/input/navigate.ts calls ctx.refreshRepo), so a test
+// that needs a PR row drives that key rather than relying on mount timing.
+const githubFixtures = vi.hoisted(() => ({
+  prsByRepoPath: new Map<
+    string,
+    Array<{
+      number: number;
+      title: string;
+      state: "OPEN" | "MERGED" | "CLOSED";
+      headRefName: string;
+      rollupState: "success" | "failure" | "pending" | null;
+    }>
+  >(),
+}));
+
+vi.mock("../../src/services/github-service", () => ({
+  GitHubService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listPrs: (repoPath: string) =>
+          Promise.resolve(githubFixtures.prsByRepoPath.get(repoPath) ?? []),
+      }),
+  },
+}));
+
+vi.mock("../../src/services/pr-cache-service", () => ({
+  PrCacheService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        getCached: () => null,
+        setCached: () => Promise.resolve(),
+        setError: () => Promise.resolve(),
+      }),
+  },
+}));
+
+export { githubFixtures, registryItems, runtimeMock, worktreeFixtures };
+
+/** Reset every controllable fixture and runtime spy; call from `beforeEach`. */
+export function resetHarnessFixtures(): void {
+  registryItems.items = [];
+  worktreeFixtures.byRepoPath.clear();
+  githubFixtures.prsByRepoPath.clear();
+  runtimeMock.runPromise.mockClear();
+  runtimeMock.runSync.mockClear();
+}
+
+export type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+export type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  ref: () => NodeJS.ReadStream;
+  unref: () => NodeJS.ReadStream;
+};
+
+export function makeWorktree(repoPath: string, branch: string): Worktree {
+  return {
+    path: join(repoPath, branch.replaceAll("/", "-")),
+    branch,
+    commit: "abc123",
+    isBare: false,
+  };
+}
+
+export function stripAnsi(value: string): string {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value.charAt(i);
+    if (char === "\x1b" && value.charAt(i + 1) === "[") {
+      i += 2;
+      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
+        i += 1;
+      }
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+export async function tick(count = 1): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+export async function renderApp(
+  node: React.ReactElement,
+  termRows = 32,
+  termCols = 100,
+) {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = termCols;
+  stdout.rows = termRows;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = true;
+
+  // Ordered event log shared by stdout writes and raw-mode flips, so tests
+  // can assert real orderings (e.g. MOUSE_DISABLE before setRawMode(false)).
+  // stdout.write is patched (not the 'data' event) because write is
+  // synchronous with the caller while 'data' emission may be deferred.
+  const events: Array<
+    { kind: "write"; data: string } | { kind: "rawmode"; mode: boolean }
+  > = [];
+  // Forward EVERY argument: Ink resolves waitUntilExit via an empty write's
+  // completion callback, so dropping the callback would hang the exit path.
+  const originalWrite = stdout.write.bind(stdout) as (
+    ...args: unknown[]
+  ) => boolean;
+  stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    events.push({
+      kind: "write",
+      data:
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    });
+    return originalWrite(chunk, ...rest);
+  }) as typeof stdout.write;
+  stdin.setRawMode = (mode: boolean) => {
+    events.push({ kind: "rawmode", mode });
+    return stdin;
+  };
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  const { render } = await import("ink");
+  const instance = render(node, {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  return {
+    stdin,
+    stdout,
+    events,
+    instance,
+    // The last full frame Ink wrote, split into lines, ANSI stripped.
+    lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
+    output: () => stripAnsi(chunks.join("\n")),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+export async function sendKeys(
+  stdin: NodeJS.ReadStream,
+  sequence: string,
+  ticks = 5,
+): Promise<void> {
+  stdin.write(sequence);
+  await tick(ticks);
+}
+
+export function sgrPress(col: number, row: number): string {
+  return `\x1b[<0;${col};${row}M`;
+}
+
+export function sgrRelease(col: number, row: number): string {
+  return `\x1b[<0;${col};${row}m`;
+}
+
+export function sgrWheel(dir: 1 | -1): string {
+  // 64 = wheel up (dir -1), 65 = wheel down (dir 1)
+  const cb = dir === -1 ? 64 : 65;
+  return `\x1b[<${cb};1;1M`;
+}
+
+// Mirrors App.tsx's TOP_CHROME_ROWS (== HEADER_OFFSET): the `wct` header line
+// + a blank spacer line above the tree viewport.
+export const HEADER_OFFSET = 2;
+
+export function sgrRowFor(viewportRow: number): number {
+  return viewportRow + 1 + HEADER_OFFSET;
+}
+
+/** The single rendered line containing the ❯ selection cursor, or undefined. */
+export function selectedLine(lines: string[]): string | undefined {
+  return lines.find((l) => l.includes("❯"));
+}

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -457,6 +457,43 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
       }
     });
 
+    test("entering Search after a wheel scroll (selection already at index 0) resets the viewport to the first match", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(40);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Selection stays on the repo row (index 0, never moved). Wheel-scroll
+        // the viewport away so the selected row is off-screen.
+        for (let i = 0; i < 15; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toBeUndefined();
+
+        // Enter Search and type a query that still matches many rows. The
+        // cursor reset (setSelectedIndex(0)) is a no-op — selectedIndex is
+        // already 0 — so `selectionChanged` stays false and the keep-visible
+        // effect never fires; without the explicit scroll reset in the
+        // searchQueryChanged branch, Search would open with the selected
+        // first match scrolled off-screen and no visible cursor.
+        await sendKeys(rendered.stdin, "/");
+        await sendKeys(rendered.stdin, "f");
+        await tick(5);
+
+        const line = selectedLine(rendered.lines());
+        expect(line).toBeDefined();
+        expect(line).toContain("alpha");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
     test("a genuine selectedIndex change still nudges the viewport", async () => {
       registryItems.items = [
         { id: "repo-1", repo_path: repoPath, project: "alpha" },

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -19,6 +19,7 @@ import {
   resetHarnessFixtures,
   selectedLine,
   sendKeys,
+  setTallWorktrees,
   sgrPress,
   sgrRelease,
   sgrRowFor,
@@ -225,18 +226,8 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
   });
 
   describe("Bug 2: background refresh (new `rows`/`repos` ref, same selectedIndex) must not re-anchor a wheel-scrolled viewport", () => {
-    function setTallWorktrees(n: number) {
-      worktreeFixtures.byRepoPath.set(repoPath, [
-        worktree("main"),
-        ...Array.from({ length: n }, (_, i) => worktree(`feature/${i}`)),
-      ]);
-    }
-
     test("a background refresh (repos ref change, selectedIndex unchanged) does not move the viewport", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(40);
+      setTallWorktrees(repoPath, 40);
 
       // A short terminal forces a small viewport so the tree scrolls.
       const rendered = await renderApp(<App />, 14);
@@ -295,10 +286,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     });
 
     test("entering Search after a wheel scroll (selection already at index 0) resets the viewport to the first match", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(40);
+      setTallWorktrees(repoPath, 40);
 
       const rendered = await renderApp(<App />, 14);
       try {
@@ -332,10 +320,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     });
 
     test("two wheel-downs written as one stdin chunk scroll twice end-to-end (guard integration)", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(40);
+      setTallWorktrees(repoPath, 40);
 
       const rendered = await renderApp(<App />, 14);
       try {
@@ -364,10 +349,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     });
 
     test("a click's press+release written as one chunk leaves the Search query clean (guard integration)", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(5);
+      setTallWorktrees(repoPath, 5);
 
       const rendered = await renderApp(<App />, 20);
       try {
@@ -396,10 +378,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     });
 
     test("a wheel right after a no-nudge click is not undone (selectionChanged falling edge)", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(40);
+      setTallWorktrees(repoPath, 40);
 
       const rendered = await renderApp(<App />, 14);
       try {
@@ -437,10 +416,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     });
 
     test("a genuine selectedIndex change still nudges the viewport", async () => {
-      registryItems.items = [
-        { id: "repo-1", repo_path: repoPath, project: "alpha" },
-      ];
-      setTallWorktrees(40);
+      setTallWorktrees(repoPath, 40);
 
       const rendered = await renderApp(<App />, 14);
       try {

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -621,6 +621,47 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
       }
     });
 
+    test("a wheel right after a no-nudge click is not undone (selectionChanged falling edge)", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(40);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Wheel the viewport down so the selection (repo, row 0) is
+        // off-screen, then click the TOP visible row (feature/3, row 5 at
+        // offset 5). The click is a deliberate selection change but needs NO
+        // nudge — the row is already visible — so the keep-visible effect's
+        // functional update returns the same offset and React bails without
+        // an extra commit that would consume the selectionChanged edge.
+        for (let i = 0; i < 5; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toBeUndefined();
+
+        await sendKeys(rendered.stdin, sgrPress(3, sgrRowFor(0)));
+        expect(selectedLine(rendered.lines())).toContain("feature/3");
+
+        // The very next wheel tick scrolls the just-clicked selection off the
+        // top. This commit re-fires the keep-visible effect purely via the
+        // FALLING edge of selectionChanged (true -> false) while the
+        // visibility ref still says "was visible" — without requiring the
+        // row/viewport to have actually changed, the effect would re-anchor
+        // and snap the offset straight back, eating the wheel tick.
+        await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        await tick(5);
+
+        expect(selectedLine(rendered.lines())).toBeUndefined();
+      } finally {
+        rendered.unmount();
+      }
+    });
+
     test("a genuine selectedIndex change still nudges the viewport", async () => {
       registryItems.items = [
         { id: "repo-1", repo_path: repoPath, project: "alpha" },
@@ -726,6 +767,138 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         expect(after.find((l) => /feature\/\d+/.test(l))).toEqual(
           firstVisibleBefore,
         );
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("Bug: row reflow above the selection must not hide it (PR #104 r3530858752)", () => {
+    // 52 chars: the PR label ("PR #7: <title> (OPEN)", 66 chars) renders on
+    // ONE row at 100 columns (92-column label budget after the 8-column
+    // indent/selector chrome) but wraps onto TWO at 60 columns (52-column
+    // budget) — so narrowing the terminal shifts every row below the PR down
+    // by one while selectedIndex and viewportRows stay unchanged.
+    const wrappingTitle =
+      "Keep the selection visible when rows above it reflow";
+
+    function setupRepoWithPr(featureCount: number) {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        worktree("feature/0"),
+        ...Array.from({ length: featureCount }, (_, i) =>
+          worktree(`feature/${i + 1}`),
+        ),
+      ]);
+      githubFixtures.prsByRepoPath.set(repoPath, [
+        {
+          number: 7,
+          title: wrappingTitle,
+          state: "OPEN",
+          headRefName: "feature/0",
+          rollupState: null,
+        },
+      ]);
+    }
+
+    test("a PR title wrapping after a width resize keeps a bottom-row selection visible", async () => {
+      setupRepoWithPr(20);
+
+      const rendered = await renderApp(<App />, 14, 100);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Put the PR detail row in the tree: select feature/0, fetch PRs via
+        // the real Navigate-only "r" path, then expand it. Items while
+        // Expanded: repo-1(0), main(1), feature/0(2), PR-detail(3),
+        // feature/1(4), … — Expanded ↑/↓ then walks the whole tree without
+        // exiting the mode, so the detail row stays rendered.
+        await sendKeys(rendered.stdin, "\x1b[B"); // repo -> main
+        await sendKeys(rendered.stdin, "\x1b[B"); // main -> feature/0
+        await sendKeys(rendered.stdin, "r"); // fetch PRs for repo "alpha"
+        await tick(15);
+        await sendKeys(rendered.stdin, "\x1b[C"); // right: expand feature/0
+        expect(rendered.output()).toContain("PR #7");
+
+        // Walk the cursor well past the first viewport so the keep-visible
+        // effect pins it to the BOTTOM visible row (12 downs from feature/0
+        // land on feature/11 at row index 14, past the PR detail row).
+        for (let i = 0; i < 12; i++) {
+          await sendKeys(rendered.stdin, "\x1b[B", 2);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toContain("feature/11");
+
+        // Narrow the terminal. The PR label above the window wraps onto a
+        // second row, pushing the selection's visual row down by one while
+        // selectedIndex AND viewportRows stay unchanged — so neither the
+        // selectionChanged gate nor a viewport-shrink signal fires, and the
+        // recovery effect's clamp only ever DECREASES the offset. Without
+        // reflow handling the bottom-pinned cursor falls below the window
+        // and disappears until the next navigation key.
+        rendered.stdout.columns = 60;
+        rendered.stdout.emit("resize");
+        await tick(10);
+
+        expect(selectedLine(rendered.lines())).toContain("feature/11");
+
+        // Prove the reflow actually happened — otherwise this test passes
+        // vacuously if the resize ever stops propagating `columns` (the
+        // visible worktree set is identical pre/post resize by construction).
+        // Wheel back to the top: the PR label must now wrap onto a
+        // continuation row ("reflow (OPEN)" on its own line, no "PR #7").
+        for (let i = 0; i < 10; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(-1), 1);
+        }
+        await tick(5);
+        const contLine = rendered
+          .lines()
+          .find((l) => l.includes("reflow (OPEN)"));
+        expect(contLine).toBeDefined();
+        expect(contLine).not.toContain("PR #7");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("a reflow with the selection already wheel-scrolled off-screen leaves the viewport alone", async () => {
+      setupRepoWithPr(40);
+
+      const rendered = await renderApp(<App />, 14, 100);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        await sendKeys(rendered.stdin, "\x1b[B"); // repo -> main
+        await sendKeys(rendered.stdin, "\x1b[B"); // main -> feature/0
+        await sendKeys(rendered.stdin, "r"); // fetch PRs for repo "alpha"
+        await tick(15);
+        await sendKeys(rendered.stdin, "\x1b[C"); // right: expand feature/0
+        expect(rendered.output()).toContain("PR #7");
+
+        // Park the cursor BELOW the PR detail row (feature/1, row 4) so the
+        // wrap will move its visual row, then wheel the viewport away — the
+        // deliberate PRD §3 state with the selection off-screen above.
+        await sendKeys(rendered.stdin, "\x1b[B"); // feature/0 -> PR detail
+        await sendKeys(rendered.stdin, "\x1b[B"); // PR detail -> feature/1
+        for (let i = 0; i < 15; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toBeUndefined();
+
+        // The reflow moves the selection's visual row (4 -> 5), but the
+        // selection was already off-screen — re-anchoring would discard the
+        // wheel scroll, so the viewport must stay put.
+        rendered.stdout.columns = 60;
+        rendered.stdout.emit("resize");
+        await tick(10);
+
+        expect(selectedLine(rendered.lines())).toBeUndefined();
       } finally {
         rendered.unmount();
       }

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -1,0 +1,488 @@
+// Regression tests for Bug 1 (click-to-exit-Expanded selects the wrong
+// worktree) and Bug 2 (background refresh re-anchors a wheel-scrolled
+// viewport) that render the REAL exported `App` from `src/tui/App.tsx` — not
+// a hand-copied reimplementation of its effects — so reverting the fix in
+// App.tsx actually fails these tests.
+//
+// Mocking strategy mirrors the established pattern in this test suite
+// (tests/tui/use-tmux.test.ts, tests/tui/session-actions.test.ts,
+// tests/tui/modal-actions.test.ts): mock each `XService.use(selector)` to
+// call `selector` synchronously against a controllable fake service object
+// (so it returns a plain Promise, not a real Effect), and mock
+// `tuiRuntime.runPromise`/`runSync` as a transparent pass-through. Since the
+// `.use()` mocks already resolve the "effect" argument to a real Promise or
+// plain value before it reaches `runPromise`, the pass-through is enough —
+// the one caller that does NOT go through a `.use()` seam (`loadConfig` in
+// `getIdeDefaults`) is wrapped in a try/catch with a safe fallback in the
+// real code, so passing it through unresolved is harmless.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { Worktree } from "../../src/services/worktree-service";
+
+const runtimeMock = vi.hoisted(() => ({
+  runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
+  // The `.use()` mocks below already resolve the "effect" argument to a
+  // plain value before it reaches here, so this is a transparent pass-through
+  // (like runPromise), not a stub that discards its argument.
+  runSync: vi.fn((effect: unknown) => effect),
+}));
+
+vi.mock("../../src/tui/runtime", () => ({
+  tuiRuntime: runtimeMock,
+  runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
+}));
+
+// --- RegistryService: repos controllable per test via registryItems. ---
+const registryItems = vi.hoisted(() => ({
+  items: [] as Array<{ id: string; repo_path: string; project: string }>,
+}));
+
+vi.mock("../../src/services/registry-service", () => ({
+  RegistryService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listRepos: () => Promise.resolve(registryItems.items),
+      }),
+  },
+}));
+
+// --- WorktreeService: worktrees keyed by repoPath, controllable per test. ---
+const worktreeFixtures = vi.hoisted(() => ({
+  byRepoPath: new Map<string, Worktree[]>(),
+}));
+
+vi.mock("../../src/services/worktree-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/worktree-service")
+  >("../../src/services/worktree-service");
+  return {
+    ...actual,
+    WorktreeService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listWorktrees: (repoPath: string) =>
+            Promise.resolve(worktreeFixtures.byRepoPath.get(repoPath) ?? []),
+          getDefaultBranch: () => Promise.resolve("main"),
+          getChangedFileCount: () => Promise.resolve(0),
+          getAheadBehind: () =>
+            Promise.resolve({ ahead: 0, behind: 0 }) as Promise<{
+              ahead: number;
+              behind: number;
+            } | null>,
+        }),
+    },
+  };
+});
+
+// --- TmuxService: no client, no sessions — App renders without tmux. ---
+vi.mock("../../src/services/tmux", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/tmux")
+  >("../../src/services/tmux");
+  return {
+    ...actual,
+    TmuxService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listClients: () => Promise.resolve([]),
+          listSessions: () => Promise.resolve(null),
+          listPanes: () => Promise.resolve([]),
+        }),
+    },
+  };
+});
+
+// --- GitHubService + PrCacheService: no PRs by default. useGitHub never
+// fetches on a fresh App mount for the current repo (its mount effect reads
+// `repos`, which is always `[]` on the very first render — before
+// useRegistry's async listRepos() resolves — and its callback identity never
+// changes, so it doesn't re-run once repos populate). The one REAL,
+// keyboard-reachable path that calls GitHubService.listPrs is pressing "r" in
+// Navigate mode (src/tui/input/navigate.ts calls ctx.refreshRepo), so a test
+// that needs a PR row drives that key rather than relying on mount timing.
+const githubFixtures = vi.hoisted(() => ({
+  prsByRepoPath: new Map<
+    string,
+    Array<{
+      number: number;
+      title: string;
+      state: "OPEN" | "MERGED" | "CLOSED";
+      headRefName: string;
+      rollupState: "success" | "failure" | "pending" | null;
+    }>
+  >(),
+}));
+
+vi.mock("../../src/services/github-service", () => ({
+  GitHubService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listPrs: (repoPath: string) =>
+          Promise.resolve(githubFixtures.prsByRepoPath.get(repoPath) ?? []),
+      }),
+  },
+}));
+
+vi.mock("../../src/services/pr-cache-service", () => ({
+  PrCacheService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        getCached: () => null,
+        setCached: () => Promise.resolve(),
+        setError: () => Promise.resolve(),
+      }),
+  },
+}));
+
+const { App } = await import("../../src/tui/App");
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  ref: () => NodeJS.ReadStream;
+  unref: () => NodeJS.ReadStream;
+};
+
+function createStdoutStdin(rows: number) {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 100;
+  stdout.rows = rows;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => stdin;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+  return { stdout, stdin };
+}
+
+function stripAnsi(value: string) {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value.charAt(i);
+    if (char === "" && value.charAt(i + 1) === "[") {
+      i += 2;
+      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
+        i += 1;
+      }
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+async function tick(count = 1) {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+async function renderApp(node: React.ReactElement, termRows = 32) {
+  const { stdout, stdin } = createStdoutStdin(termRows);
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  const { render } = await import("ink");
+  const instance = render(node, {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  return {
+    stdin,
+    // The last full frame Ink wrote, split into lines, ANSI stripped.
+    lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
+    output: () => stripAnsi(chunks.join("\n")),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+async function sendKeys(stdin: NodeJS.ReadStream, sequence: string, ticks = 5) {
+  stdin.write(sequence);
+  await tick(ticks);
+}
+
+function sgrPress(col: number, row: number): string {
+  return `\x1b[<0;${col};${row}M`;
+}
+
+function sgrRelease(col: number, row: number): string {
+  return `\x1b[<0;${col};${row}m`;
+}
+
+function sgrWheel(dir: 1 | -1): string {
+  // 64 = wheel up (dir -1), 65 = wheel down (dir 1)
+  const cb = dir === -1 ? 64 : 65;
+  return `\x1b[<${cb};1;1M`;
+}
+
+// Mirrors App.tsx's TOP_CHROME_ROWS (== HEADER_OFFSET): the `wct` header line
+// + a blank spacer line above the tree viewport.
+const HEADER_OFFSET = 2;
+
+function sgrRowFor(viewportRow: number): number {
+  return viewportRow + 1 + HEADER_OFFSET;
+}
+
+/** The single rendered line containing the ❯ selection cursor, or undefined. */
+function selectedLine(lines: string[]): string | undefined {
+  return lines.find((l) => l.includes("❯"));
+}
+
+describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
+  let homeDir: string;
+  let repoPath: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "wct-app-mouse-home-"));
+    repoPath = mkdtempSync(join(tmpdir(), "wct-app-mouse-repo-"));
+    // useRefresh's fs.watch(`${HOME}/.wct`) call throws synchronously (caught
+    // and silently swallowed) if the directory does not exist AT MOUNT TIME —
+    // it does not retroactively pick up a directory created after the watch()
+    // call. Create it up front so tests that trigger a real background
+    // refresh via a file write under it actually land.
+    mkdirSync(join(homeDir, ".wct"), { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+    registryItems.items = [];
+    worktreeFixtures.byRepoPath.clear();
+    githubFixtures.prsByRepoPath.clear();
+    runtimeMock.runPromise.mockClear();
+    runtimeMock.runSync.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(homeDir, { recursive: true, force: true });
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  function worktree(branch: string): Worktree {
+    return {
+      path: join(repoPath, branch.replaceAll("/", "-")),
+      branch,
+      commit: "abc123",
+      isBare: false,
+    };
+  }
+
+  describe("Bug 1: click-to-exit-Expanded selects the clicked sibling, not the old identity", () => {
+    test("without a detail row on the expanded worktree", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        worktree("feature/a"),
+        worktree("feature/b"),
+      ]);
+
+      const rendered = await renderApp(<App />);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("feature/a");
+        expect(rendered.output()).toContain("feature/b");
+
+        // Rows after auto-expand: repo-1(0), main(1), feature/a(2),
+        // feature/b(3). Select feature/a with the keyboard, then expand it
+        // with the real right-arrow handler (handleNavigateInput).
+        await sendKeys(rendered.stdin, "\x1b[B"); // down: repo -> main
+        await sendKeys(rendered.stdin, "\x1b[B"); // down: main -> feature/a
+        await sendKeys(rendered.stdin, "\x1b[C"); // right: expand feature/a
+
+        expect(selectedLine(rendered.lines())).toContain("feature/a");
+
+        // No PR/pane data for feature/a → no detail row while Expanded, so
+        // rows still map 1:1 to items: repo-1(0), main(1), feature/a(2),
+        // feature/b(3). Click feature/b (viewportRow 3) to exit Expanded.
+        const sgrRow = sgrRowFor(3);
+        await sendKeys(rendered.stdin, sgrPress(3, sgrRow));
+        await sendKeys(rendered.stdin, sgrRelease(3, sgrRow));
+
+        // Bug 1: without the fix, identity recovery snaps the cursor back to
+        // feature/a. With the fix, the clicked feature/b stays selected.
+        const line = selectedLine(rendered.lines());
+        expect(line).toContain("feature/b");
+        expect(line).not.toContain("feature/a");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("with a detail row on the expanded worktree (PR row shifts every later index)", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        worktree("feature/a"),
+        worktree("feature/b"),
+      ]);
+      // feature/a has a PR — while Expanded on feature/a, one extra "detail"
+      // row renders beneath it, shifting feature/b's row down by one. This
+      // is exactly the scenario adjustIndexForDetailCollapse must correct
+      // for when the click resolves against the pre-collapse item indices.
+      githubFixtures.prsByRepoPath.set(repoPath, [
+        {
+          number: 7,
+          title: "Add thing",
+          state: "OPEN",
+          headRefName: "feature/a",
+          rollupState: null,
+        },
+      ]);
+
+      const rendered = await renderApp(<App />);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("feature/a");
+
+        await sendKeys(rendered.stdin, "\x1b[B"); // repo -> main
+        await sendKeys(rendered.stdin, "\x1b[B"); // main -> feature/a
+        await sendKeys(rendered.stdin, "\x1b[C"); // expand feature/a
+
+        // Fetch PRs for real via the actual keyboard-reachable refresh path
+        // (pressing "r" in Navigate calls ctx.refreshRepo -> refreshGitHub ->
+        // GitHubService.use(listPrs); see the githubFixtures comment above
+        // for why this is the only real path to populate PR data here). "r"
+        // is Navigate-only, so collapse out of Expanded first, then re-expand.
+        await sendKeys(rendered.stdin, "\x1b[D"); // left: collapse to Navigate
+        await sendKeys(rendered.stdin, "r"); // refresh PRs for repo "alpha"
+        await tick(15);
+        await sendKeys(rendered.stdin, "\x1b[C"); // right: re-expand feature/a
+
+        // Rows while Expanded: repo-1(0), main(1), feature/a(2), PR-detail(3),
+        // feature/b(4). Confirm the PR detail row actually rendered before
+        // clicking, so this test is exercising the index-shift it claims to.
+        expect(rendered.output()).toContain("PR #7");
+
+        const sgrRow = sgrRowFor(4);
+        await sendKeys(rendered.stdin, sgrPress(3, sgrRow));
+        await sendKeys(rendered.stdin, sgrRelease(3, sgrRow));
+
+        // Bug 1a: without adjustIndexForDetailCollapse, the raw clicked
+        // itemIndex (4) is used post-collapse, but after the PR detail row
+        // is removed feature/b sits at index 3 — so an unadjusted click would
+        // select the wrong row (or the row after feature/b, if any existed).
+        // With the fix, feature/b is selected correctly.
+        const line = selectedLine(rendered.lines());
+        expect(line).toContain("feature/b");
+        expect(line).not.toContain("feature/a");
+        expect(line).not.toContain("main");
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("Bug 2: background refresh (new `rows`/`repos` ref, same selectedIndex) must not re-anchor a wheel-scrolled viewport", () => {
+    function setTallWorktrees(n: number) {
+      const worktrees: Worktree[] = [
+        worktree("main"),
+        ...Array.from({ length: n }, (_, i) => worktree(`feature/${i}`)),
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, worktrees);
+    }
+
+    test("a background refresh (repos ref change, selectedIndex unchanged) does not move the viewport", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(40);
+
+      // A short terminal forces a small viewport so the tree scrolls.
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Selection stays on the repo row (index 0, never moved). Wheel-scroll
+        // down repeatedly so the viewport moves away from the selection —
+        // this is the intended PRD §3 behaviour (wheel scrolls independent of
+        // selection).
+        for (let i = 0; i < 15; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+
+        const beforeRefresh = rendered.lines();
+        // The selected row (repo-1, still index 0) must have scrolled out of
+        // the visible window.
+        expect(selectedLine(beforeRefresh)).toBeUndefined();
+        // Capture which worktree branches are visible right before the
+        // simulated background refresh.
+        const visibleBefore = beforeRefresh.filter((l) =>
+          /feature\/\d+/.test(l),
+        );
+        expect(visibleBefore.length).toBeGreaterThan(0);
+
+        // Trigger a REAL background refresh through useRefresh's fs.watch
+        // path (not a simulated re-render): useRefresh watches
+        // `${HOME}/.wct/` for `.db`/`-wal` changes with a 150ms debounce and
+        // calls refreshAll -> refreshRegistry -> useRegistry's refresh(),
+        // which re-fetches from RegistryService/WorktreeService. Our mocks
+        // re-read their fixture maps fresh on every call and return brand-new
+        // arrays each time — exactly like the real services — so this is a
+        // content-identical, reference-different refresh, which is the exact
+        // condition useRegistry.ts triggers on (it has no equality bail-out
+        // before calling setRepos).
+        const wctDir = join(homeDir, ".wct");
+        mkdirSync(wctDir, { recursive: true });
+        writeFileSync(join(wctDir, "registry.db"), "trigger");
+        await new Promise((resolve) => setTimeout(resolve, 250)); // past the 150ms debounce
+        await tick(10);
+
+        const afterRefresh = rendered.lines();
+        // Bug 2: without the selectionChanged gate, a background refresh
+        // that only changes object identity (not content) would re-fire the
+        // auto-scroll effect and snap the viewport back to the (unchanged)
+        // selection, discarding the wheel scroll. With the fix, the viewport
+        // must still show the same scrolled-to region.
+        expect(selectedLine(afterRefresh)).toBeUndefined();
+        const visibleAfter = afterRefresh.filter((l) => /feature\/\d+/.test(l));
+        expect(visibleAfter).toEqual(visibleBefore);
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("a genuine selectedIndex change still nudges the viewport", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(40);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+
+        for (let i = 0; i < 15; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toBeUndefined();
+
+        // Click a visible row — a deliberate selection change must nudge the
+        // viewport to include it.
+        const sgrRow = sgrRowFor(0);
+        await sendKeys(rendered.stdin, sgrPress(3, sgrRow));
+
+        const line = selectedLine(rendered.lines());
+        expect(line).toBeDefined();
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+});

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -148,9 +148,9 @@ type TestStdin = NodeJS.ReadStream & {
   unref: () => NodeJS.ReadStream;
 };
 
-function createStdoutStdin(rows: number) {
+function createStdoutStdin(rows: number, columns = 100) {
   const stdout = new PassThrough() as unknown as TestStdout;
-  stdout.columns = 100;
+  stdout.columns = columns;
   stdout.rows = rows;
   const stdin = new PassThrough() as unknown as TestStdin;
   stdin.isTTY = true;
@@ -182,8 +182,12 @@ async function tick(count = 1) {
   }
 }
 
-async function renderApp(node: React.ReactElement, termRows = 32) {
-  const { stdout, stdin } = createStdoutStdin(termRows);
+async function renderApp(
+  node: React.ReactElement,
+  termRows = 32,
+  termCols = 100,
+) {
+  const { stdout, stdin } = createStdoutStdin(termRows, termCols);
   const chunks: string[] = [];
   stdout.on("data", (chunk) => {
     chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
@@ -200,6 +204,7 @@ async function renderApp(node: React.ReactElement, termRows = 32) {
 
   return {
     stdin,
+    stdout,
     // The last full frame Ink wrote, split into lines, ANSI stripped.
     lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
     output: () => stripAnsi(chunks.join("\n")),
@@ -380,6 +385,64 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         expect(line).toContain("feature/b");
         expect(line).not.toContain("feature/a");
         expect(line).not.toContain("main");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("selects the clicked row even when its post-collapse index equals the cursor's (PR #104 r3511242204)", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        worktree("feature/a"),
+        worktree("feature/b"),
+        worktree("feature/c"),
+      ]);
+      githubFixtures.prsByRepoPath.set(repoPath, [
+        {
+          number: 7,
+          title: "Add thing",
+          state: "OPEN",
+          headRefName: "feature/a",
+          rollupState: null,
+        },
+      ]);
+
+      const rendered = await renderApp(<App />);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("feature/c");
+
+        await sendKeys(rendered.stdin, "\x1b[B"); // repo -> main
+        await sendKeys(rendered.stdin, "\x1b[B"); // main -> feature/a
+        await sendKeys(rendered.stdin, "r"); // fetch PRs (Navigate-only key)
+        await tick(15);
+        await sendKeys(rendered.stdin, "\x1b[C"); // right: expand feature/a
+        expect(rendered.output()).toContain("PR #7");
+
+        // Items while Expanded: repo-1(0), main(1), feature/a(2),
+        // PR-detail(3), feature/b(4), feature/c(5). Walk the cursor PAST the
+        // detail block onto feature/b — Expanded ↑/↓ navigates the whole
+        // tree without exiting the mode.
+        await sendKeys(rendered.stdin, "\x1b[B"); // feature/a -> PR detail
+        await sendKeys(rendered.stdin, "\x1b[B"); // PR detail -> feature/b
+        expect(selectedLine(rendered.lines())).toContain("feature/b");
+
+        // Click feature/c (item 5). Collapsing removes the PR detail row, so
+        // feature/c's adjusted index is 4 — exactly the cursor's pre-collapse
+        // index. setSelectedIndex(4) is then a no-op and selectionChanged
+        // stays false; without pre-storing the clicked item's identity, the
+        // recovery effect would treat the collapse as a background tree
+        // change and snap the cursor back to feature/b.
+        const sgrRow = sgrRowFor(5);
+        await sendKeys(rendered.stdin, sgrPress(3, sgrRow));
+        await sendKeys(rendered.stdin, sgrRelease(3, sgrRow));
+
+        const line = selectedLine(rendered.lines());
+        expect(line).toContain("feature/c");
+        expect(line).not.toContain("feature/b");
       } finally {
         rendered.unmount();
       }
@@ -581,6 +644,129 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
 
         const line = selectedLine(rendered.lines());
         expect(line).toBeDefined();
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("Bug: a viewport shrink must not hide the selection (PR #104 r3512096209)", () => {
+    test("resizing the terminal shorter keeps a bottom-row selection visible", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        ...Array.from({ length: 40 }, (_, i) => worktree(`feature/${i}`)),
+      ]);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Walk the cursor well past the first viewport; the keep-visible
+        // effect pins it to the bottom visible row (rows are 1:1 with items
+        // here, so 12 downs land on feature/10 at row index 12).
+        for (let i = 0; i < 12; i++) {
+          await sendKeys(rendered.stdin, "\x1b[B", 2);
+        }
+        await tick(5);
+        expect(selectedLine(rendered.lines())).toContain("feature/10");
+
+        // Shrink the terminal by two rows. selectedIndex is unchanged, so
+        // the keep-visible effect's selectionChanged gate alone skips it,
+        // and the recovery effect's clamp can only DECREASE the offset (a
+        // shrink raises the max offset) — without the viewport-shrink signal
+        // the selected bottom row falls below the window and the cursor
+        // disappears until the next navigation key.
+        rendered.stdout.rows = 12;
+        rendered.stdout.emit("resize");
+        await tick(10);
+
+        expect(selectedLine(rendered.lines())).toContain("feature/10");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("a shrink with the selection already wheel-scrolled off-screen leaves the viewport alone", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        ...Array.from({ length: 40 }, (_, i) => worktree(`feature/${i}`)),
+      ]);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        // Selection stays on the repo row (index 0); wheel the viewport away
+        // so the selected row is off-screen — the deliberate PRD §3 state.
+        for (let i = 0; i < 15; i++) {
+          await sendKeys(rendered.stdin, sgrWheel(1), 1);
+        }
+        await tick(5);
+        const before = rendered.lines();
+        expect(selectedLine(before)).toBeUndefined();
+        const firstVisibleBefore = before.find((l) => /feature\/\d+/.test(l));
+
+        // A shrink must NOT re-anchor to a selection that was already
+        // off-screen — the wheel-scrolled region stays put (its top row is
+        // unchanged; the shrink only trims rows off the bottom).
+        rendered.stdout.rows = 12;
+        rendered.stdout.emit("resize");
+        await tick(10);
+
+        const after = rendered.lines();
+        expect(selectedLine(after)).toBeUndefined();
+        expect(after.find((l) => /feature\/\d+/.test(l))).toEqual(
+          firstVisibleBefore,
+        );
+      } finally {
+        rendered.unmount();
+      }
+    });
+  });
+
+  describe("Bug: narrow terminals must not wrap bottom chrome (PR #104 r3520956519)", () => {
+    test("the frame stays within terminal rows when a hint line exceeds the width", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      worktreeFixtures.byRepoPath.set(repoPath, [
+        worktree("main"),
+        ...Array.from({ length: 20 }, (_, i) => worktree(`feature/${i}`)),
+      ]);
+
+      // 45 columns: BOTH the Navigate hint line (46 chars without a tmux
+      // client) and the tmux-error line ("No tmux client found — …", 49
+      // chars, always shown in this clientless test env) no longer fit.
+      // Without truncation Ink wraps each onto a second row, the 14-row
+      // budget (2 header + 8 viewport + 4 chrome: tmux error, divider, 2
+      // hints) under-counts, and the overflowing layout clips rows and
+      // misaligns mouse hit-testing.
+      const rendered = await renderApp(<App />, 14, 45);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        const frame = rendered.lines();
+        while (
+          frame.length > 0 &&
+          (frame[frame.length - 1] ?? "").trim() === ""
+        ) {
+          frame.pop();
+        }
+        expect(frame.length).toBeLessThanOrEqual(14);
+        // The full budgeted layout must actually be present: the last of the
+        // 8 viewport rows (repo, main, feature/0..5) and the second hint
+        // line's tail must both have survived.
+        expect(frame.some((l) => l.includes("feature/5"))).toBe(true);
+        expect(frame[frame.length - 1]).toContain("q:quit");
       } finally {
         rendered.unmount();
       }

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -494,6 +494,70 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
       }
     });
 
+    test("two wheel-downs written as one stdin chunk scroll twice end-to-end (guard integration)", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(40);
+
+      const rendered = await renderApp(<App />, 14);
+      try {
+        await tick(20);
+        // Rows: repo-1(0), main(1), feature/0(2), feature/1(3), …
+        expect(rendered.output()).toContain("main");
+
+        // Write BOTH wheel-down sequences in ONE stdin chunk. Ink 7.1's input
+        // parser splits the chunk into TWO per-sequence useInput events before
+        // dispatch, so this verifies the guarded dispatcher handles every
+        // event of a coalesced write end-to-end — NOT splitMouseSequences
+        // (that multi-sequence splitter only runs on Ink's paste-fallback
+        // path and is pinned by the pure tests in input-mouse.test.ts). Each
+        // event must scroll one row: offset 0 → 2, so the first visible row
+        // becomes feature/0 and main scrolls off; if only one event were
+        // acted on, offset would be 1 and main would still be visible.
+        await sendKeys(rendered.stdin, sgrWheel(1) + sgrWheel(1));
+        await tick(5);
+
+        const lines = rendered.lines();
+        expect(lines.some((l) => l.includes("feature/0"))).toBe(true);
+        expect(lines.some((l) => l.includes("main"))).toBe(false);
+      } finally {
+        rendered.unmount();
+      }
+    });
+
+    test("a click's press+release written as one chunk leaves the Search query clean (guard integration)", async () => {
+      registryItems.items = [
+        { id: "repo-1", repo_path: repoPath, project: "alpha" },
+      ];
+      setTallWorktrees(5);
+
+      const rendered = await renderApp(<App />, 20);
+      try {
+        await tick(20);
+        expect(rendered.output()).toContain("main");
+
+        await sendKeys(rendered.stdin, "/"); // enter Search
+        // A real click always emits press + release; write both in one stdin
+        // chunk. Ink splits them into two per-sequence useInput events, so
+        // this verifies the shape-based guard swallows BOTH halves in Search
+        // mode end-to-end — in particular the release, which parseSgrMouse
+        // resolves to null but must never fall through to the query handler.
+        await sendKeys(rendered.stdin, sgrPress(3, 3) + sgrRelease(3, 3));
+        await sendKeys(rendered.stdin, "f");
+        await tick(5);
+
+        // Query must be exactly "f" — still matching the feature/* rows. Had
+        // either half leaked into the query, nothing would match and no
+        // selection cursor would render.
+        const line = selectedLine(rendered.lines());
+        expect(line).toBeDefined();
+        expect(line).toContain("alpha");
+      } finally {
+        rendered.unmount();
+      }
+    });
+
     test("a genuine selectedIndex change still nudges the viewport", async () => {
       registryItems.items = [
         { id: "repo-1", repo_path: repoPath, project: "alpha" },

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -4,247 +4,30 @@
 // a hand-copied reimplementation of its effects — so reverting the fix in
 // App.tsx actually fails these tests.
 //
-// Mocking strategy mirrors the established pattern in this test suite
-// (tests/tui/use-tmux.test.ts, tests/tui/session-actions.test.ts,
-// tests/tui/modal-actions.test.ts): mock each `XService.use(selector)` to
-// call `selector` synchronously against a controllable fake service object
-// (so it returns a plain Promise, not a real Effect), and mock
-// `tuiRuntime.runPromise`/`runSync` as a transparent pass-through. Since the
-// `.use()` mocks already resolve the "effect" argument to a real Promise or
-// plain value before it reaches `runPromise`, the pass-through is enough —
-// the one caller that does NOT go through a `.use()` seam (`loadConfig` in
-// `getIdeDefaults`) is wrapped in a try/catch with a safe fallback in the
-// real code, so passing it through unresolved is harmless.
+// Service mocks and the Ink render harness live in tests/tui/app-harness.tsx
+// (shared with tests/tui/app-review-fixes.test.tsx); see the mocking-strategy
+// note there.
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
-import type React from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { Worktree } from "../../src/services/worktree-service";
-
-const runtimeMock = vi.hoisted(() => ({
-  runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
-  // The `.use()` mocks below already resolve the "effect" argument to a
-  // plain value before it reaches here, so this is a transparent pass-through
-  // (like runPromise), not a stub that discards its argument.
-  runSync: vi.fn((effect: unknown) => effect),
-}));
-
-vi.mock("../../src/tui/runtime", () => ({
-  tuiRuntime: runtimeMock,
-  runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
-}));
-
-// --- RegistryService: repos controllable per test via registryItems. ---
-const registryItems = vi.hoisted(() => ({
-  items: [] as Array<{ id: string; repo_path: string; project: string }>,
-}));
-
-vi.mock("../../src/services/registry-service", () => ({
-  RegistryService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        listRepos: () => Promise.resolve(registryItems.items),
-      }),
-  },
-}));
-
-// --- WorktreeService: worktrees keyed by repoPath, controllable per test. ---
-const worktreeFixtures = vi.hoisted(() => ({
-  byRepoPath: new Map<string, Worktree[]>(),
-}));
-
-vi.mock("../../src/services/worktree-service", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../src/services/worktree-service")
-  >("../../src/services/worktree-service");
-  return {
-    ...actual,
-    WorktreeService: {
-      use: (selector: (svc: unknown) => unknown) =>
-        selector({
-          listWorktrees: (repoPath: string) =>
-            Promise.resolve(worktreeFixtures.byRepoPath.get(repoPath) ?? []),
-          getDefaultBranch: () => Promise.resolve("main"),
-          getChangedFileCount: () => Promise.resolve(0),
-          getAheadBehind: () =>
-            Promise.resolve({ ahead: 0, behind: 0 }) as Promise<{
-              ahead: number;
-              behind: number;
-            } | null>,
-        }),
-    },
-  };
-});
-
-// --- TmuxService: no client, no sessions — App renders without tmux. ---
-vi.mock("../../src/services/tmux", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../src/services/tmux")
-  >("../../src/services/tmux");
-  return {
-    ...actual,
-    TmuxService: {
-      use: (selector: (svc: unknown) => unknown) =>
-        selector({
-          listClients: () => Promise.resolve([]),
-          listSessions: () => Promise.resolve(null),
-          listPanes: () => Promise.resolve([]),
-        }),
-    },
-  };
-});
-
-// --- GitHubService + PrCacheService: no PRs by default. useGitHub never
-// fetches on a fresh App mount for the current repo (its mount effect reads
-// `repos`, which is always `[]` on the very first render — before
-// useRegistry's async listRepos() resolves — and its callback identity never
-// changes, so it doesn't re-run once repos populate). The one REAL,
-// keyboard-reachable path that calls GitHubService.listPrs is pressing "r" in
-// Navigate mode (src/tui/input/navigate.ts calls ctx.refreshRepo), so a test
-// that needs a PR row drives that key rather than relying on mount timing.
-const githubFixtures = vi.hoisted(() => ({
-  prsByRepoPath: new Map<
-    string,
-    Array<{
-      number: number;
-      title: string;
-      state: "OPEN" | "MERGED" | "CLOSED";
-      headRefName: string;
-      rollupState: "success" | "failure" | "pending" | null;
-    }>
-  >(),
-}));
-
-vi.mock("../../src/services/github-service", () => ({
-  GitHubService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        listPrs: (repoPath: string) =>
-          Promise.resolve(githubFixtures.prsByRepoPath.get(repoPath) ?? []),
-      }),
-  },
-}));
-
-vi.mock("../../src/services/pr-cache-service", () => ({
-  PrCacheService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        getCached: () => null,
-        setCached: () => Promise.resolve(),
-        setError: () => Promise.resolve(),
-      }),
-  },
-}));
+import {
+  githubFixtures,
+  makeWorktree,
+  registryItems,
+  renderApp,
+  resetHarnessFixtures,
+  selectedLine,
+  sendKeys,
+  sgrPress,
+  sgrRelease,
+  sgrRowFor,
+  sgrWheel,
+  tick,
+  worktreeFixtures,
+} from "./app-harness";
 
 const { App } = await import("../../src/tui/App");
-
-type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
-type TestStdin = NodeJS.ReadStream & {
-  isTTY: boolean;
-  setRawMode: (mode: boolean) => NodeJS.ReadStream;
-  ref: () => NodeJS.ReadStream;
-  unref: () => NodeJS.ReadStream;
-};
-
-function createStdoutStdin(rows: number, columns = 100) {
-  const stdout = new PassThrough() as unknown as TestStdout;
-  stdout.columns = columns;
-  stdout.rows = rows;
-  const stdin = new PassThrough() as unknown as TestStdin;
-  stdin.isTTY = true;
-  stdin.setRawMode = () => stdin;
-  stdin.ref = () => stdin;
-  stdin.unref = () => stdin;
-  return { stdout, stdin };
-}
-
-function stripAnsi(value: string) {
-  let output = "";
-  for (let i = 0; i < value.length; i += 1) {
-    const char = value.charAt(i);
-    if (char === "" && value.charAt(i + 1) === "[") {
-      i += 2;
-      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
-        i += 1;
-      }
-      continue;
-    }
-    output += char;
-  }
-  return output;
-}
-
-async function tick(count = 1) {
-  for (let i = 0; i < count; i += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
-async function renderApp(
-  node: React.ReactElement,
-  termRows = 32,
-  termCols = 100,
-) {
-  const { stdout, stdin } = createStdoutStdin(termRows, termCols);
-  const chunks: string[] = [];
-  stdout.on("data", (chunk) => {
-    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
-  });
-
-  const { render } = await import("ink");
-  const instance = render(node, {
-    stdout,
-    stdin,
-    debug: true,
-    patchConsole: false,
-    exitOnCtrlC: false,
-  });
-
-  return {
-    stdin,
-    stdout,
-    // The last full frame Ink wrote, split into lines, ANSI stripped.
-    lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
-    output: () => stripAnsi(chunks.join("\n")),
-    unmount() {
-      instance.unmount();
-    },
-  };
-}
-
-async function sendKeys(stdin: NodeJS.ReadStream, sequence: string, ticks = 5) {
-  stdin.write(sequence);
-  await tick(ticks);
-}
-
-function sgrPress(col: number, row: number): string {
-  return `\x1b[<0;${col};${row}M`;
-}
-
-function sgrRelease(col: number, row: number): string {
-  return `\x1b[<0;${col};${row}m`;
-}
-
-function sgrWheel(dir: 1 | -1): string {
-  // 64 = wheel up (dir -1), 65 = wheel down (dir 1)
-  const cb = dir === -1 ? 64 : 65;
-  return `\x1b[<${cb};1;1M`;
-}
-
-// Mirrors App.tsx's TOP_CHROME_ROWS (== HEADER_OFFSET): the `wct` header line
-// + a blank spacer line above the tree viewport.
-const HEADER_OFFSET = 2;
-
-function sgrRowFor(viewportRow: number): number {
-  return viewportRow + 1 + HEADER_OFFSET;
-}
-
-/** The single rendered line containing the ❯ selection cursor, or undefined. */
-function selectedLine(lines: string[]): string | undefined {
-  return lines.find((l) => l.includes("❯"));
-}
 
 describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
   let homeDir: string;
@@ -260,11 +43,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     // refresh via a file write under it actually land.
     mkdirSync(join(homeDir, ".wct"), { recursive: true });
     vi.stubEnv("HOME", homeDir);
-    registryItems.items = [];
-    worktreeFixtures.byRepoPath.clear();
-    githubFixtures.prsByRepoPath.clear();
-    runtimeMock.runPromise.mockClear();
-    runtimeMock.runSync.mockClear();
+    resetHarnessFixtures();
   });
 
   afterEach(() => {
@@ -273,13 +52,8 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
     rmSync(repoPath, { recursive: true, force: true });
   });
 
-  function worktree(branch: string): Worktree {
-    return {
-      path: join(repoPath, branch.replaceAll("/", "-")),
-      branch,
-      commit: "abc123",
-      isBare: false,
-    };
+  function worktree(branch: string) {
+    return makeWorktree(repoPath, branch);
   }
 
   describe("Bug 1: click-to-exit-Expanded selects the clicked sibling, not the old identity", () => {
@@ -359,9 +133,10 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
 
         // Fetch PRs for real via the actual keyboard-reachable refresh path
         // (pressing "r" in Navigate calls ctx.refreshRepo -> refreshGitHub ->
-        // GitHubService.use(listPrs); see the githubFixtures comment above
-        // for why this is the only real path to populate PR data here). "r"
-        // is Navigate-only, so collapse out of Expanded first, then re-expand.
+        // GitHubService.use(listPrs); see the githubFixtures comment in
+        // app-harness.tsx for why this is the only real path to populate PR
+        // data here). "r" is Navigate-only, so collapse out of Expanded
+        // first, then re-expand.
         await sendKeys(rendered.stdin, "\x1b[D"); // left: collapse to Navigate
         await sendKeys(rendered.stdin, "r"); // refresh PRs for repo "alpha"
         await tick(15);
@@ -451,11 +226,10 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
 
   describe("Bug 2: background refresh (new `rows`/`repos` ref, same selectedIndex) must not re-anchor a wheel-scrolled viewport", () => {
     function setTallWorktrees(n: number) {
-      const worktrees: Worktree[] = [
+      worktreeFixtures.byRepoPath.set(repoPath, [
         worktree("main"),
         ...Array.from({ length: n }, (_, i) => worktree(`feature/${i}`)),
-      ];
-      worktreeFixtures.byRepoPath.set(repoPath, worktrees);
+      ]);
     }
 
     test("a background refresh (repos ref change, selectedIndex unchanged) does not move the viewport", async () => {

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -9,217 +9,34 @@
 // 3. Ctrl+C writes MOUSE_DISABLE BEFORE Ink turns raw mode off (same ordering
 //    fix as the `q` path; requires exitOnCtrlC to be off so the app owns \x03).
 // 4. Legacy X10 mouse bytes (terminal honors ?1000 but not ?1006) are
-//    swallowed by the guard instead of typing junk into the Search query.
+//    swallowed by the guard instead of typing junk into the Search query —
+//    including payload bytes ≥ 0x80 that UTF-8 decode merges into ONE
+//    multi-byte character (the guard must count raw bytes, not characters).
 // 5. Horizontal wheel events (SGR cb 66/67) do not scroll the viewport.
+// 6. A multi-line bracketed paste into Search is collapsed onto one query row
+//    (StatusBar budgets the query line as exactly one terminal row).
 //
-// Mocking strategy is identical to tests/tui/app-mouse-wiring.test.tsx.
+// Service mocks and the Ink render harness live in tests/tui/app-harness.tsx
+// (shared with tests/tui/app-mouse-wiring.test.tsx); see the mocking-strategy
+// note there.
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
-import type React from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { Worktree } from "../../src/services/worktree-service";
-
-const runtimeMock = vi.hoisted(() => ({
-  runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
-  runSync: vi.fn((effect: unknown) => effect),
-}));
-
-vi.mock("../../src/tui/runtime", () => ({
-  tuiRuntime: runtimeMock,
-  runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
-}));
-
-const registryItems = vi.hoisted(() => ({
-  items: [] as Array<{ id: string; repo_path: string; project: string }>,
-}));
-
-vi.mock("../../src/services/registry-service", () => ({
-  RegistryService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        listRepos: () => Promise.resolve(registryItems.items),
-      }),
-  },
-}));
-
-const worktreeFixtures = vi.hoisted(() => ({
-  byRepoPath: new Map<string, Worktree[]>(),
-}));
-
-vi.mock("../../src/services/worktree-service", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../src/services/worktree-service")
-  >("../../src/services/worktree-service");
-  return {
-    ...actual,
-    WorktreeService: {
-      use: (selector: (svc: unknown) => unknown) =>
-        selector({
-          listWorktrees: (repoPath: string) =>
-            Promise.resolve(worktreeFixtures.byRepoPath.get(repoPath) ?? []),
-          getDefaultBranch: () => Promise.resolve("main"),
-          getChangedFileCount: () => Promise.resolve(0),
-          getAheadBehind: () =>
-            Promise.resolve({ ahead: 0, behind: 0 }) as Promise<{
-              ahead: number;
-              behind: number;
-            } | null>,
-        }),
-    },
-  };
-});
-
-vi.mock("../../src/services/tmux", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../src/services/tmux")
-  >("../../src/services/tmux");
-  return {
-    ...actual,
-    TmuxService: {
-      use: (selector: (svc: unknown) => unknown) =>
-        selector({
-          listClients: () => Promise.resolve([]),
-          listSessions: () => Promise.resolve(null),
-          listPanes: () => Promise.resolve([]),
-        }),
-    },
-  };
-});
-
-vi.mock("../../src/services/github-service", () => ({
-  GitHubService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        listPrs: () => Promise.resolve([]),
-      }),
-  },
-}));
-
-vi.mock("../../src/services/pr-cache-service", () => ({
-  PrCacheService: {
-    use: (selector: (svc: unknown) => unknown) =>
-      selector({
-        getCached: () => null,
-        setCached: () => Promise.resolve(),
-        setError: () => Promise.resolve(),
-      }),
-  },
-}));
+import {
+  makeWorktree,
+  registryItems,
+  renderApp,
+  resetHarnessFixtures,
+  selectedLine,
+  sendKeys,
+  sgrWheel,
+  tick,
+  worktreeFixtures,
+} from "./app-harness";
 
 const { App } = await import("../../src/tui/App");
 const { MOUSE_DISABLE } = await import("../../src/tui/hooks/useMouse");
-
-type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
-type TestStdin = NodeJS.ReadStream & {
-  isTTY: boolean;
-  setRawMode: (mode: boolean) => NodeJS.ReadStream;
-  ref: () => NodeJS.ReadStream;
-  unref: () => NodeJS.ReadStream;
-};
-
-function stripAnsi(value: string) {
-  let output = "";
-  for (let i = 0; i < value.length; i += 1) {
-    const char = value.charAt(i);
-    if (char === "" && value.charAt(i + 1) === "[") {
-      i += 2;
-      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
-        i += 1;
-      }
-      continue;
-    }
-    output += char;
-  }
-  return output;
-}
-
-async function tick(count = 1) {
-  for (let i = 0; i < count; i += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
-async function renderApp(
-  node: React.ReactElement,
-  termRows = 32,
-  termCols = 100,
-) {
-  const stdout = new PassThrough() as unknown as TestStdout;
-  stdout.columns = termCols;
-  stdout.rows = termRows;
-  const stdin = new PassThrough() as unknown as TestStdin;
-  stdin.isTTY = true;
-
-  // Ordered event log shared by stdout writes and raw-mode flips, so tests
-  // can assert real orderings (e.g. MOUSE_DISABLE before setRawMode(false)).
-  // stdout.write is patched (not the 'data' event) because write is
-  // synchronous with the caller while 'data' emission may be deferred.
-  const events: Array<
-    { kind: "write"; data: string } | { kind: "rawmode"; mode: boolean }
-  > = [];
-  // Forward EVERY argument: Ink resolves waitUntilExit via an empty write's
-  // completion callback, so dropping the callback would hang the exit path.
-  const originalWrite = stdout.write.bind(stdout) as (
-    ...args: unknown[]
-  ) => boolean;
-  stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
-    events.push({
-      kind: "write",
-      data:
-        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
-    });
-    return originalWrite(chunk, ...rest);
-  }) as typeof stdout.write;
-  stdin.setRawMode = (mode: boolean) => {
-    events.push({ kind: "rawmode", mode });
-    return stdin;
-  };
-  stdin.ref = () => stdin;
-  stdin.unref = () => stdin;
-
-  const chunks: string[] = [];
-  stdout.on("data", (chunk) => {
-    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
-  });
-
-  const { render } = await import("ink");
-  const instance = render(node, {
-    stdout,
-    stdin,
-    debug: true,
-    patchConsole: false,
-    exitOnCtrlC: false,
-  });
-
-  return {
-    stdin,
-    stdout,
-    events,
-    instance,
-    lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
-    output: () => stripAnsi(chunks.join("\n")),
-    unmount() {
-      instance.unmount();
-    },
-  };
-}
-
-async function sendKeys(stdin: NodeJS.ReadStream, sequence: string, ticks = 5) {
-  stdin.write(sequence);
-  await tick(ticks);
-}
-
-function sgrWheel(dir: 1 | -1): string {
-  const cb = dir === -1 ? 64 : 65;
-  return `\x1b[<${cb};1;1M`;
-}
-
-/** The single rendered line containing the ❯ selection cursor, or undefined. */
-function selectedLine(lines: string[]): string | undefined {
-  return lines.find((l) => l.includes("❯"));
-}
 
 describe("App.tsx review fixes (real App)", () => {
   let homeDir: string;
@@ -230,10 +47,7 @@ describe("App.tsx review fixes (real App)", () => {
     repoPath = mkdtempSync(join(tmpdir(), "wct-app-review-repo-"));
     mkdirSync(join(homeDir, ".wct"), { recursive: true });
     vi.stubEnv("HOME", homeDir);
-    registryItems.items = [];
-    worktreeFixtures.byRepoPath.clear();
-    runtimeMock.runPromise.mockClear();
-    runtimeMock.runSync.mockClear();
+    resetHarnessFixtures();
   });
 
   afterEach(() => {
@@ -242,19 +56,12 @@ describe("App.tsx review fixes (real App)", () => {
     rmSync(repoPath, { recursive: true, force: true });
   });
 
-  function worktree(branch: string): Worktree {
-    return {
-      path: join(repoPath, branch.replaceAll("/", "-")),
-      branch,
-      commit: "abc123",
-      isBare: false,
-    };
-  }
-
   function setTallWorktrees(n: number) {
     worktreeFixtures.byRepoPath.set(repoPath, [
-      worktree("main"),
-      ...Array.from({ length: n }, (_, i) => worktree(`feature/${i}`)),
+      makeWorktree(repoPath, "main"),
+      ...Array.from({ length: n }, (_, i) =>
+        makeWorktree(repoPath, `feature/${i}`),
+      ),
     ]);
     registryItems.items = [
       { id: "repo-1", repo_path: repoPath, project: "alpha" },
@@ -381,6 +188,105 @@ describe("App.tsx review fixes (real App)", () => {
       // the query line rendered as "/f" and no payload junk appended.
       expect(rendered.lines().some((l) => l.trim() === "/f")).toBe(true);
       expect(selectedLine(rendered.lines())).toBeDefined();
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("X10 payload bytes that UTF-8 decode merges into one character do not desync the guard", async () => {
+    setTallWorktrees(5);
+
+    const rendered = await renderApp(<App />, 20);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      await sendKeys(rendered.stdin, "/"); // enter Search
+      // An X10 left-click press+release at col 163, row 137: the coordinate
+      // bytes are col+32 = 0xC3 and row+32 = 0xA9, which stdin's UTF-8
+      // decode merges into the SINGLE character "é" — the 3-byte payload
+      // arrives as the two-character string " é". A guard that decrements by
+      // string length drains only 2 of the 3 armed bytes, stays armed, and
+      // eats the next real keystroke; the byte-counted guard drains exactly.
+      await sendKeys(rendered.stdin, "\x1b[M é\x1b[M#é");
+      await sendKeys(rendered.stdin, "f");
+      await tick(5);
+
+      // The "f" typed after the click must reach the query (rendered "/f"),
+      // and no payload characters may leak in.
+      expect(rendered.lines().some((l) => l.trim() === "/f")).toBe(true);
+      expect(selectedLine(rendered.lines())).toBeDefined();
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("X10 payload bytes that are INVALID UTF-8 are swallowed, not leaked to the query", async () => {
+    setTallWorktrees(5);
+
+    const rendered = await renderApp(<App />, 20);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      await sendKeys(rendered.stdin, "/"); // enter Search
+      // An X10 left-click press+release at col 100, row 8: the col byte is
+      // col+32 = 0x84 — a lone UTF-8 continuation byte, which stdin's decode
+      // replaces with U+FFFD (THREE UTF-8 bytes standing in for ONE raw
+      // byte). Counting the replacement char at its encoded width overshoots
+      // the 3-byte counter, drops the guard, and leaks "�(" into the query;
+      // counting it as the single raw byte it replaced drains exactly. The
+      // bytes must be written RAW (a JS string would re-encode 0x84 as two
+      // valid UTF-8 bytes and never produce the replacement char).
+      rendered.stdin.write(
+        Buffer.from([
+          0x1b,
+          0x5b,
+          0x4d,
+          0x20,
+          0x84,
+          0x28, // press:   ESC [ M 0x20 0x84 0x28
+          0x1b,
+          0x5b,
+          0x4d,
+          0x23,
+          0x84,
+          0x28, // release: ESC [ M 0x23 0x84 0x28
+        ]),
+      );
+      await tick(5);
+      await sendKeys(rendered.stdin, "f");
+      await tick(5);
+
+      expect(rendered.lines().some((l) => l.trim() === "/f")).toBe(true);
+      expect(selectedLine(rendered.lines())).toBeDefined();
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("a multi-line bracketed paste into Search stays on one query row", async () => {
+    setTallWorktrees(5);
+
+    const rendered = await renderApp(<App />, 20);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      await sendKeys(rendered.stdin, "/"); // enter Search
+      // Ink's bracketed-paste fallback (no paste listener registered)
+      // delivers the pasted text as ONE input event, embedded newline
+      // included. statusBarRowCount(Search) budgets the query as exactly one
+      // row and wrap="truncate" cannot remove newlines — un-collapsed, the
+      // paste would render an extra chrome row and desync mouse hit-testing.
+      await sendKeys(rendered.stdin, "\x1b[200~feat\nure\x1b[201~");
+      await tick(5);
+
+      const lines = rendered.lines();
+      // The newline is collapsed to a space on a single query row...
+      expect(lines.some((l) => l.trim() === "/feat ure")).toBe(true);
+      // ...and no second line carries the paste's tail.
+      expect(lines.some((l) => l.trim() === "ure")).toBe(false);
     } finally {
       rendered.unmount();
     }

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -1,0 +1,409 @@
+// Regression tests for the PR #104 review fixes that render the REAL exported
+// `App` from `src/tui/App.tsx` through Ink's actual input pipeline:
+//
+// 1. Opening a true modal (`o`) and cancelling must not wipe a wheel-scrolled
+//    viewport (the old `viewportRows = rows.length` modal branch clamped the
+//    scroll offset to 0 and re-anchored to the selection on cancel).
+// 2. A true modal over a tree taller than the terminal renders intact instead
+//    of being garbled by the overflowing full tree (overflowY clipping).
+// 3. Ctrl+C writes MOUSE_DISABLE BEFORE Ink turns raw mode off (same ordering
+//    fix as the `q` path; requires exitOnCtrlC to be off so the app owns \x03).
+// 4. Legacy X10 mouse bytes (terminal honors ?1000 but not ?1006) are
+//    swallowed by the guard instead of typing junk into the Search query.
+// 5. Horizontal wheel events (SGR cb 66/67) do not scroll the viewport.
+//
+// Mocking strategy is identical to tests/tui/app-mouse-wiring.test.tsx.
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { Worktree } from "../../src/services/worktree-service";
+
+const runtimeMock = vi.hoisted(() => ({
+  runPromise: vi.fn((effect: unknown) => Promise.resolve(effect)),
+  runSync: vi.fn((effect: unknown) => effect),
+}));
+
+vi.mock("../../src/tui/runtime", () => ({
+  tuiRuntime: runtimeMock,
+  runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
+}));
+
+const registryItems = vi.hoisted(() => ({
+  items: [] as Array<{ id: string; repo_path: string; project: string }>,
+}));
+
+vi.mock("../../src/services/registry-service", () => ({
+  RegistryService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listRepos: () => Promise.resolve(registryItems.items),
+      }),
+  },
+}));
+
+const worktreeFixtures = vi.hoisted(() => ({
+  byRepoPath: new Map<string, Worktree[]>(),
+}));
+
+vi.mock("../../src/services/worktree-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/worktree-service")
+  >("../../src/services/worktree-service");
+  return {
+    ...actual,
+    WorktreeService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listWorktrees: (repoPath: string) =>
+            Promise.resolve(worktreeFixtures.byRepoPath.get(repoPath) ?? []),
+          getDefaultBranch: () => Promise.resolve("main"),
+          getChangedFileCount: () => Promise.resolve(0),
+          getAheadBehind: () =>
+            Promise.resolve({ ahead: 0, behind: 0 }) as Promise<{
+              ahead: number;
+              behind: number;
+            } | null>,
+        }),
+    },
+  };
+});
+
+vi.mock("../../src/services/tmux", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/services/tmux")
+  >("../../src/services/tmux");
+  return {
+    ...actual,
+    TmuxService: {
+      use: (selector: (svc: unknown) => unknown) =>
+        selector({
+          listClients: () => Promise.resolve([]),
+          listSessions: () => Promise.resolve(null),
+          listPanes: () => Promise.resolve([]),
+        }),
+    },
+  };
+});
+
+vi.mock("../../src/services/github-service", () => ({
+  GitHubService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        listPrs: () => Promise.resolve([]),
+      }),
+  },
+}));
+
+vi.mock("../../src/services/pr-cache-service", () => ({
+  PrCacheService: {
+    use: (selector: (svc: unknown) => unknown) =>
+      selector({
+        getCached: () => null,
+        setCached: () => Promise.resolve(),
+        setError: () => Promise.resolve(),
+      }),
+  },
+}));
+
+const { App } = await import("../../src/tui/App");
+const { MOUSE_DISABLE } = await import("../../src/tui/hooks/useMouse");
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  ref: () => NodeJS.ReadStream;
+  unref: () => NodeJS.ReadStream;
+};
+
+function stripAnsi(value: string) {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value.charAt(i);
+    if (char === "" && value.charAt(i + 1) === "[") {
+      i += 2;
+      while (i < value.length && !/[\x40-\x7E]/.test(value.charAt(i))) {
+        i += 1;
+      }
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+async function tick(count = 1) {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+async function renderApp(
+  node: React.ReactElement,
+  termRows = 32,
+  termCols = 100,
+) {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = termCols;
+  stdout.rows = termRows;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = true;
+
+  // Ordered event log shared by stdout writes and raw-mode flips, so tests
+  // can assert real orderings (e.g. MOUSE_DISABLE before setRawMode(false)).
+  // stdout.write is patched (not the 'data' event) because write is
+  // synchronous with the caller while 'data' emission may be deferred.
+  const events: Array<
+    { kind: "write"; data: string } | { kind: "rawmode"; mode: boolean }
+  > = [];
+  // Forward EVERY argument: Ink resolves waitUntilExit via an empty write's
+  // completion callback, so dropping the callback would hang the exit path.
+  const originalWrite = stdout.write.bind(stdout) as (
+    ...args: unknown[]
+  ) => boolean;
+  stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    events.push({
+      kind: "write",
+      data:
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    });
+    return originalWrite(chunk, ...rest);
+  }) as typeof stdout.write;
+  stdin.setRawMode = (mode: boolean) => {
+    events.push({ kind: "rawmode", mode });
+    return stdin;
+  };
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  const { render } = await import("ink");
+  const instance = render(node, {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  return {
+    stdin,
+    stdout,
+    events,
+    instance,
+    lines: () => stripAnsi(chunks[chunks.length - 1] ?? "").split("\n"),
+    output: () => stripAnsi(chunks.join("\n")),
+    unmount() {
+      instance.unmount();
+    },
+  };
+}
+
+async function sendKeys(stdin: NodeJS.ReadStream, sequence: string, ticks = 5) {
+  stdin.write(sequence);
+  await tick(ticks);
+}
+
+function sgrWheel(dir: 1 | -1): string {
+  const cb = dir === -1 ? 64 : 65;
+  return `\x1b[<${cb};1;1M`;
+}
+
+/** The single rendered line containing the ❯ selection cursor, or undefined. */
+function selectedLine(lines: string[]): string | undefined {
+  return lines.find((l) => l.includes("❯"));
+}
+
+describe("App.tsx review fixes (real App)", () => {
+  let homeDir: string;
+  let repoPath: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "wct-app-review-home-"));
+    repoPath = mkdtempSync(join(tmpdir(), "wct-app-review-repo-"));
+    mkdirSync(join(homeDir, ".wct"), { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+    registryItems.items = [];
+    worktreeFixtures.byRepoPath.clear();
+    runtimeMock.runPromise.mockClear();
+    runtimeMock.runSync.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(homeDir, { recursive: true, force: true });
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  function worktree(branch: string): Worktree {
+    return {
+      path: join(repoPath, branch.replaceAll("/", "-")),
+      branch,
+      commit: "abc123",
+      isBare: false,
+    };
+  }
+
+  function setTallWorktrees(n: number) {
+    worktreeFixtures.byRepoPath.set(repoPath, [
+      worktree("main"),
+      ...Array.from({ length: n }, (_, i) => worktree(`feature/${i}`)),
+    ]);
+    registryItems.items = [
+      { id: "repo-1", repo_path: repoPath, project: "alpha" },
+    ];
+  }
+
+  test("opening and cancelling a modal preserves a wheel-scrolled viewport", async () => {
+    setTallWorktrees(40);
+
+    const rendered = await renderApp(<App />, 14);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      // Selection stays on the repo row (index 0); wheel the viewport away so
+      // the selected row is off-screen — the deliberate PRD §3 state.
+      for (let i = 0; i < 15; i++) {
+        await sendKeys(rendered.stdin, sgrWheel(1), 1);
+      }
+      await tick(5);
+      const before = rendered.lines();
+      expect(selectedLine(before)).toBeUndefined();
+      const visibleBefore = before.filter((l) => /feature\/\d+/.test(l));
+      expect(visibleBefore.length).toBeGreaterThan(0);
+
+      // Open the OpenModal and cancel straight out of it. The old modal
+      // branch set viewportRows = rows.length, whose clamp effect zeroed the
+      // persistent scrollOffset — after Esc the viewport re-anchored to the
+      // selection and the reading position (visibleBefore) was gone.
+      await sendKeys(rendered.stdin, "o");
+      expect(rendered.output()).toContain("Select mode");
+      // A lone ESC sits in Ink's pending-escape buffer for 20ms (it could be
+      // the start of a CSI sequence) before it is flushed as the escape key —
+      // wait past that flush, not just event-loop ticks.
+      await sendKeys(rendered.stdin, "\x1b"); // esc: cancel back to Navigate
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await tick(5);
+
+      const after = rendered.lines();
+      expect(selectedLine(after)).toBeUndefined();
+      expect(after.filter((l) => /feature\/\d+/.test(l))).toEqual(
+        visibleBefore,
+      );
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("a modal over a tree taller than the terminal renders intact (no garble)", async () => {
+    setTallWorktrees(40);
+
+    const rendered = await renderApp(<App />, 14);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      await sendKeys(rendered.stdin, "o");
+
+      const frame = rendered.lines();
+      while (
+        frame.length > 0 &&
+        (frame[frame.length - 1] ?? "").trim() === ""
+      ) {
+        frame.pop();
+      }
+      // The whole frame must fit the terminal (the overflowing tree clips
+      // inside its own box instead of painting over the modal)...
+      expect(frame.length).toBeLessThanOrEqual(14);
+      // ...the header must survive (the garbled layout corrupted it to " ct")...
+      expect(frame[0]).toBe("wct");
+      // ...and the modal must be fully present: title on its top border and
+      // an intact bottom border, in order.
+      const topBorder = frame.findIndex((l) => l.includes("Select mode"));
+      const bottomBorder = frame.findIndex((l) => l.includes("╰"));
+      expect(topBorder).toBeGreaterThan(-1);
+      expect(frame[topBorder]).toContain("╭");
+      expect(bottomBorder).toBeGreaterThan(topBorder);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("Ctrl+C disables mouse reporting BEFORE raw mode is turned off, then exits", async () => {
+    setTallWorktrees(3);
+
+    const rendered = await renderApp(<App />, 20);
+    await tick(20);
+
+    await sendKeys(rendered.stdin, "\x03");
+    await rendered.instance.waitUntilExit();
+
+    const disableIndex = rendered.events.findIndex(
+      (e) => e.kind === "write" && e.data.includes(MOUSE_DISABLE),
+    );
+    const rawModeOffIndex = rendered.events.findIndex(
+      (e) => e.kind === "rawmode" && e.mode === false,
+    );
+    // Without the fix Ink's own \x03 shortcut runs handleExit first: raw mode
+    // goes off during handleExit and MOUSE_DISABLE only lands later, in the
+    // React unmount cleanup — echoing any in-flight reports onto the shell.
+    expect(disableIndex).toBeGreaterThan(-1);
+    expect(rawModeOffIndex).toBeGreaterThan(-1);
+    expect(disableIndex).toBeLessThan(rawModeOffIndex);
+  });
+
+  test("legacy X10 mouse bytes are swallowed instead of typed into the Search query", async () => {
+    setTallWorktrees(5);
+
+    const rendered = await renderApp(<App />, 20);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+
+      await sendKeys(rendered.stdin, "/"); // enter Search
+      // An X10 left-click press+release at col 5, row 12: ESC [ M + 3 payload
+      // bytes each. Ink splits each report into an "[M" CSI event plus a
+      // separate printable payload event; the payload (" %," / "#%,") is what
+      // leaked into the query before the guard armed a byte-counted swallow.
+      await sendKeys(rendered.stdin, "\x1b[M %,\x1b[M#%,");
+      await sendKeys(rendered.stdin, "f");
+      await tick(5);
+
+      // The query must be exactly "f": still matching feature/* rows, with
+      // the query line rendered as "/f" and no payload junk appended.
+      expect(rendered.lines().some((l) => l.trim() === "/f")).toBe(true);
+      expect(selectedLine(rendered.lines())).toBeDefined();
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("horizontal wheel events (cb 66/67) do not scroll the viewport", async () => {
+    setTallWorktrees(40);
+
+    const rendered = await renderApp(<App />, 14);
+    try {
+      await tick(20);
+      expect(rendered.output()).toContain("main");
+      const before = rendered.lines();
+
+      // A horizontal trackpad swipe burst: wheel-left and wheel-right ticks.
+      await sendKeys(rendered.stdin, "\x1b[<66;1;1M\x1b[<67;1;1M\x1b[<66;1;1M");
+      await tick(5);
+
+      // Before the fix these decoded as vertical wheel via bit 0 and jerked
+      // the viewport; now the frame must be unchanged.
+      expect(rendered.lines()).toEqual(before);
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -24,15 +24,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
-  makeWorktree,
-  registryItems,
   renderApp,
   resetHarnessFixtures,
   selectedLine,
   sendKeys,
+  setTallWorktrees,
   sgrWheel,
   tick,
-  worktreeFixtures,
 } from "./app-harness";
 
 const { App } = await import("../../src/tui/App");
@@ -56,20 +54,8 @@ describe("App.tsx review fixes (real App)", () => {
     rmSync(repoPath, { recursive: true, force: true });
   });
 
-  function setTallWorktrees(n: number) {
-    worktreeFixtures.byRepoPath.set(repoPath, [
-      makeWorktree(repoPath, "main"),
-      ...Array.from({ length: n }, (_, i) =>
-        makeWorktree(repoPath, `feature/${i}`),
-      ),
-    ]);
-    registryItems.items = [
-      { id: "repo-1", repo_path: repoPath, project: "alpha" },
-    ];
-  }
-
   test("opening and cancelling a modal preserves a wheel-scrolled viewport", async () => {
-    setTallWorktrees(40);
+    setTallWorktrees(repoPath, 40);
 
     const rendered = await renderApp(<App />, 14);
     try {
@@ -111,7 +97,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("a modal over a tree taller than the terminal renders intact (no garble)", async () => {
-    setTallWorktrees(40);
+    setTallWorktrees(repoPath, 40);
 
     const rendered = await renderApp(<App />, 14);
     try {
@@ -145,7 +131,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("Ctrl+C disables mouse reporting BEFORE raw mode is turned off, then exits", async () => {
-    setTallWorktrees(3);
+    setTallWorktrees(repoPath, 3);
 
     const rendered = await renderApp(<App />, 20);
     await tick(20);
@@ -168,7 +154,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("legacy X10 mouse bytes are swallowed instead of typed into the Search query", async () => {
-    setTallWorktrees(5);
+    setTallWorktrees(repoPath, 5);
 
     const rendered = await renderApp(<App />, 20);
     try {
@@ -194,7 +180,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("X10 payload bytes that UTF-8 decode merges into one character do not desync the guard", async () => {
-    setTallWorktrees(5);
+    setTallWorktrees(repoPath, 5);
 
     const rendered = await renderApp(<App />, 20);
     try {
@@ -222,7 +208,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("X10 payload bytes that are INVALID UTF-8 are swallowed, not leaked to the query", async () => {
-    setTallWorktrees(5);
+    setTallWorktrees(repoPath, 5);
 
     const rendered = await renderApp(<App />, 20);
     try {
@@ -266,7 +252,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("a multi-line bracketed paste into Search stays on one query row", async () => {
-    setTallWorktrees(5);
+    setTallWorktrees(repoPath, 5);
 
     const rendered = await renderApp(<App />, 20);
     try {
@@ -293,7 +279,7 @@ describe("App.tsx review fixes (real App)", () => {
   });
 
   test("horizontal wheel events (cb 66/67) do not scroll the viewport", async () => {
-    setTallWorktrees(40);
+    setTallWorktrees(repoPath, 40);
 
     const rendered = await renderApp(<App />, 14);
     try {

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -7,6 +7,7 @@ import {
   isWithinExpandedSubtree,
   scrollToKeepVisible,
 } from "../../src/tui/tree-helpers";
+import { wrapPrLabel } from "../../src/tui/pr-layout";
 import { type PendingAction, pendingKey } from "../../src/tui/types";
 
 function repo(overrides: Partial<RepoInfo> & { id: string }): RepoInfo {
@@ -562,6 +563,17 @@ describe("buildTreeRows", () => {
       itemIndex: 3,
       kind: "worktree",
     });
+
+    // Every PR row carries its own wrapped line text so the render consumes
+    // exactly the lines this model counted (DetailRow never re-wraps): the
+    // detail row holds line 0 and each continuation row holds its piece.
+    const prItem = items[2];
+    if (prItem?.type !== "detail") throw new Error("expected detail item");
+    const expectedLines = wrapPrLabel(prItem.label, 40, true);
+    const prRows = rows.filter(
+      (r) => r.kind === "detail" || r.kind === "detail-pr-cont",
+    );
+    expect(prRows.map((r) => r.prLine)).toEqual(expectedLines);
   });
 
   test("a PR label that fits on one line emits no continuation rows", () => {

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, test } from "vitest";
+import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
+import {
+  buildTreeItems,
+  buildTreeRows,
+  clampScrollOffset,
+  isWithinExpandedSubtree,
+  scrollToKeepVisible,
+} from "../../src/tui/tree-helpers";
+import { type PendingAction, pendingKey } from "../../src/tui/types";
+
+function repo(overrides: Partial<RepoInfo> & { id: string }): RepoInfo {
+  return {
+    id: overrides.id,
+    repoPath: overrides.repoPath ?? `/tmp/${overrides.id}`,
+    project: overrides.project ?? overrides.id,
+    worktrees: overrides.worktrees ?? [],
+    profileNames: overrides.profileNames ?? [],
+    ideDefaults: overrides.ideDefaults ?? { baseNoIde: true, profileNoIde: {} },
+  };
+}
+
+const emptyOpts = {
+  prData: new Map(),
+  panes: new Map(),
+  jumpToPane: () => undefined,
+};
+
+describe("buildTreeRows", () => {
+  test("a collapsed repo with one worktree maps each row 1:1 to its item", () => {
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions: new Map(),
+    });
+
+    // items: [repo, worktree]; sync is clean so no stats row even if expanded.
+    expect(rows.map((r) => r.itemIndex)).toEqual([0, 1]);
+    expect(rows.map((r) => r.kind)).toEqual(["repo", "worktree"]);
+  });
+
+  test("an expanded worktree with stats inserts a null-mapped stats row", () => {
+    const branch = "feature/x";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-x",
+            isMainWorktree: false,
+            changedFiles: 3,
+            sync: { ahead: 1, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+    });
+
+    // items: [repo(0), worktree(1)]
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: null, kind: "worktree-stats" },
+      ],
+    );
+  });
+
+  test("a clean expanded worktree does NOT insert a stats row", () => {
+    const branch = "feature/clean";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-clean",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+    });
+
+    expect(rows.map((r) => r.kind)).toEqual(["repo", "worktree"]);
+  });
+
+  test("an expanded repo with no worktrees emits a (no worktrees) row", () => {
+    const repos = [repo({ id: "repo-1", project: "empty", worktrees: [] })];
+    const expandedRepos = new Set(["repo-1"]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions: new Map(),
+    });
+
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: null, kind: "repo-empty" },
+      ],
+    );
+  });
+
+  test("a collapsed repo with no worktrees does NOT emit a (no worktrees) row", () => {
+    const repos = [repo({ id: "repo-1", project: "empty", worktrees: [] })];
+    const expandedRepos = new Set<string>();
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions: new Map(),
+    });
+
+    expect(rows.map((r) => r.kind)).toEqual(["repo"]);
+  });
+
+  test("phantom opening rows for a populated repo follow its worktree block", () => {
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const pendingActions = new Map<string, PendingAction>([
+      [
+        pendingKey("alpha", "feature/new"),
+        { type: "opening", branch: "feature/new", project: "alpha" },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions,
+    });
+
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: null, kind: "phantom" },
+      ],
+    );
+  });
+
+  test("phantom rows for an empty expanded repo are appended at the bottom of the whole tree", () => {
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+      repo({ id: "repo-2", project: "empty", worktrees: [] }),
+    ];
+    const expandedRepos = new Set(["repo-1", "repo-2"]);
+    const pendingActions = new Map<string, PendingAction>([
+      [
+        pendingKey("empty", "feature/seed"),
+        { type: "opening", branch: "feature/seed", project: "empty" },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      ...emptyOpts,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions,
+    });
+
+    // items: [repo-1(0), worktree(1), repo-2(2)]
+    // The empty-repo phantom is NOT placed under repo-2; it is appended last.
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: 2, kind: "repo" },
+        { itemIndex: null, kind: "repo-empty" },
+        { itemIndex: null, kind: "phantom" },
+      ],
+    );
+  });
+
+  test("detail rows under an expanded worktree map 1:1 to their items", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "Add thing",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+    });
+
+    // items: [repo(0), worktree(1), pr-detail(2)]; clean sync → no stats row.
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: 2, kind: "detail" },
+      ],
+    );
+  });
+});
+
+describe("clampScrollOffset", () => {
+  test("clamps below zero to zero", () => {
+    expect(clampScrollOffset(-5, 10, 4)).toBe(0);
+  });
+
+  test("clamps above the max scrollable offset", () => {
+    // max = rowsLength - viewportRows = 10 - 4 = 6
+    expect(clampScrollOffset(99, 10, 4)).toBe(6);
+  });
+
+  test("leaves an in-range offset untouched", () => {
+    expect(clampScrollOffset(3, 10, 4)).toBe(3);
+  });
+
+  test("forces 0 when the tree fits the viewport", () => {
+    expect(clampScrollOffset(2, 4, 10)).toBe(0);
+    expect(clampScrollOffset(2, 10, 10)).toBe(0);
+  });
+});
+
+describe("scrollToKeepVisible", () => {
+  test("leaves the offset unchanged when the row is already inside the window", () => {
+    // window covers rows [2..6]
+    expect(scrollToKeepVisible(4, 2, 5)).toBe(2);
+    expect(scrollToKeepVisible(2, 2, 5)).toBe(2); // top edge
+    expect(scrollToKeepVisible(6, 2, 5)).toBe(2); // bottom edge
+  });
+
+  test("scrolls up by exactly the gap when the row is just above the window", () => {
+    // window [5..9]; selecting row 4 nudges offset to 4 (gap of 1)
+    expect(scrollToKeepVisible(4, 5, 5)).toBe(4);
+    // selecting row 1 nudges offset to 1
+    expect(scrollToKeepVisible(1, 5, 5)).toBe(1);
+  });
+
+  test("scrolls down minimally when the row is just below the window", () => {
+    // window [0..4]; selecting row 5 → offset = 5 - 5 + 1 = 1
+    expect(scrollToKeepVisible(5, 0, 5)).toBe(1);
+    // selecting row 7 → offset = 7 - 5 + 1 = 3
+    expect(scrollToKeepVisible(7, 0, 5)).toBe(3);
+  });
+
+  test("returns the offset unchanged for a zero/negative viewport", () => {
+    expect(scrollToKeepVisible(3, 2, 0)).toBe(2);
+  });
+});
+
+describe("isWithinExpandedSubtree", () => {
+  const repos = [
+    repo({
+      id: "repo-1",
+      project: "alpha",
+      worktrees: [
+        {
+          branch: "feature/a",
+          path: "/tmp/a",
+          isMainWorktree: false,
+          changedFiles: 0,
+          sync: null,
+        },
+        {
+          branch: "feature/b",
+          path: "/tmp/b",
+          isMainWorktree: false,
+          changedFiles: 0,
+          sync: null,
+        },
+      ],
+    }),
+    repo({
+      id: "repo-2",
+      project: "beta",
+      worktrees: [
+        {
+          branch: "feature/c",
+          path: "/tmp/c",
+          isMainWorktree: false,
+          changedFiles: 0,
+          sync: null,
+        },
+      ],
+    }),
+  ];
+  const expandedKey = pendingKey("alpha", "feature/a");
+  // items: 0 repo-1, 1 wt feature/a, 2 detail(a), 3 wt feature/b,
+  //        4 repo-2, 5 wt feature/c
+  const items = [
+    { type: "repo" as const, repoIndex: 0 },
+    { type: "worktree" as const, repoIndex: 0, worktreeIndex: 0 },
+    {
+      type: "detail" as const,
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pr" as const,
+      label: "PR #1",
+      meta: { rollupState: "success" as const },
+    },
+    { type: "worktree" as const, repoIndex: 0, worktreeIndex: 1 },
+    { type: "repo" as const, repoIndex: 1 },
+    { type: "worktree" as const, repoIndex: 1, worktreeIndex: 0 },
+  ];
+
+  test("a detail row owned by the expanded worktree is within the subtree", () => {
+    expect(isWithinExpandedSubtree(items, 2, expandedKey, repos)).toBe(true);
+  });
+
+  test("the expanded worktree row itself is within the subtree", () => {
+    expect(isWithinExpandedSubtree(items, 1, expandedKey, repos)).toBe(true);
+  });
+
+  test("a sibling worktree in the same repo is NOT within the subtree", () => {
+    expect(isWithinExpandedSubtree(items, 3, expandedKey, repos)).toBe(false);
+  });
+
+  test("a worktree in another repo is NOT within the subtree", () => {
+    expect(isWithinExpandedSubtree(items, 5, expandedKey, repos)).toBe(false);
+  });
+
+  test("a repo row resolves to no owning worktree and is not within", () => {
+    expect(isWithinExpandedSubtree(items, 0, expandedKey, repos)).toBe(false);
+  });
+
+  test("returns false when no worktree is expanded", () => {
+    expect(isWithinExpandedSubtree(items, 1, null, repos)).toBe(false);
+  });
+});

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
+import { wrapPrLabel } from "../../src/tui/pr-layout";
 import {
   buildTreeItems,
   buildTreeRows,
@@ -7,7 +8,6 @@ import {
   isWithinExpandedSubtree,
   scrollToKeepVisible,
 } from "../../src/tui/tree-helpers";
-import { wrapPrLabel } from "../../src/tui/pr-layout";
 import { type PendingAction, pendingKey } from "../../src/tui/types";
 
 function repo(overrides: Partial<RepoInfo> & { id: string }): RepoInfo {

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -488,6 +488,187 @@ describe("buildTreeRows", () => {
       ],
     );
   });
+
+  test("a PR label that wraps emits continuation rows so rows below stay aligned", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "a very long pull request title that certainly wraps",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+      maxWidth: 40,
+    });
+
+    // items: [repo(0), wt feature/pr(1), pr-detail(2), wt main(3)].
+    // The PR line wraps at width 40, so the row model inserts continuation
+    // row(s) — all carrying the PR's own itemIndex (2) — before the next
+    // worktree row (item 3), which must remain a distinct terminal row.
+    const shape = rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }));
+    expect(shape[0]).toEqual({ itemIndex: 0, kind: "repo" });
+    expect(shape[1]).toEqual({ itemIndex: 1, kind: "worktree" });
+    expect(shape[2]).toEqual({ itemIndex: 2, kind: "detail" });
+
+    const contRows = shape.filter((r) => r.kind === "detail-pr-cont");
+    expect(contRows.length).toBeGreaterThan(0);
+    expect(contRows.every((r) => r.itemIndex === 2)).toBe(true);
+
+    // The following worktree is still its own row, right after the PR block.
+    expect(shape[3 + contRows.length]).toEqual({
+      itemIndex: 3,
+      kind: "worktree",
+    });
+  });
+
+  test("a PR label that fits on one line emits no continuation rows", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "short",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+      maxWidth: 80,
+    });
+
+    expect(rows.map((r) => r.kind)).toEqual(["repo", "worktree", "detail"]);
+  });
+
+  test("a PR with no rollup icon still emits continuation rows when it wraps", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "a very long pull request title that certainly wraps",
+          state: "OPEN" as const,
+          headRefName: branch,
+          // No rollup icon → wrap budget uses prLabelStart(false), a different
+          // code path than the icon case.
+          rollupState: null,
+        },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions: new Map(),
+      maxWidth: 40,
+    });
+
+    const contRows = rows.filter((r) => r.kind === "detail-pr-cont");
+    expect(contRows.length).toBeGreaterThan(0);
+    expect(contRows.every((r) => r.itemIndex === 2)).toBe(true);
+  });
 });
 
 describe("clampScrollOffset", () => {

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -233,6 +233,154 @@ describe("buildTreeRows", () => {
     );
   });
 
+  test("phantom rows still follow the last worktree when it is expanded with trailing detail rows", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "Add thing",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const pendingActions = new Map<string, PendingAction>([
+      [
+        pendingKey("alpha", "feature/new"),
+        { type: "opening", branch: "feature/new", project: "alpha" },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions,
+    });
+
+    // items: [repo(0), wt main(1), wt feature/pr(2), pr-detail(3)]. The
+    // phantom must come AFTER the expanded last worktree's detail rows — a
+    // next-item-only "last worktree" check would drop it entirely.
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: 2, kind: "worktree" },
+        { itemIndex: 3, kind: "detail" },
+        { itemIndex: null, kind: "phantom" },
+      ],
+    );
+  });
+
+  test("phantom rows follow the LAST worktree when an earlier worktree is expanded with detail rows", () => {
+    const branch = "feature/pr";
+    const repos = [
+      repo({
+        id: "repo-1",
+        project: "alpha",
+        worktrees: [
+          {
+            branch,
+            path: "/tmp/alpha-pr",
+            isMainWorktree: false,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+          {
+            branch: "main",
+            path: "/tmp/alpha-main",
+            isMainWorktree: true,
+            changedFiles: 0,
+            sync: { ahead: 0, behind: 0 },
+          },
+        ],
+      }),
+    ];
+    const expandedRepos = new Set(["repo-1"]);
+    const expandedWorktreeKey = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        expandedWorktreeKey,
+        {
+          number: 1,
+          title: "Add thing",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const pendingActions = new Map<string, PendingAction>([
+      [
+        pendingKey("alpha", "feature/new"),
+        { type: "opening", branch: "feature/new", project: "alpha" },
+      ],
+    ]);
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey,
+      pendingActions,
+    });
+
+    // items: [repo(0), wt feature/pr(1), pr-detail(2), wt main(3)]. Detail
+    // rows in the MIDDLE of the repo block must not trigger phantom emission;
+    // the phantom still trails the final worktree.
+    expect(rows.map((r) => ({ itemIndex: r.itemIndex, kind: r.kind }))).toEqual(
+      [
+        { itemIndex: 0, kind: "repo" },
+        { itemIndex: 1, kind: "worktree" },
+        { itemIndex: 2, kind: "detail" },
+        { itemIndex: 3, kind: "worktree" },
+        { itemIndex: null, kind: "phantom" },
+      ],
+    );
+  });
+
   test("phantom rows for an empty expanded repo are appended at the bottom of the whole tree", () => {
     const repos = [
       repo({

--- a/tests/tui/detail-row.test.tsx
+++ b/tests/tui/detail-row.test.tsx
@@ -240,6 +240,47 @@ describe("DetailRow", () => {
     unmount();
   });
 
+  test("wraps a long pr label instead of truncating it", async () => {
+    // maxWidth=30, hasIcon → budget=20. Word-wrap yields
+    // ["PR #7: fix the login", "flow (OPEN)"]: piece 0 is the primary line,
+    // piece 1 the continuation. The full title survives, no ellipsis.
+    const label = "PR #7: fix the login flow (OPEN)";
+    const item = {
+      type: "detail",
+      repoIndex: 0,
+      worktreeIndex: 0,
+      detailKind: "pr",
+      label,
+      meta: { rollupState: "success" as const },
+    } as Extract<TreeItem, { type: "detail"; detailKind: "pr" }>;
+
+    const primary = await renderDetailRow({
+      item,
+      isSelected: false,
+      maxWidth: 30,
+      pieceIndex: 0,
+    });
+    const continuation = await renderDetailRow({
+      item,
+      isSelected: false,
+      maxWidth: 30,
+      pieceIndex: 1,
+    });
+
+    // The primary line shows the icon and the start of the title; the
+    // continuation line shows a later part. Nothing is replaced by an ellipsis.
+    expect(primary.output).toContain("✓");
+    expect(primary.output).toContain("PR #7: fix the login");
+    expect(primary.output).not.toContain("…");
+    expect(continuation.output).not.toContain("…");
+    // The tail of the title lands on the continuation line, not the primary.
+    expect(continuation.output).toContain("flow (OPEN)");
+    expect(primary.output).not.toContain("(OPEN)");
+
+    primary.unmount();
+    continuation.unmount();
+  });
+
   test("renders no rollup icon for pr row when rollupState is null", async () => {
     const { output, unmount } = await renderDetailRow({
       item: {

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -12,7 +12,7 @@ import {
   buildTreeRows,
   type TreeRow,
 } from "../../src/tui/tree-helpers";
-import { Mode, pendingKey } from "../../src/tui/types";
+import { Mode, type PaneInfo, pendingKey } from "../../src/tui/types";
 
 describe("parseSgrMouse", () => {
   test("decodes wheel up (cb=64) as wheel, NOT a click (the %4 bug is absent)", () => {
@@ -245,6 +245,7 @@ function buildCtx(
   mode: Mode,
   expandedWorktreeKey: string | null,
   overrides?: Partial<MouseActionContext>,
+  panes: Map<string, PaneInfo[]> = new Map(),
 ): MouseActionContext {
   const expandedRepos = new Set(["repo-1", "repo-2"]);
   const treeItems = buildTreeItems({
@@ -252,7 +253,7 @@ function buildCtx(
     expandedRepos,
     expandedWorktreeKey,
     prData: new Map(),
-    panes: new Map(),
+    panes,
     jumpToPane: () => undefined,
   });
   const rows = buildTreeRows({
@@ -377,6 +378,70 @@ describe("resolveMouseAction", () => {
         ctx,
       ),
     ).toEqual({ kind: "selectAndExitExpanded", itemIndex });
+  });
+
+  test("a click on an inert pane-header row resolves to none, but a pane row selects (keyboard parity)", () => {
+    const key = pendingKey("alpha", "feature/a");
+    // feature/a's session name is formatSessionName(basename("/tmp/a")) = "a".
+    const panes = new Map<string, PaneInfo[]>([
+      [
+        "a",
+        [
+          {
+            paneId: "%1",
+            paneIndex: 0,
+            command: "vim",
+            window: "0",
+            zoomed: false,
+            active: true,
+          },
+        ],
+      ],
+    ]);
+    const ctx = buildCtx(Mode.Expanded(key), key, undefined, panes);
+
+    const headerItemIndex = ctx.treeItems.findIndex(
+      (item) => item.type === "detail" && item.detailKind === "pane-header",
+    );
+    expect(headerItemIndex).toBeGreaterThan(-1);
+    const headerRowIndex = ctx.rows.findIndex(
+      (r: TreeRow) => r.itemIndex === headerItemIndex,
+    );
+    expect(headerRowIndex).toBeGreaterThan(-1);
+
+    // createNavigateTree skips pane-header rows for the keyboard, so a mouse
+    // click on one must be a no-op — not a selection the keyboard could
+    // never reach.
+    expect(
+      resolveMouseAction(
+        {
+          kind: "press",
+          button: "left",
+          col: 3,
+          row: headerRowIndex + 1 + HEADER_OFFSET,
+        },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+
+    // A pane row directly below the header IS selectable by mouse.
+    const paneItemIndex = ctx.treeItems.findIndex(
+      (item) => item.type === "detail" && item.detailKind === "pane",
+    );
+    const paneRowIndex = ctx.rows.findIndex(
+      (r: TreeRow) => r.itemIndex === paneItemIndex,
+    );
+    expect(
+      resolveMouseAction(
+        {
+          kind: "press",
+          button: "left",
+          col: 3,
+          row: paneRowIndex + 1 + HEADER_OFFSET,
+        },
+        ctx,
+      ),
+    ).toEqual({ kind: "select", itemIndex: paneItemIndex });
   });
 
   test("non-interactive modes (Search/modals/confirm) resolve to none", () => {

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "vitest";
+import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
+import {
+  HEADER_OFFSET,
+  type MouseActionContext,
+  parseSgrMouse,
+  resolveMouseAction,
+} from "../../src/tui/input/mouse";
+import {
+  buildTreeItems,
+  buildTreeRows,
+  type TreeRow,
+} from "../../src/tui/tree-helpers";
+import { Mode, pendingKey } from "../../src/tui/types";
+
+describe("parseSgrMouse", () => {
+  test("decodes wheel up (cb=64) as wheel, NOT a click (the %4 bug is absent)", () => {
+    const event = parseSgrMouse("[<64;10;5M");
+    expect(event).toEqual({ kind: "wheel", dir: -1 });
+    // If the parser used `cb % 4`, 64 % 4 === 0 would decode as a left press.
+    expect(event?.kind).not.toBe("press");
+  });
+
+  test("decodes wheel down (cb=65) as wheel down", () => {
+    expect(parseSgrMouse("[<65;10;5M")).toEqual({ kind: "wheel", dir: 1 });
+  });
+
+  test("tolerates a leading ESC on the sequence", () => {
+    expect(parseSgrMouse("\x1b[<64;1;1M")).toEqual({ kind: "wheel", dir: -1 });
+  });
+
+  test("decodes a left press with 1-based col/row", () => {
+    expect(parseSgrMouse("[<0;45;12M")).toEqual({
+      kind: "press",
+      button: "left",
+      col: 45,
+      row: 12,
+    });
+  });
+
+  test("decodes a middle press", () => {
+    expect(parseSgrMouse("[<1;3;4M")).toEqual({
+      kind: "press",
+      button: "middle",
+      col: 3,
+      row: 4,
+    });
+  });
+
+  test("decodes a right press", () => {
+    expect(parseSgrMouse("[<2;3;4M")).toEqual({
+      kind: "press",
+      button: "right",
+      col: 3,
+      row: 4,
+    });
+  });
+
+  test("ignores a release (trailing m)", () => {
+    expect(parseSgrMouse("[<0;45;12m")).toBeNull();
+  });
+
+  test("ignores motion/drag (cb & 32)", () => {
+    // 32 = motion bit; 35 = motion + left button held (drag)
+    expect(parseSgrMouse("[<35;45;12M")).toBeNull();
+    expect(parseSgrMouse("[<32;45;12M")).toBeNull();
+  });
+
+  test("ignores additional buttons 8+ (back/forward) instead of misdecoding as left", () => {
+    // cb=128 (button 8, back): would otherwise hit `(128 & 3) === 0` → "left".
+    expect(parseSgrMouse("[<128;10;5M")).toBeNull();
+    // cb=129 (button 9, forward).
+    expect(parseSgrMouse("[<129;10;5M")).toBeNull();
+  });
+
+  test("returns null for non-mouse / malformed input", () => {
+    expect(parseSgrMouse("q")).toBeNull();
+    expect(parseSgrMouse("[A")).toBeNull();
+    expect(parseSgrMouse("[<0;45M")).toBeNull();
+    expect(parseSgrMouse("[<0;45;12X")).toBeNull();
+    expect(parseSgrMouse("")).toBeNull();
+    // Must be anchored: trailing junk after the final byte does not match.
+    expect(parseSgrMouse("[<0;45;12Mxx")).toBeNull();
+  });
+
+  test("modifier bits (shift/meta/ctrl) on a left press still decode as left", () => {
+    // cb = 0 (left) | 4 (shift) | 8 (meta) | 16 (ctrl) = 28
+    expect(parseSgrMouse("[<28;5;6M")).toEqual({
+      kind: "press",
+      button: "left",
+      col: 5,
+      row: 6,
+    });
+  });
+});
+
+function repo(overrides: Partial<RepoInfo> & { id: string }): RepoInfo {
+  return {
+    id: overrides.id,
+    repoPath: overrides.repoPath ?? `/tmp/${overrides.id}`,
+    project: overrides.project ?? overrides.id,
+    worktrees: overrides.worktrees ?? [],
+    profileNames: overrides.profileNames ?? [],
+    ideDefaults: overrides.ideDefaults ?? { baseNoIde: true, profileNoIde: {} },
+  };
+}
+
+const repos: RepoInfo[] = [
+  repo({
+    id: "repo-1",
+    project: "alpha",
+    worktrees: [
+      {
+        branch: "feature/a",
+        path: "/tmp/a",
+        isMainWorktree: false,
+        changedFiles: 0,
+        sync: { ahead: 0, behind: 0 },
+      },
+      {
+        branch: "feature/b",
+        path: "/tmp/b",
+        isMainWorktree: false,
+        changedFiles: 0,
+        sync: { ahead: 0, behind: 0 },
+      },
+    ],
+  }),
+  repo({
+    id: "repo-2",
+    project: "beta",
+    worktrees: [
+      {
+        branch: "feature/c",
+        path: "/tmp/c",
+        isMainWorktree: false,
+        changedFiles: 0,
+        sync: { ahead: 0, behind: 0 },
+      },
+    ],
+  }),
+];
+
+function buildCtx(
+  mode: Mode,
+  expandedWorktreeKey: string | null,
+  overrides?: Partial<MouseActionContext>,
+): MouseActionContext {
+  const expandedRepos = new Set(["repo-1", "repo-2"]);
+  const treeItems = buildTreeItems({
+    repos,
+    expandedRepos,
+    expandedWorktreeKey,
+    prData: new Map(),
+    panes: new Map(),
+    jumpToPane: () => undefined,
+  });
+  const rows = buildTreeRows({
+    items: treeItems,
+    repos,
+    expandedRepos,
+    expandedWorktreeKey,
+    pendingActions: new Map(),
+  });
+  return {
+    mode,
+    rows,
+    effectiveScrollOffset: 0,
+    viewportRows: rows.length,
+    treeItems,
+    repos,
+    expandedWorktreeKey,
+    ...overrides,
+  };
+}
+
+describe("resolveMouseAction", () => {
+  test("wheel scrolls only; selection untouched", () => {
+    const ctx = buildCtx(Mode.Navigate, null);
+    expect(resolveMouseAction({ kind: "wheel", dir: -1 }, ctx)).toEqual({
+      kind: "scroll",
+      delta: -1,
+    });
+    expect(resolveMouseAction({ kind: "wheel", dir: 1 }, ctx)).toEqual({
+      kind: "scroll",
+      delta: 1,
+    });
+  });
+
+  test("left-click in Navigate selects the hit row", () => {
+    const ctx = buildCtx(Mode.Navigate, null);
+    // rows: [repo-1(0), wt-a(1), wt-b(2), repo-2(3), wt-c(4)]
+    // SGR row = viewportRow + 1 + HEADER_OFFSET. viewportRow 1 → wt-a (item 1).
+    const sgrRow = 1 + 1 + HEADER_OFFSET;
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 3, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "select", itemIndex: 1 });
+  });
+
+  test("non-left buttons resolve to none", () => {
+    const ctx = buildCtx(Mode.Navigate, null);
+    const sgrRow = 1 + 1 + HEADER_OFFSET;
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "right", col: 3, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "middle", col: 3, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+  });
+
+  test("clicks on header rows resolve to none", () => {
+    const ctx = buildCtx(Mode.Navigate, null);
+    // SGR rows 1 and 2 are the header + spacer (viewportRow < 0).
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 1, row: 1 },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 1, row: 2 },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+  });
+
+  test("clicks below the viewport (StatusBar region) resolve to none", () => {
+    const ctx = buildCtx(Mode.Navigate, null, { viewportRows: 3 });
+    // viewportRow 3 is >= viewportRows (3) → out of range.
+    const sgrRow = 3 + 1 + HEADER_OFFSET;
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 1, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "none" });
+  });
+
+  test("Expanded: within-subtree click selects and stays", () => {
+    const key = pendingKey("alpha", "feature/a");
+    const ctx = buildCtx(Mode.Expanded(key), key);
+    // items: repo-1(0), wt-a(1), [pr detail if any], wt-b, repo-2, wt-c.
+    // Clicking wt-a (the expanded worktree itself, item 1, row index 1).
+    const sgrRow = 1 + 1 + HEADER_OFFSET;
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 3, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "select", itemIndex: 1 });
+  });
+
+  test("Expanded: outside-subtree click exits to Navigate and selects", () => {
+    const key = pendingKey("alpha", "feature/a");
+    const ctx = buildCtx(Mode.Expanded(key), key);
+    // Click the sibling worktree feature/b. Find its row index in rows.
+    const rowIndex = ctx.rows.findIndex((r: TreeRow) => {
+      if (r.itemIndex == null) return false;
+      const item = ctx.treeItems[r.itemIndex];
+      return item?.type === "worktree" && item.worktreeIndex === 1;
+    });
+    const itemIndex = ctx.rows[rowIndex]?.itemIndex as number;
+    const sgrRow = rowIndex + 1 + HEADER_OFFSET;
+    expect(
+      resolveMouseAction(
+        { kind: "press", button: "left", col: 3, row: sgrRow },
+        ctx,
+      ),
+    ).toEqual({ kind: "selectAndExitExpanded", itemIndex });
+  });
+
+  test("non-interactive modes (Search/modals/confirm) resolve to none", () => {
+    for (const mode of [
+      Mode.Search,
+      Mode.OpenModal,
+      Mode.AddProjectModal,
+    ] as Mode[]) {
+      const ctx = buildCtx(mode, null);
+      expect(resolveMouseAction({ kind: "wheel", dir: -1 }, ctx)).toEqual({
+        kind: "none",
+      });
+      const sgrRow = 1 + 1 + HEADER_OFFSET;
+      expect(
+        resolveMouseAction(
+          { kind: "press", button: "left", col: 3, row: sgrRow },
+          ctx,
+        ),
+      ).toEqual({ kind: "none" });
+    }
+  });
+
+  test("hit-test round-trip: every visible row maps back to the item it renders", () => {
+    const ctx = buildCtx(Mode.Navigate, null, {
+      effectiveScrollOffset: 1,
+      viewportRows: 3,
+    });
+    // Visible rows are rows[1], rows[2], rows[3] at viewportRow 0,1,2.
+    for (let viewportRow = 0; viewportRow < ctx.viewportRows; viewportRow++) {
+      const sgrRow = viewportRow + 1 + HEADER_OFFSET;
+      const expectedRow = ctx.rows[ctx.effectiveScrollOffset + viewportRow];
+      const action = resolveMouseAction(
+        { kind: "press", button: "left", col: 1, row: sgrRow },
+        ctx,
+      );
+      if (expectedRow?.itemIndex == null) {
+        expect(action).toEqual({ kind: "none" });
+      } else {
+        expect(action).toEqual({
+          kind: "select",
+          itemIndex: expectedRow.itemIndex,
+        });
+      }
+    }
+  });
+});

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -3,6 +3,7 @@ import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
 import {
   HEADER_OFFSET,
   isMouseSequence,
+  isX10MousePrefix,
   type MouseActionContext,
   parseSgrMouse,
   resolveMouseAction,
@@ -14,6 +15,23 @@ import {
   type TreeRow,
 } from "../../src/tui/tree-helpers";
 import { Mode, type PaneInfo, pendingKey } from "../../src/tui/types";
+
+describe("isX10MousePrefix", () => {
+  test("matches the legacy X10 report prefix, with or without leading ESC", () => {
+    // Ink terminates the CSI at the `M` final byte and strips each event's
+    // leading ESC, so the prefix arrives as "[M" (or "\x1b[M" defensively).
+    expect(isX10MousePrefix("[M")).toBe(true);
+    expect(isX10MousePrefix("\x1b[M")).toBe(true);
+  });
+
+  test("rejects SGR sequences and ordinary input", () => {
+    expect(isX10MousePrefix("[<0;5;5M")).toBe(false);
+    expect(isX10MousePrefix("M")).toBe(false);
+    expect(isX10MousePrefix("[Mx")).toBe(false);
+    expect(isX10MousePrefix("q")).toBe(false);
+    expect(isX10MousePrefix("")).toBe(false);
+  });
+});
 
 describe("parseSgrMouse", () => {
   test("decodes wheel up (cb=64) as wheel, NOT a click (the %4 bug is absent)", () => {
@@ -60,6 +78,24 @@ describe("parseSgrMouse", () => {
 
   test("ignores a release (trailing m)", () => {
     expect(parseSgrMouse("[<0;45;12m")).toBeNull();
+  });
+
+  test("ignores horizontal wheel (cb=66 wheel-left, cb=67 wheel-right)", () => {
+    // Tilt wheels / horizontal trackpad swipes must not decode by bit 0 as
+    // vertical scrolling (66 → up, 67 → down) — they are not vertical events.
+    expect(parseSgrMouse("[<66;10;5M")).toBeNull();
+    expect(parseSgrMouse("[<67;10;5M")).toBeNull();
+  });
+
+  test("ignores horizontal wheel with modifier bits set", () => {
+    // shift=4, ctrl=16 on top of 66/67 keep the low 2 bits horizontal.
+    expect(parseSgrMouse("[<70;10;5M")).toBeNull(); // 66 + shift
+    expect(parseSgrMouse("[<83;10;5M")).toBeNull(); // 67 + ctrl
+  });
+
+  test("still decodes vertical wheel with modifier bits set", () => {
+    expect(parseSgrMouse("[<68;10;5M")).toEqual({ kind: "wheel", dir: -1 }); // 64 + shift
+    expect(parseSgrMouse("[<81;10;5M")).toEqual({ kind: "wheel", dir: 1 }); // 65 + ctrl
   });
 
   test("ignores motion/drag (cb & 32)", () => {

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
 import {
   HEADER_OFFSET,
+  isMouseSequence,
   type MouseActionContext,
   parseSgrMouse,
   resolveMouseAction,
@@ -91,6 +92,105 @@ describe("parseSgrMouse", () => {
       col: 5,
       row: 6,
     });
+  });
+});
+
+describe("isMouseSequence", () => {
+  // Bug 3 regression: a single click emits BOTH a press (`M`) and a release
+  // (`m`) SGR sequence. `parseSgrMouse` intentionally returns `null` for the
+  // release half (and for motion/extra-button events) because they aren't
+  // actionable — but the dispatcher guard must still swallow them by SHAPE,
+  // not by whether they parsed to an action, or the raw escape bytes fall
+  // through to mode-specific handlers (e.g. corrupting the Search query).
+  test("matches a release sequence (trailing m)", () => {
+    expect(isMouseSequence("\x1b[<0;45;12m")).toBe(true);
+    expect(isMouseSequence("[<0;45;12m")).toBe(true);
+  });
+
+  test("matches a motion sequence (cb & 32)", () => {
+    expect(isMouseSequence("\x1b[<35;10;5M")).toBe(true);
+  });
+
+  test("matches an extra-button sequence (cb & 0x80)", () => {
+    expect(isMouseSequence("\x1b[<128;10;5M")).toBe(true);
+  });
+
+  test("matches an ordinary actionable press too", () => {
+    expect(isMouseSequence("\x1b[<0;45;12M")).toBe(true);
+  });
+
+  test("does not match a normal keypress", () => {
+    expect(isMouseSequence("\x1b[A")).toBe(false);
+  });
+
+  test("does not match plain text or empty input", () => {
+    expect(isMouseSequence("q")).toBe(false);
+    expect(isMouseSequence("")).toBe(false);
+  });
+
+  test("agrees with parseSgrMouse on every case where parseSgrMouse is non-null", () => {
+    // Whenever parseSgrMouse resolves an actionable event, isMouseSequence
+    // must also be true — parseSgrMouse being non-null is a strict subset of
+    // "is a mouse sequence."
+    const actionable = ["[<64;10;5M", "[<0;45;12M", "[<1;3;4M", "[<2;3;4M"];
+    for (const seq of actionable) {
+      expect(parseSgrMouse(seq)).not.toBeNull();
+      expect(isMouseSequence(seq)).toBe(true);
+    }
+  });
+});
+
+describe("dispatcher guard: release/motion events never reach Search text input", () => {
+  // Mirrors the exact guard shape in App.tsx's useInput dispatcher:
+  //   if (isMouseSequence(input)) {
+  //     const mouse = parseSgrMouse(input);
+  //     if (mouse) handleMouse(mouse);
+  //     return;
+  //   }
+  //   ... falls through to handleSearchInput(input, key) in Search mode ...
+  // Bug 3 was that the OLD guard checked `parseSgrMouse(input)` truthiness
+  // instead of sequence shape, so release/motion/extra-button sequences (which
+  // parseSgrMouse deliberately resolves to null) fell through and got appended
+  // to the search query as raw escape bytes.
+  function dispatch(input: string, appendToQuery: (text: string) => void) {
+    if (isMouseSequence(input)) {
+      const mouse = parseSgrMouse(input);
+      if (mouse) {
+        // handleMouse(mouse) — not relevant to this test, Search ignores mouse
+      }
+      return;
+    }
+    // handleSearchInput's catch-all text-input branch (App.tsx ~line 445):
+    // `else if (input && !key.ctrl && !key.meta) setSearchQuery((q) => q + input)`
+    appendToQuery(input);
+  }
+
+  test("a click's release half does not get appended to the search query", () => {
+    let query = "";
+    const append = (text: string) => {
+      query += text;
+    };
+
+    dispatch("a", append); // normal typed character
+    dispatch("\x1b[<0;45;12M", append); // press half of a click (actionable, swallowed)
+    dispatch("\x1b[<0;45;12m", append); // release half (non-actionable, must still be swallowed)
+    dispatch("b", append);
+
+    expect(query).toBe("ab");
+  });
+
+  test("motion and extra-button sequences also do not get appended", () => {
+    let query = "";
+    const append = (text: string) => {
+      query += text;
+    };
+
+    dispatch("x", append);
+    dispatch("\x1b[<35;10;5M", append); // motion
+    dispatch("\x1b[<128;10;5M", append); // extra button
+    dispatch("y", append);
+
+    expect(query).toBe("xy");
   });
 });
 

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -516,6 +516,74 @@ describe("resolveMouseAction", () => {
     ).toEqual({ kind: "select", itemIndex: paneItemIndex });
   });
 
+  test("Expanded: a click on a wrapped PR's continuation row selects the PR", () => {
+    const branch = "feature/a";
+    const key = pendingKey("alpha", branch);
+    const prData = new Map([
+      [
+        key,
+        {
+          number: 1,
+          title: "a very long pull request title that certainly wraps",
+          state: "OPEN" as const,
+          headRefName: branch,
+          rollupState: "success" as const,
+        },
+      ],
+    ]);
+    const expandedRepos = new Set(["repo-1", "repo-2"]);
+    const treeItems = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: key,
+      prData,
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const rows = buildTreeRows({
+      items: treeItems,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: key,
+      pendingActions: new Map(),
+      maxWidth: 40, // forces the PR title to wrap
+    });
+    const ctx: MouseActionContext = {
+      mode: Mode.Expanded(key),
+      rows,
+      effectiveScrollOffset: 0,
+      viewportRows: rows.length,
+      treeItems,
+      repos,
+      expandedWorktreeKey: key,
+    };
+
+    // The continuation row carries the PR's own itemIndex, so clicking the
+    // wrapped line resolves to selecting the PR (within the expanded subtree).
+    const contRowIndex = rows.findIndex(
+      (r: TreeRow) => r.kind === "detail-pr-cont",
+    );
+    expect(contRowIndex).toBeGreaterThan(-1);
+    const prItemIndex = rows[contRowIndex]?.itemIndex as number;
+    // The primary PR row precedes it and maps to the same item.
+    expect(rows[contRowIndex - 1]).toMatchObject({
+      kind: "detail",
+      itemIndex: prItemIndex,
+    });
+
+    expect(
+      resolveMouseAction(
+        {
+          kind: "press",
+          button: "left",
+          col: 12,
+          row: contRowIndex + 1 + HEADER_OFFSET,
+        },
+        ctx,
+      ),
+    ).toEqual({ kind: "select", itemIndex: prItemIndex });
+  });
+
   test("non-interactive modes (Search/modals/confirm) resolve to none", () => {
     for (const mode of [
       Mode.Search,

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -6,6 +6,7 @@ import {
   type MouseActionContext,
   parseSgrMouse,
   resolveMouseAction,
+  splitMouseSequences,
 } from "../../src/tui/input/mouse";
 import {
   buildTreeItems,
@@ -128,6 +129,34 @@ describe("isMouseSequence", () => {
     expect(isMouseSequence("")).toBe(false);
   });
 
+  // Multi-sequence strings — defense-in-depth, NOT the normal stdin path.
+  // Ink 7.1's input parser (ink/build/input-parser.js) splits every complete
+  // CSI sequence in a stdin chunk into its OWN useInput event and strips the
+  // leading ESC per event, so a concatenated string can only reach useInput
+  // via Ink's bracketed-paste fallback (emitInput(event.paste) when no paste
+  // listener is registered) carrying mouse-shaped pasted text — or a future
+  // change in Ink's delivery model. The guard accepts one-or-more sequences
+  // so that path can never leak escape bytes into text inputs either.
+  test("matches a concatenated press+release+release string (paste-fallback shape)", () => {
+    expect(isMouseSequence("[<0;12;38M\x1b[<0;12;38m\x1b[<0;1;1m")).toBe(true);
+  });
+
+  test("matches a concatenated string whether or not each sequence keeps its ESC", () => {
+    expect(isMouseSequence("\x1b[<65;1;1M\x1b[<65;1;1M")).toBe(true);
+    expect(isMouseSequence("[<65;1;1M[<65;1;1M")).toBe(true);
+  });
+
+  test("does NOT match a mixed string — a keystroke merged with a sequence is keyboard input", () => {
+    // Semantics (documented on isMouseSequence): input is swallowed as mouse
+    // only when it is ENTIRELY mouse sequences. Swallowing a mixed string
+    // would eat the 'a' keystroke. (Accepted trade-off, also documented
+    // there: a paste that is EXACTLY mouse-shaped tokens IS swallowed.)
+    expect(isMouseSequence("a\x1b[<0;5;5M")).toBe(false);
+    expect(isMouseSequence("a[<0;5;5M")).toBe(false);
+    expect(isMouseSequence("\x1b[<0;5;5Mx")).toBe(false);
+    expect(isMouseSequence("[<0;5;5M[<0;5;5")).toBe(false); // truncated tail
+  });
+
   test("agrees with parseSgrMouse on every case where parseSgrMouse is non-null", () => {
     // Whenever parseSgrMouse resolves an actionable event, isMouseSequence
     // must also be true — parseSgrMouse being non-null is a strict subset of
@@ -137,6 +166,49 @@ describe("isMouseSequence", () => {
       expect(parseSgrMouse(seq)).not.toBeNull();
       expect(isMouseSequence(seq)).toBe(true);
     }
+  });
+});
+
+describe("splitMouseSequences", () => {
+  // Pins the ordering/multi-event contract for multi-sequence strings (the
+  // paste-fallback shape — see the delivery-model note above). This pure
+  // suite is the real coverage for the splitter; the app-mouse-wiring tests
+  // exercise guard integration end-to-end but Ink splits their stdin writes
+  // into per-sequence events before the splitter is ever needed.
+  test("splits a concatenated string into single sequences, in order", () => {
+    expect(splitMouseSequences("[<0;12;38M\x1b[<0;12;38m\x1b[<0;1;1m")).toEqual(
+      ["[<0;12;38M", "\x1b[<0;12;38m", "\x1b[<0;1;1m"],
+    );
+  });
+
+  test("a single sequence yields itself", () => {
+    expect(splitMouseSequences("\x1b[<65;1;1M")).toEqual(["\x1b[<65;1;1M"]);
+  });
+
+  test("each split sequence is consumable by parseSgrMouse — two wheel-downs yield two scroll events in order", () => {
+    const events = splitMouseSequences("\x1b[<65;1;1M\x1b[<65;1;1M").map(
+      parseSgrMouse,
+    );
+    expect(events).toEqual([
+      { kind: "wheel", dir: 1 },
+      { kind: "wheel", dir: 1 },
+    ]);
+  });
+
+  test("press+release split: press parses, release parses to null (non-actionable but swallowed)", () => {
+    const events = splitMouseSequences("\x1b[<0;12;38M\x1b[<0;12;38m").map(
+      parseSgrMouse,
+    );
+    expect(events).toEqual([
+      { kind: "press", button: "left", col: 12, row: 38 },
+      null,
+    ]);
+  });
+
+  test("returns [] for mixed or non-mouse input (never swallows keystrokes)", () => {
+    expect(splitMouseSequences("a\x1b[<0;5;5M")).toEqual([]);
+    expect(splitMouseSequences("q")).toEqual([]);
+    expect(splitMouseSequences("")).toEqual([]);
   });
 });
 

--- a/tests/tui/modal-mouse-guard.test.tsx
+++ b/tests/tui/modal-mouse-guard.test.tsx
@@ -1,0 +1,145 @@
+// Regression tests for the manual-testing bug where clicking the terminal
+// while a modal text input was focused pasted raw SGR mouse escape text
+// (`[<0;12;38M[<0;12;38m[<0;1;1m`) into the field.
+//
+// Delivery model (verified against ink/build/input-parser.js): Ink 7.1 splits
+// every complete CSI sequence in a stdin chunk into its OWN useInput event
+// and strips the leading ESC per event. The screenshot garble was therefore
+// THREE per-sequence events (press, release, release) each appended in order
+// by the unguarded modal handlers — the per-hook guard in useGuardedInput is
+// the real fix, and it must live in the shared wrapper because Ink dispatches
+// every event to ALL active useInput hooks, not only App.tsx's dispatcher.
+// (The guard's multi-sequence regex additionally covers Ink's bracketed-paste
+// fallback, the one path that can deliver a concatenated string.)
+//
+// These tests render the real modal components through the PassThrough-stdout
+// harness and write the bug's sequences to stdin — as one chunk (which Ink
+// splits into per-sequence events before dispatch) and individually.
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const runPromiseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/tui/runtime", () => ({
+  tuiRuntime: {
+    runPromise: runPromiseMock,
+  },
+  runTuiSilentPromise: (effect: unknown) => runPromiseMock(effect),
+}));
+
+vi.mock("../../src/tui/hooks/useBlink", () => ({
+  useBlink: () => false,
+}));
+
+const { NewBranchForm } = await import("../../src/tui/components/OpenModal");
+const { AddProjectModal } = await import(
+  "../../src/tui/components/AddProjectModal"
+);
+const { CTRL_ENTER, renderWithInput, sendKeys } = await import(
+  "./keypress-harness"
+);
+
+const defaultIdeDefaults = { baseNoIde: true, profileNoIde: {} };
+
+// The bug's press + release + release written as one stdin chunk. Ink's
+// parser splits this into three per-sequence useInput events (one leading
+// ESC stripped per event), so each event must be swallowed by the guard.
+const BATCHED_CLICK = "[<0;12;38M\x1b[<0;12;38m\x1b[<0;1;1m";
+const SINGLE_PRESS = "\x1b[<0;12;38M";
+const SINGLE_RELEASE = "\x1b[<0;12;38m";
+
+function renderNewBranchForm(onSubmit: (result: unknown) => void) {
+  return renderWithInput(
+    <NewBranchForm
+      defaultBase="main"
+      profileNames={["default"]}
+      ideDefaults={defaultIdeDefaults}
+      onSubmit={onSubmit}
+      onBack={() => {}}
+      width={80}
+    />,
+  );
+}
+
+describe("modal text inputs never consume mouse sequences as text", () => {
+  const originalConsoleError = console.error;
+  const suppressedPattern =
+    /Encountered two children with the same key|Raw mode is not supported/;
+
+  beforeEach(() => {
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === "string" && suppressedPattern.test(args[0]))
+        return;
+      originalConsoleError(...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+    vi.clearAllMocks();
+    runPromiseMock.mockReset();
+  });
+
+  test("OpenModal Branch input: a batched click chunk inserts nothing (screenshot bug)", async () => {
+    const onSubmitMock = vi.fn();
+    const rendered = await renderNewBranchForm(onSubmitMock);
+
+    try {
+      await sendKeys(rendered.stdin, "feature-x");
+      await sendKeys(rendered.stdin, BATCHED_CLICK);
+      await sendKeys(rendered.stdin, SINGLE_PRESS);
+      await sendKeys(rendered.stdin, SINGLE_RELEASE);
+      await sendKeys(rendered.stdin, CTRL_ENTER);
+
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      expect(onSubmitMock).toHaveBeenCalledWith(
+        expect.objectContaining({ branch: "feature-x" }),
+      );
+      // The rendered frame must never show the escape garble either.
+      expect(rendered.output()).not.toContain("[<0;");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("OpenModal Branch input: a click on an empty field leaves it empty (submit stays blocked)", async () => {
+    const onSubmitMock = vi.fn();
+    const rendered = await renderNewBranchForm(onSubmitMock);
+
+    try {
+      await sendKeys(rendered.stdin, BATCHED_CLICK);
+      // doSubmit is a no-op while branch is empty — if the chunk had been
+      // pasted into the field, this Ctrl+Enter would submit the garble.
+      await sendKeys(rendered.stdin, CTRL_ENTER);
+
+      expect(onSubmitMock).not.toHaveBeenCalled();
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("AddProjectModal PathInput: a batched click chunk does not corrupt the path", async () => {
+    runPromiseMock.mockResolvedValue(true); // git-repo check passes; completions fail harmlessly
+    const onSubmitMock = vi.fn();
+    const rendered = await renderWithInput(
+      <AddProjectModal
+        visible
+        width={60}
+        onSubmit={onSubmitMock}
+        onCancel={() => {}}
+      />,
+    );
+
+    try {
+      await new Promise((r) => setTimeout(r, 150)); // past the git-check debounce
+      await sendKeys(rendered.stdin, BATCHED_CLICK);
+      await sendKeys(rendered.stdin, CTRL_ENTER);
+
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      const result = onSubmitMock.mock.calls[0]?.[0] as { path: string };
+      expect(result.path).toBe(process.env.HOME ?? "/tmp");
+      expect(result.path).not.toContain("[<");
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/tests/tui/pr-layout.test.ts
+++ b/tests/tui/pr-layout.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, test } from "vitest";
 import { prLabelStart, wrapPrLabel } from "../../src/tui/pr-layout";
+import { displayWidth } from "../../src/tui/utils/display-width";
+
+describe("displayWidth", () => {
+  test("counts ASCII one column per character", () => {
+    expect(displayWidth("PR #1: short (OPEN)")).toBe(19);
+  });
+
+  test("counts CJK glyphs two columns each", () => {
+    expect(displayWidth("日本語")).toBe(6);
+  });
+
+  test("counts emoji two columns, including ZWJ sequences as one glyph", () => {
+    expect(displayWidth("🎉")).toBe(2);
+    expect(displayWidth("⚡")).toBe(2); // default emoji presentation, BMP
+    expect(displayWidth("👨‍👩‍👧‍👦")).toBe(2); // family: 4 code points joined by ZWJ
+  });
+
+  test("overcounts a combining-mark cluster rather than undercount", () => {
+    // "e" + U+0301 renders 1 column; the deliberate safety bias counts every
+    // multi-code-point grapheme as 2 so wrapping can never emit a line Ink
+    // measures as wider than budgeted.
+    expect(displayWidth("e\u0301")).toBe(2);
+    // The precomposed single code point stays 1 column.
+    expect(displayWidth("\u00e9")).toBe(1);
+  });
+});
 
 describe("prLabelStart", () => {
   test("reserves indent(6) + selector(2) with no icon", () => {
@@ -47,5 +73,30 @@ describe("wrapPrLabel", () => {
 
   test("never returns zero lines for an empty label", () => {
     expect(wrapPrLabel("", 80, false)).toEqual([""]);
+  });
+
+  test("wraps by display width, not code points, for a CJK title", () => {
+    // budget = 20 - 8 = 12 columns; each glyph is 2 columns, so only six fit
+    // per line even though twelve code points would.
+    const lines = wrapPrLabel("日本語のタイトル", 20, false);
+    expect(lines).toEqual(["日本語のタイ", "トル"]);
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(12);
+    }
+  });
+
+  test("wraps emoji words by their two-column width", () => {
+    // budget = 18 - 8 = 10 columns; the five-emoji word is exactly 10 columns
+    // and cannot share a line with "fix" (3 + 1 + 10 > 10).
+    const lines = wrapPrLabel("fix 🎉🎉🎉🎉🎉", 18, false);
+    expect(lines).toEqual(["fix", "🎉🎉🎉🎉🎉"]);
+  });
+
+  test("never splits an emoji ZWJ sequence when hard-breaking", () => {
+    const family = "👨‍👩‍👧‍👦"; // one grapheme (4 code points + ZWJs), 2 columns
+    // budget = 12 - 8 = 4 columns; the unbroken 8-column "word" must split
+    // into whole-family pieces, two per line.
+    const lines = wrapPrLabel(family.repeat(4), 12, false);
+    expect(lines).toEqual([family.repeat(2), family.repeat(2)]);
   });
 });

--- a/tests/tui/pr-layout.test.ts
+++ b/tests/tui/pr-layout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { prLabelStart, wrapPrLabel } from "../../src/tui/pr-layout";
+
+describe("prLabelStart", () => {
+  test("reserves indent(6) + selector(2) with no icon", () => {
+    expect(prLabelStart(false)).toBe(8);
+  });
+
+  test("reserves an extra 2 columns for the rollup icon", () => {
+    expect(prLabelStart(true)).toBe(10);
+  });
+});
+
+describe("wrapPrLabel", () => {
+  test("keeps a short label on a single line", () => {
+    expect(wrapPrLabel("PR #1: short (OPEN)", 80, true)).toEqual([
+      "PR #1: short (OPEN)",
+    ]);
+  });
+
+  test("wraps a long label onto multiple lines at word boundaries", () => {
+    const lines = wrapPrLabel(
+      "PR #1: a very long pull request title that certainly wraps (OPEN)",
+      40,
+      true,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    // Each line must fit the label budget (maxWidth - prLabelStart = 30).
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(30);
+    }
+    // No content is lost: joining the lines reproduces the label.
+    expect(lines.join(" ")).toBe(
+      "PR #1: a very long pull request title that certainly wraps (OPEN)",
+    );
+  });
+
+  test("hard-breaks a single word longer than the budget", () => {
+    const lines = wrapPrLabel("x".repeat(50), 20, false);
+    // budget = 20 - 8 = 12
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(12);
+    }
+    expect(lines.join("")).toBe("x".repeat(50));
+  });
+
+  test("never returns zero lines for an empty label", () => {
+    expect(wrapPrLabel("", 80, false)).toEqual([""]);
+  });
+});

--- a/tests/tui/repo-node.test.tsx
+++ b/tests/tui/repo-node.test.tsx
@@ -50,7 +50,6 @@ describe("RepoNode", () => {
       expanded: false,
       isSelected: false,
       isChildSelected: false,
-      worktreeCount: 1,
       maxWidth: 40,
     });
     expect(output).toContain("my-project");
@@ -64,7 +63,6 @@ describe("RepoNode", () => {
       expanded: false,
       isSelected: false,
       isChildSelected: false,
-      worktreeCount: 1,
       maxWidth: 10,
     });
     expect(output).toContain("my-pr…");
@@ -79,7 +77,6 @@ describe("RepoNode", () => {
       expanded: false,
       isSelected: false,
       isChildSelected: false,
-      worktreeCount: 1,
       maxWidth: 14,
     });
     expect(output).toContain("my-project");

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -10,9 +10,9 @@ type TestStdin = NodeJS.ReadStream & {
   setRawMode: (mode: boolean) => NodeJS.ReadStream;
 };
 
-function createStdoutStdin() {
+function createStdoutStdin(columns = 80) {
   const stdout = new PassThrough() as unknown as TestStdout;
-  stdout.columns = 80;
+  stdout.columns = columns;
   stdout.rows = 24;
   const stdin = new PassThrough() as unknown as TestStdin;
   stdin.isTTY = false;
@@ -20,8 +20,11 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
-  const { stdout, stdin } = createStdoutStdin();
+async function renderStatusBar(
+  props: React.ComponentProps<typeof StatusBar>,
+  columns = 80,
+) {
+  const { stdout, stdin } = createStdoutStdin(columns);
   const chunks: string[] = [];
   stdout.on("data", (chunk) => {
     chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
@@ -39,6 +42,7 @@ async function renderStatusBar(props: React.ComponentProps<typeof StatusBar>) {
 
   return {
     output: chunks.join(""),
+    lastFrame: () => chunks[chunks.length - 1] ?? "",
     unmount() {
       instance.unmount();
     },
@@ -151,5 +155,44 @@ describe("StatusBar", () => {
     expect(rendered.output).not.toContain("x:kill");
 
     rendered.unmount();
+  });
+
+  // App.tsx budgets bottomChromeRows assuming every StatusBar line occupies
+  // exactly one terminal row — a hint or error line wrapping in a narrow
+  // terminal would silently overflow the viewport and misalign mouse
+  // hit-testing, so these pin the truncate behaviour at widths where the
+  // hint text is longer than the terminal.
+  describe("narrow terminals (one row per chrome line)", () => {
+    test("Navigate hints truncate instead of wrapping", async () => {
+      // With a client, line1 is ~60 chars — well past 40 columns.
+      const rendered = await renderStatusBar(
+        { mode: Mode.Navigate, hasClient: true },
+        40,
+      );
+
+      // divider + 2 hint lines, regardless of hint text length.
+      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(3);
+      expect(rendered.output).toContain("↑↓:navigate");
+
+      rendered.unmount();
+    });
+
+    test("a long repoError line truncates instead of wrapping", async () => {
+      const rendered = await renderStatusBar(
+        {
+          mode: Mode.Navigate,
+          hasClient: false,
+          repoError:
+            "gh: HTTP 502 from api.github.com while fetching pull requests for a-very-long-project-name",
+        },
+        40,
+      );
+
+      // divider + repoError + 2 hint lines.
+      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(4);
+      expect(rendered.output).toContain("⚠ gh: HTTP 502");
+
+      rendered.unmount();
+    });
   });
 });

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -1,7 +1,10 @@
 import { PassThrough } from "node:stream";
 import React from "react";
 import { describe, expect, test } from "vitest";
-import { StatusBar } from "../../src/tui/components/StatusBar";
+import {
+  StatusBar,
+  statusBarRowCount,
+} from "../../src/tui/components/StatusBar";
 import { Mode } from "../../src/tui/types";
 
 type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
@@ -194,5 +197,71 @@ describe("StatusBar", () => {
 
       rendered.unmount();
     });
+
+    test("a multi-line repoError renders on a single row", async () => {
+      const rendered = await renderStatusBar(
+        {
+          mode: Mode.Navigate,
+          hasClient: false,
+          // wrap="truncate" does not remove embedded newlines, so without
+          // toSingleLine this would render 2+ rows and break the viewport
+          // budget that counts every chrome line as exactly one row.
+          repoError: "gh: HTTP 502\nadvice: try again later",
+        },
+        80,
+      );
+
+      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(4);
+      expect(rendered.output).toContain(
+        "⚠ gh: HTTP 502 advice: try again later",
+      );
+
+      rendered.unmount();
+    });
+  });
+
+  describe("statusBarRowCount stays true to the render", () => {
+    // The anti-drift contract: App.tsx budgets the tree viewport with
+    // statusBarRowCount, so for every renderable mode the helper must equal
+    // the row count StatusBar actually produces.
+    const cases: Array<{
+      name: string;
+      mode: Mode;
+      repoError?: string;
+    }> = [
+      { name: "Navigate", mode: Mode.Navigate },
+      { name: "Navigate + repoError", mode: Mode.Navigate, repoError: "boom" },
+      { name: "Expanded", mode: Mode.Expanded("proj/branch") },
+      {
+        name: "Expanded + repoError",
+        mode: Mode.Expanded("proj/branch"),
+        repoError: "boom",
+      },
+      { name: "Search", mode: Mode.Search },
+      // Search's early return ignores repoError; the count must match that.
+      { name: "Search + repoError", mode: Mode.Search, repoError: "boom" },
+      {
+        name: "ConfirmKill",
+        mode: Mode.ConfirmKill("%1", "1:0 vim", "proj/branch"),
+        repoError: "boom",
+      },
+    ];
+
+    for (const { name, mode, repoError } of cases) {
+      test(name, async () => {
+        const rendered = await renderStatusBar({
+          mode,
+          hasClient: true,
+          searchQuery: "",
+          repoError,
+        });
+
+        expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(
+          statusBarRowCount(mode, Boolean(repoError)),
+        );
+
+        rendered.unmount();
+      });
+    }
   });
 });

--- a/tests/tui/tree-view-wiring.test.tsx
+++ b/tests/tui/tree-view-wiring.test.tsx
@@ -2,6 +2,7 @@ import { PassThrough } from "node:stream";
 import React from "react";
 import { describe, expect, test } from "vitest";
 import { TreeView } from "../../src/tui/components/TreeView";
+import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
 import { buildTreeItems } from "../../src/tui/tree-helpers";
 
 type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
@@ -74,5 +75,80 @@ describe("TreeView maxWidth wiring", () => {
     expect(output).not.toContain("very-long-project-name");
 
     instance.unmount();
+  });
+});
+
+describe("TreeView windowing", () => {
+  function collapsedRepos(): RepoInfo[] {
+    return Array.from({ length: 6 }, (_, i) => ({
+      id: `repo-${i}`,
+      repoPath: `/tmp/repo-${i}`,
+      project: `project-${i}`,
+      worktrees: [],
+      profileNames: [],
+      ideDefaults: { baseNoIde: true, profileNoIde: {} },
+    }));
+  }
+
+  async function renderTree(
+    props: Partial<React.ComponentProps<typeof TreeView>>,
+  ) {
+    const repos = collapsedRepos();
+    const expandedRepos = new Set<string>();
+    const items = buildTreeItems({
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      prData: new Map(),
+      panes: new Map(),
+      jumpToPane: () => undefined,
+    });
+    const { stdout, stdin } = createStdoutStdin();
+    const chunks: string[] = [];
+    stdout.on("data", (chunk) => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    });
+    const { render } = await import("ink");
+    const instance = render(
+      React.createElement(TreeView, {
+        repos,
+        sessions: [],
+        expandedRepos,
+        selectedIndex: 0,
+        items,
+        pendingActions: new Map(),
+        prData: new Map(),
+        panes: new Map(),
+        expandedWorktreeKey: null,
+        maxWidth: 80,
+        ...props,
+      }),
+      { stdout, stdin, debug: true, patchConsole: false, exitOnCtrlC: false },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return { output: chunks.join(""), unmount: () => instance.unmount() };
+  }
+
+  test("renders all rows when no viewport is supplied", async () => {
+    const { output, unmount } = await renderTree({});
+    for (let i = 0; i < 6; i++) {
+      expect(output).toContain(`project-${i}`);
+    }
+    unmount();
+  });
+
+  test("renders only the windowed slice", async () => {
+    // viewportRows=3, scrollOffset=2 → rows [2,3,4] → project-2/3/4 visible
+    const { output, unmount } = await renderTree({
+      scrollOffset: 2,
+      viewportRows: 3,
+    });
+    expect(output).not.toContain("project-0");
+    expect(output).not.toContain("project-1");
+    expect(output).toContain("project-2");
+    expect(output).toContain("project-3");
+    expect(output).toContain("project-4");
+    expect(output).not.toContain("project-5");
+    unmount();
   });
 });

--- a/tests/tui/tree-view-wiring.test.tsx
+++ b/tests/tui/tree-view-wiring.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { describe, expect, test } from "vitest";
 import { TreeView } from "../../src/tui/components/TreeView";
 import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
-import { buildTreeItems } from "../../src/tui/tree-helpers";
+import { buildTreeItems, buildTreeRows } from "../../src/tui/tree-helpers";
 
 type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
 type TestStdin = NodeJS.ReadStream & {
@@ -42,6 +42,16 @@ describe("TreeView maxWidth wiring", () => {
       panes: new Map(),
       jumpToPane: () => undefined,
     });
+    // TreeView renders the row model its owner built — the same contract
+    // App.tsx uses (one buildTreeRows call shared with hit-testing).
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions: new Map(),
+      maxWidth: 15,
+    });
 
     const { stdout, stdin } = createStdoutStdin();
     const chunks: string[] = [];
@@ -57,6 +67,7 @@ describe("TreeView maxWidth wiring", () => {
         expandedRepos,
         selectedIndex: 0,
         items,
+        rows,
         pendingActions: new Map(),
         prData: new Map(),
         panes: new Map(),
@@ -103,6 +114,14 @@ describe("TreeView windowing", () => {
       panes: new Map(),
       jumpToPane: () => undefined,
     });
+    const rows = buildTreeRows({
+      items,
+      repos,
+      expandedRepos,
+      expandedWorktreeKey: null,
+      pendingActions: new Map(),
+      maxWidth: 80,
+    });
     const { stdout, stdin } = createStdoutStdin();
     const chunks: string[] = [];
     stdout.on("data", (chunk) => {
@@ -116,6 +135,7 @@ describe("TreeView windowing", () => {
         expandedRepos,
         selectedIndex: 0,
         items,
+        rows,
         pendingActions: new Map(),
         prData: new Map(),
         panes: new Map(),

--- a/tests/tui/truncate.test.ts
+++ b/tests/tui/truncate.test.ts
@@ -32,6 +32,19 @@ describe("truncateBranch", () => {
   test("returns empty string when available is 0", () => {
     expect(truncateBranch("feature/branch", 0)).toBe("");
   });
+
+  test("budgets CJK glyphs at two display columns each", () => {
+    // "日本語ブランチ" is 7 glyphs = 14 columns. At 9 columns, only four
+    // glyphs (8) fit before the 1-column ellipsis. Counting code points would
+    // keep 8 of them and render 17 columns wide — soft-wrapping the tree row.
+    expect(truncateBranch("日本語ブランチ", 9)).toBe("日本語ブ…");
+    expect(truncateBranch("日本語ブランチ", 14)).toBe("日本語ブランチ");
+  });
+
+  test("never splits an emoji ZWJ sequence when truncating", () => {
+    const family = "👨‍👩‍👧‍👦"; // one grapheme (4 code points + ZWJs), 2 columns
+    expect(truncateBranch(family.repeat(3), 5)).toBe(`${family.repeat(2)}…`);
+  });
 });
 
 describe("truncateWithPrefix", () => {
@@ -68,6 +81,12 @@ describe("truncateWithPrefix", () => {
   test("handles empty rest", () => {
     expect(truncateWithPrefix("1:0 ", "", 10)).toBe("1:0 ");
     expect(truncateWithPrefix("1:0 ", "", 4)).toBe("1:0 ");
+  });
+
+  test("measures the rest by display width", () => {
+    // prefix "1:0 " (4 cols), rest "🎉🎉🎉" (6 cols), available 8 → rest gets
+    // 4 columns: one 2-column emoji + the ellipsis.
+    expect(truncateWithPrefix("1:0 ", "🎉🎉🎉", 8)).toBe("1:0 🎉…");
   });
 });
 

--- a/tests/tui/truncate.test.ts
+++ b/tests/tui/truncate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  toSingleLine,
   truncateBranch,
   truncateWithPrefix,
 } from "../../src/tui/utils/truncate";
@@ -67,5 +68,28 @@ describe("truncateWithPrefix", () => {
   test("handles empty rest", () => {
     expect(truncateWithPrefix("1:0 ", "", 10)).toBe("1:0 ");
     expect(truncateWithPrefix("1:0 ", "", 4)).toBe("1:0 ");
+  });
+});
+
+describe("toSingleLine", () => {
+  test("returns a single-line string unchanged", () => {
+    expect(toSingleLine("fatal: not a git repository")).toBe(
+      "fatal: not a git repository",
+    );
+  });
+
+  test("collapses git-style multi-line stderr onto one line", () => {
+    // The exact shape that breaks the one-row-per-error budget: wrap="truncate"
+    // does not remove embedded newlines, so this MUST be collapsed before render.
+    expect(toSingleLine("fatal: something went wrong\nhint: try again")).toBe(
+      "fatal: something went wrong hint: try again",
+    );
+  });
+
+  test("squashes CRLF, indentation after the break, and trailing newlines", () => {
+    expect(toSingleLine("error: HTTP 502\r\n   advice: retry later\n")).toBe(
+      "error: HTTP 502 advice: retry later",
+    );
+    expect(toSingleLine("a\n\n\nb")).toBe("a b");
   });
 });

--- a/tests/tui/use-mouse.test.ts
+++ b/tests/tui/use-mouse.test.ts
@@ -1,0 +1,193 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  createMouseController,
+  MOUSE_DISABLE,
+  MOUSE_ENABLE,
+  useMouse,
+} from "../../src/tui/hooks/useMouse";
+
+describe("createMouseController", () => {
+  test("enable writes the enable bytes exactly once", () => {
+    const writes: string[] = [];
+    const c = createMouseController({ write: (d) => writes.push(d) });
+    c.enable();
+    c.enable(); // idempotent — already enabled
+    expect(writes).toEqual([MOUSE_ENABLE]);
+    expect(c.isEnabled()).toBe(true);
+  });
+
+  test("disable writes the disable bytes exactly once and is idempotent", () => {
+    const writes: string[] = [];
+    const c = createMouseController({ write: (d) => writes.push(d) });
+    c.enable();
+    writes.length = 0;
+    c.disable();
+    c.disable(); // idempotent — already disabled
+    expect(writes).toEqual([MOUSE_DISABLE]);
+    expect(c.isEnabled()).toBe(false);
+  });
+
+  test("disable before enable is a no-op", () => {
+    const writes: string[] = [];
+    const c = createMouseController({ write: (d) => writes.push(d) });
+    c.disable();
+    expect(writes).toEqual([]);
+  });
+
+  test("enable bytes turn on ?1000 + ?1006; disable reverses ?1006 then ?1000", () => {
+    expect(MOUSE_ENABLE).toBe("\x1b[?1000h\x1b[?1006h");
+    expect(MOUSE_DISABLE).toBe("\x1b[?1006l\x1b[?1000l");
+  });
+});
+
+type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
+type TestStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  ref: () => NodeJS.ReadStream;
+  unref: () => NodeJS.ReadStream;
+};
+
+function createStdoutStdin() {
+  const stdout = new PassThrough() as unknown as TestStdout;
+  stdout.columns = 80;
+  stdout.rows = 24;
+  const stdin = new PassThrough() as unknown as TestStdin;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => stdin;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+  return { stdout, stdin };
+}
+
+function MouseProbe() {
+  useMouse();
+  return null;
+}
+
+/** A probe that renders Ink but does NOT call useMouse — a control to isolate
+ * the per-signal listeners Ink itself registers (via signal-exit) from any our
+ * hook might add. */
+function NullProbe() {
+  return null;
+}
+
+async function renderProbe(component: React.FC) {
+  const { stdout, stdin } = createStdoutStdin();
+  const chunks: string[] = [];
+  stdout.on("data", (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+  const { render } = await import("ink");
+  const instance = render(React.createElement(component), {
+    stdout,
+    stdin,
+    debug: true,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return {
+    output: () => chunks.join(""),
+    unmount: () => instance.unmount(),
+  };
+}
+
+function renderMouseProbe() {
+  return renderProbe(MouseProbe);
+}
+
+describe("useMouse (default-on)", () => {
+  const original = process.env.WCT_DISABLE_MOUSE;
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.WCT_DISABLE_MOUSE;
+    } else {
+      process.env.WCT_DISABLE_MOUSE = original;
+    }
+  });
+
+  test("writes enable bytes on mount", async () => {
+    delete process.env.WCT_DISABLE_MOUSE;
+    const probe = await renderMouseProbe();
+    expect(probe.output()).toContain(MOUSE_ENABLE);
+    probe.unmount();
+  });
+
+  test("writes disable bytes on unmount and removes the exit handler", async () => {
+    delete process.env.WCT_DISABLE_MOUSE;
+    const exitBefore = process.listenerCount("exit");
+
+    const probe = await renderMouseProbe();
+    probe.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(probe.output()).toContain(MOUSE_DISABLE);
+    // The "exit" handler registered on mount must be removed on unmount.
+    expect(process.listenerCount("exit")).toBe(exitBefore);
+  });
+
+  test("registers NO per-signal handlers (preserves Ink's signal-exit invariant)", async () => {
+    // Regression guard: Ink tears down on signals via signal-exit, which only
+    // re-raises (and runs Ink.unmount) when it is the SOLE listener for a
+    // signal. Adding our own SIGINT/SIGTERM/SIGHUP listener breaks that and
+    // hangs the process (notably on SIGHUP). useMouse must add ZERO per-signal
+    // listeners.
+    //
+    // Ink itself registers one signal-exit listener per signal while mounted,
+    // so the absolute count is non-zero. We isolate our contribution by
+    // comparing a useMouse probe against a control probe that renders Ink but
+    // does NOT call useMouse: the mounted-state per-signal counts must match.
+    delete process.env.WCT_DISABLE_MOUSE;
+
+    // Baseline before any probe mounts.
+    const baseline = signals.map((s) => process.listenerCount(s));
+
+    // Control: Ink alone (no useMouse). Capture its mounted-state counts.
+    const control = await renderProbe(NullProbe);
+    const controlCounts = signals.map((s) => process.listenerCount(s));
+    control.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // useMouse probe: mounted-state per-signal counts must EQUAL the control,
+    // i.e. useMouse contributes zero per-signal listeners on top of Ink's.
+    const probe = await renderMouseProbe();
+    signals.forEach((s, i) => {
+      expect(process.listenerCount(s)).toBe(controlCounts[i]);
+    });
+
+    probe.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // No leak: per-signal counts return to the pre-mount baseline.
+    signals.forEach((s, i) => {
+      expect(process.listenerCount(s)).toBe(baseline[i]);
+    });
+  });
+
+  test("WCT_DISABLE_MOUSE is a complete no-op (no bytes, no handlers)", async () => {
+    process.env.WCT_DISABLE_MOUSE = "1";
+    const exitBefore = process.listenerCount("exit");
+    const sigBefore = signals.map((s) => process.listenerCount(s));
+
+    const probe = await renderMouseProbe();
+    expect(probe.output()).not.toContain(MOUSE_ENABLE);
+    // The opt-out registers no handlers of its own. (Ink itself may register a
+    // signal-exit listener, but it removes it on unmount, so the
+    // before-mount → after-unmount counts are the meaningful contract.)
+    expect(process.listenerCount("exit")).toBe(exitBefore);
+
+    probe.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // No enable on mount means the early-return path ran, so nothing to
+    // disable on unmount either.
+    expect(probe.output()).not.toContain(MOUSE_DISABLE);
+    expect(process.listenerCount("exit")).toBe(exitBefore);
+    sigBefore.forEach((count, i) => {
+      expect(process.listenerCount(signals[i] as NodeJS.Signals)).toBe(count);
+    });
+  });
+});

--- a/tests/tui/worktree-item.test.ts
+++ b/tests/tui/worktree-item.test.ts
@@ -2,6 +2,7 @@ import { PassThrough } from "node:stream";
 import React from "react";
 import { describe, expect, test } from "vitest";
 import { WorktreeItem } from "../../src/tui/components/WorktreeItem";
+import { WorktreeStatsRow } from "../../src/tui/components/WorktreeStatsRow";
 import { truncateBranch } from "../../src/tui/utils/truncate";
 
 type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };
@@ -20,16 +21,14 @@ function createStdoutStdin() {
   return { stdout, stdin };
 }
 
-async function renderWorktreeItem(
-  props: React.ComponentProps<typeof WorktreeItem>,
-) {
+async function renderElement(node: React.ReactElement) {
   const { stdout, stdin } = createStdoutStdin();
   const chunks: string[] = [];
   stdout.on("data", (chunk) => {
     chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
   });
   const { render } = await import("ink");
-  const instance = render(React.createElement(WorktreeItem, props), {
+  const instance = render(node, {
     stdout,
     stdin,
     debug: true,
@@ -47,12 +46,14 @@ async function renderWorktreeItem(
   };
 }
 
+function renderWorktreeItem(props: React.ComponentProps<typeof WorktreeItem>) {
+  return renderElement(React.createElement(WorktreeItem, props));
+}
+
 const baseWorktreeProps = {
   branch: "feature/layout",
   hasSession: true,
   isAttached: false,
-  sync: "↑1",
-  changedFiles: 3,
   isSelected: false,
   isExpanded: false,
   maxWidth: 80,
@@ -88,26 +89,27 @@ describe("truncateBranch", () => {
 });
 
 describe("WorktreeItem", () => {
-  test("does not render git stats for a focused collapsed worktree", async () => {
+  test("renders the branch and never the git stats (stats moved to WorktreeStatsRow)", async () => {
     const { output, unmount } = await renderWorktreeItem({
       ...baseWorktreeProps,
       isSelected: true,
-      isExpanded: false,
+      isExpanded: true,
     });
 
     expect(output).toContain("feature/layout");
+    // Stats are no longer part of WorktreeItem — they render as a separate row.
     expect(output).not.toContain("↑1");
     expect(output).not.toContain("~3");
 
     unmount();
   });
+});
 
-  test("renders git stats for an expanded worktree", async () => {
-    const { output, unmount } = await renderWorktreeItem({
-      ...baseWorktreeProps,
-      isSelected: false,
-      isExpanded: true,
-    });
+describe("WorktreeStatsRow", () => {
+  test("renders sync and changed-file stats", async () => {
+    const { output, unmount } = await renderElement(
+      React.createElement(WorktreeStatsRow, { sync: "↑1", changedFiles: 3 }),
+    );
 
     expect(output).toContain("↑1");
     expect(output).toContain("~3");
@@ -115,15 +117,24 @@ describe("WorktreeItem", () => {
     unmount();
   });
 
-  test("renders git stats for a selected expanded worktree", async () => {
-    const { output, unmount } = await renderWorktreeItem({
-      ...baseWorktreeProps,
-      isSelected: true,
-      isExpanded: true,
-    });
+  test("omits the changed-file marker when there are no changes", async () => {
+    const { output, unmount } = await renderElement(
+      React.createElement(WorktreeStatsRow, { sync: "↑1", changedFiles: 0 }),
+    );
 
     expect(output).toContain("↑1");
-    expect(output).toContain("~3");
+    expect(output).not.toContain("~");
+
+    unmount();
+  });
+
+  test("omits the sync marker when in sync", async () => {
+    const { output, unmount } = await renderElement(
+      React.createElement(WorktreeStatsRow, { sync: "✓", changedFiles: 2 }),
+    );
+
+    expect(output).not.toContain("✓");
+    expect(output).toContain("~2");
 
     unmount();
   });


### PR DESCRIPTION
## Summary
- Adds an independent scroll-offset viewport over the `wct tui` worktree tree (fixes keyboard-navigation clipping on trees taller than the terminal) and layers mouse support on top: wheel scrolls the viewport, left-click selects, in both Navigate and Expanded mode.
- Built on terminal SGR mouse reporting (`?1000`/`?1006`) parsed out of Ink's existing `useInput` pipeline — no second stdin listener, no new runtime dependency. On by default; `WCT_DISABLE_MOUSE=1` opts out.
- Includes a follow-up fix commit for 3 cross-slice integration bugs (wrong-worktree selection on click-to-exit-Expanded, background refresh re-anchoring a wheel-scrolled viewport, mouse release/motion bytes leaking into the Search query) found by a final whole-branch review, each pinned by a regression test that renders the real `App` component through Ink's actual input pipeline.
- Docs: README "## TUI"/"### Mouse" section, `wct tui --help`, and shell-completion description.

See `.scratch/tui-mouse-support/PRD.md`, the three issue files under `.scratch/tui-mouse-support/issues/`, and `docs/adr/0001-navigate-independent-scroll-viewport.md` / `docs/adr/0002-parse-mouse-from-ink-useinput.md` for the full spec and design rationale.

## Test plan
- [x] `bun run test` — all tests passing
- [x] `bun run typecheck` — clean
- [x] Regression tests for the 3 fixed integration bugs render the real `App` component and were confirmed to fail when the fix is reverted (proving they actually guard the fix)
- [ ] Manual smoke test in a real terminal + tmux, on a tree taller than the terminal: no `\x1b[<…M` escape garbage on `q`/Ctrl-C, wheel scrolls with selection fixed, click selects in both Navigate and Expanded, `WCT_DISABLE_MOUSE=1` fully disables mouse reporting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse support (wheel scrolling + click-to-select) with an independent scroll offset and improved viewport hit-testing.
  * Refreshed tree rendering with a visual-row model, expanded-only stats lines, “opening…” placeholders, and wrapped PR labels with continuation rows.
  * Improved Status Bar wrapping/truncation for narrow terminals.
* **Bug Fixes**
  * Prevented SGR mouse sequences from leaking into Search and modal text inputs; improved wheel/background refresh and exit behavior to keep mouse reporting consistent.
* **Documentation**
  * Expanded TUI docs and `wct tui` help with mouse behavior and `WCT_DISABLE_MOUSE=1`.
* **Tests**
  * Added/extended coverage for mouse decoding/wiring, windowing/scrolling, PR wrapping, and narrow-terminal rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->