### PR TITLE
Refine TUI confirmation modals

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -103,6 +103,7 @@ export function App() {
   const upModalReturnSelectedIndexRef = useRef<number>(0);
   const searchReturnModeRef = useRef<Mode>(Mode.Navigate);
   const modalReturnModeRef = useRef<Mode>(Mode.Navigate);
+  const confirmKillPendingRef = useRef(false);
   const lastMouseClickRef = useRef<MouseClickHistory | null>(null);
 
   // Reset selection when search query changes
@@ -564,6 +565,8 @@ export function App() {
   function submitConfirm() {
     switch (mode.type) {
       case "ConfirmKill": {
+        if (confirmKillPendingRef.current) return;
+        confirmKillPendingRef.current = true;
         const { paneId, worktreeKey } = mode;
         const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
         clearActionError();
@@ -576,6 +579,8 @@ export function App() {
             if (parentIndex !== null) setSelectedIndex(parentIndex);
             setMode(Mode.Expanded(worktreeKey));
           },
+        }).finally(() => {
+          confirmKillPendingRef.current = false;
         });
         return;
       }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -3,6 +3,7 @@
 import { Box, type Key, render, Text, useApp, useWindowSize } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddProjectModal } from "./components/AddProjectModal";
+import { ConfirmModal } from "./components/ConfirmModal";
 import { OpenModal } from "./components/OpenModal";
 import { StatusBar, statusBarRowCount } from "./components/StatusBar";
 import { TreeView } from "./components/TreeView";
@@ -17,7 +18,6 @@ import { useRegistry } from "./hooks/useRegistry";
 import { useSessionActions } from "./hooks/useSessionActions";
 import type { SessionIdeDefaults } from "./hooks/useSessionOptionsState";
 import { useTmux } from "./hooks/useTmux";
-import { handleConfirmCloseInput } from "./input/confirm-close";
 import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
 import {
@@ -218,13 +218,14 @@ export function App() {
   // would under-count, and the overflowing layout would misalign mouse
   // hit-testing.
   //
-  // True modals (OpenModal/UpModal/AddProjectModal) replace the StatusBar but
-  // budget the SAME virtual row count: viewportRows must not change when a
-  // modal opens, or the clamp/keep-visible effects would rewrite a
-  // wheel-scrolled offset the user expects back on cancel. The modal being
-  // taller than the budgeted chrome is absorbed by the tree box's
-  // overflowY="hidden" clipping (see the render below), which keeps the modal
-  // fully on-screen without inflating the viewport.
+  // True modals replace the StatusBar but budget the SAME virtual row count:
+  // viewportRows must not change when a modal opens, or the clamp/keep-visible
+  // effects would rewrite a wheel-scrolled offset the user expects back on
+  // cancel. Confirmation modals render below the header; the other modals
+  // render below the tree. A modal being taller than the budgeted chrome is
+  // absorbed by the tree box's overflowY="hidden" clipping (see the render
+  // below), which keeps the modal fully on-screen without inflating the
+  // viewport.
   const bottomChromeRows =
     statusBarRowCount(mode, Boolean(repoError)) +
     (tmuxError || actionError ? 1 : 0);
@@ -542,47 +543,59 @@ export function App() {
     }
   }
 
-  function handleConfirmKillInput(_input: string, key: Key) {
-    if (mode.type !== "ConfirmKill") {
-      return;
-    }
-
-    if (key.escape) {
-      setMode(Mode.Expanded(mode.worktreeKey));
-      return;
-    }
-
-    if (key.return) {
-      const { paneId, worktreeKey } = mode;
-      const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
-      if (parentIndex !== null) {
-        setSelectedIndex(parentIndex);
-      }
-      setMode(Mode.Expanded(worktreeKey));
-      killPane(paneId).then(() => refreshSessions());
+  function cancelConfirm() {
+    switch (mode.type) {
+      case "ConfirmKill":
+        setMode(Mode.Expanded(mode.worktreeKey));
+        return;
+      case "ConfirmDown":
+        setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
+        setMode(confirmDownReturnModeRef.current);
+        return;
+      case "ConfirmClose":
+      case "ConfirmCloseForce":
+        setSelectedIndex(confirmCloseReturnSelectedIndexRef.current);
+        setMode(confirmCloseReturnModeRef.current);
+        return;
     }
   }
 
-  function handleConfirmDownInput(_input: string, key: Key) {
-    if (mode.type !== "ConfirmDown") {
-      return;
+  function submitConfirm() {
+    switch (mode.type) {
+      case "ConfirmKill": {
+        const { paneId, worktreeKey } = mode;
+        const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
+        if (parentIndex !== null) setSelectedIndex(parentIndex);
+        setMode(Mode.Expanded(worktreeKey));
+        void killPane(paneId).then(() => refreshSessions());
+        return;
+      }
+      case "ConfirmDown":
+        void sessionActions.executeDown(
+          mode.sessionName,
+          mode.branch,
+          mode.worktreePath,
+          mode.worktreeKey,
+        );
+        return;
+      case "ConfirmClose":
+      case "ConfirmCloseForce":
+        void sessionActions.executeClose(
+          mode.sessionName,
+          mode.branch,
+          mode.worktreePath,
+          mode.worktreeKey,
+          mode.repoPath,
+          mode.project,
+          mode.type === "ConfirmCloseForce",
+        );
+        return;
     }
+  }
 
-    if (key.escape) {
-      setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
-      setMode(confirmDownReturnModeRef.current);
-      return;
-    }
-
-    if (key.return) {
-      const { branch, worktreeKey, worktreePath, sessionName } = mode;
-      void sessionActions.executeDown(
-        sessionName,
-        branch,
-        worktreePath,
-        worktreeKey,
-      );
-    }
+  function handleConfirmInput(key: Key) {
+    if (key.escape) cancelConfirm();
+    else if (key.return) submitConfirm();
   }
 
   function handleMouse(event: MouseEvent) {
@@ -699,24 +712,10 @@ export function App() {
         case "Expanded":
           return handleExpandedInput(expCtx, input, key);
         case "ConfirmKill":
-          return handleConfirmKillInput(input, key);
         case "ConfirmDown":
-          return handleConfirmDownInput(input, key);
         case "ConfirmClose":
         case "ConfirmCloseForce":
-          return handleConfirmCloseInput(
-            {
-              mode,
-              returnMode: confirmCloseReturnModeRef.current,
-              returnSelectedIndex: confirmCloseReturnSelectedIndexRef.current,
-              setMode,
-              setSelectedIndex,
-              executeClose: (...args) =>
-                void sessionActions.executeClose(...args),
-            },
-            input,
-            key,
-          );
+          return handleConfirmInput(key);
       }
     },
     { onMouseEvent: handleMouse },
@@ -739,6 +738,29 @@ export function App() {
           later rows paint over them. */}
       <Box flexDirection="column" flexShrink={0}>
         <Text bold>wct</Text>
+        {mode.type === "ConfirmKill" ||
+        mode.type === "ConfirmDown" ||
+        mode.type === "ConfirmClose" ||
+        mode.type === "ConfirmCloseForce" ? (
+          <Box flexDirection="column">
+            {tmuxError && !actionError ? (
+              <Text color="yellow" wrap="truncate">
+                {toSingleLine(tmuxError)}
+              </Text>
+            ) : null}
+            {actionError ? (
+              <Text color="red" wrap="truncate">
+                {toSingleLine(actionError)}
+              </Text>
+            ) : null}
+            <ConfirmModal
+              mode={mode}
+              width={Math.min(termCols, 60)}
+              onConfirm={submitConfirm}
+              onCancel={cancelConfirm}
+            />
+          </Box>
+        ) : null}
         <Text> </Text>
       </Box>
       {/* overflowY="hidden" + flexShrink is what lets a true modal exceed the
@@ -774,8 +796,9 @@ export function App() {
           />
         </Box>
       </Box>
-      {/* flexShrink={0} pins the bottom area (modal or status chrome) to its
-          natural height so the tree box above is the only child Yoga shrinks. */}
+      {/* flexShrink={0} pins the bottom area (form modal or status chrome) to
+          its natural height so the tree box above is the only child Yoga
+          shrinks. Confirmations render below the header instead. */}
       <Box flexDirection="column" flexShrink={0}>
         {mode.type === "OpenModal" ? (
           <OpenModal
@@ -811,7 +834,10 @@ export function App() {
             onSubmit={modalActions.handleAddProject}
             onCancel={() => setMode(modalReturnModeRef.current)}
           />
-        ) : (
+        ) : mode.type === "ConfirmKill" ||
+          mode.type === "ConfirmDown" ||
+          mode.type === "ConfirmClose" ||
+          mode.type === "ConfirmCloseForce" ? null : (
           <Box flexDirection="column">
             {tmuxError && !actionError ? (
               <Text color="yellow" wrap="truncate">

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -104,6 +104,7 @@ export function App() {
   const searchReturnModeRef = useRef<Mode>(Mode.Navigate);
   const modalReturnModeRef = useRef<Mode>(Mode.Navigate);
   const confirmKillPendingRef = useRef(false);
+  const confirmKillAttemptRef = useRef(0);
   const lastMouseClickRef = useRef<MouseClickHistory | null>(null);
 
   // Reset selection when search query changes
@@ -548,6 +549,8 @@ export function App() {
   function cancelConfirm() {
     switch (mode.type) {
       case "ConfirmKill":
+        confirmKillAttemptRef.current += 1;
+        confirmKillPendingRef.current = false;
         setMode(Mode.Expanded(mode.worktreeKey));
         return;
       case "ConfirmDown":
@@ -567,6 +570,7 @@ export function App() {
       case "ConfirmKill": {
         if (confirmKillPendingRef.current) return;
         confirmKillPendingRef.current = true;
+        const attempt = ++confirmKillAttemptRef.current;
         const { paneId, worktreeKey } = mode;
         const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
         clearActionError();
@@ -574,13 +578,16 @@ export function App() {
           paneId,
           killPane,
           refreshSessions,
+          isCurrent: () => confirmKillAttemptRef.current === attempt,
           showActionError,
           onSuccess: () => {
             if (parentIndex !== null) setSelectedIndex(parentIndex);
             setMode(Mode.Expanded(worktreeKey));
           },
         }).finally(() => {
-          confirmKillPendingRef.current = false;
+          if (confirmKillAttemptRef.current === attempt) {
+            confirmKillPendingRef.current = false;
+          }
         });
         return;
       }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -103,7 +103,7 @@ export function App() {
   const upModalReturnSelectedIndexRef = useRef<number>(0);
   const searchReturnModeRef = useRef<Mode>(Mode.Navigate);
   const modalReturnModeRef = useRef<Mode>(Mode.Navigate);
-  const confirmKillPendingRef = useRef(false);
+  const confirmPendingRef = useRef(false);
   const confirmKillAttemptRef = useRef(0);
   const lastMouseClickRef = useRef<MouseClickHistory | null>(null);
 
@@ -550,7 +550,7 @@ export function App() {
     switch (mode.type) {
       case "ConfirmKill":
         confirmKillAttemptRef.current += 1;
-        confirmKillPendingRef.current = false;
+        confirmPendingRef.current = false;
         setMode(Mode.Expanded(mode.worktreeKey));
         return;
       case "ConfirmDown":
@@ -568,8 +568,8 @@ export function App() {
   function submitConfirm() {
     switch (mode.type) {
       case "ConfirmKill": {
-        if (confirmKillPendingRef.current) return;
-        confirmKillPendingRef.current = true;
+        if (confirmPendingRef.current) return;
+        confirmPendingRef.current = true;
         const attempt = ++confirmKillAttemptRef.current;
         const { paneId, worktreeKey } = mode;
         const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
@@ -586,31 +586,45 @@ export function App() {
           },
         }).finally(() => {
           if (confirmKillAttemptRef.current === attempt) {
-            confirmKillPendingRef.current = false;
+            confirmPendingRef.current = false;
           }
         });
         return;
       }
-      case "ConfirmDown":
-        void sessionActions.executeDown(
-          mode.sessionName,
-          mode.branch,
-          mode.worktreePath,
-          mode.worktreeKey,
-        );
+      case "ConfirmDown": {
+        if (confirmPendingRef.current) return;
+        confirmPendingRef.current = true;
+        void sessionActions
+          .executeDown(
+            mode.sessionName,
+            mode.branch,
+            mode.worktreePath,
+            mode.worktreeKey,
+          )
+          .finally(() => {
+            confirmPendingRef.current = false;
+          });
         return;
+      }
       case "ConfirmClose":
-      case "ConfirmCloseForce":
-        void sessionActions.executeClose(
-          mode.sessionName,
-          mode.branch,
-          mode.worktreePath,
-          mode.worktreeKey,
-          mode.repoPath,
-          mode.project,
-          mode.type === "ConfirmCloseForce",
-        );
+      case "ConfirmCloseForce": {
+        if (confirmPendingRef.current) return;
+        confirmPendingRef.current = true;
+        void sessionActions
+          .executeClose(
+            mode.sessionName,
+            mode.branch,
+            mode.worktreePath,
+            mode.worktreeKey,
+            mode.repoPath,
+            mode.project,
+            mode.type === "ConfirmCloseForce",
+          )
+          .finally(() => {
+            confirmPendingRef.current = false;
+          });
         return;
+      }
     }
   }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -18,6 +18,7 @@ import { useRegistry } from "./hooks/useRegistry";
 import { useSessionActions } from "./hooks/useSessionActions";
 import type { SessionIdeDefaults } from "./hooks/useSessionOptionsState";
 import { useTmux } from "./hooks/useTmux";
+import { executeConfirmKill } from "./input/confirm-kill";
 import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
 import {
@@ -565,9 +566,17 @@ export function App() {
       case "ConfirmKill": {
         const { paneId, worktreeKey } = mode;
         const parentIndex = findOwningWorktreeIndex(treeItems, selectedIndex);
-        if (parentIndex !== null) setSelectedIndex(parentIndex);
-        setMode(Mode.Expanded(worktreeKey));
-        void killPane(paneId).then(() => refreshSessions());
+        clearActionError();
+        void executeConfirmKill({
+          paneId,
+          killPane,
+          refreshSessions,
+          showActionError,
+          onSuccess: () => {
+            if (parentIndex !== null) setSelectedIndex(parentIndex);
+            setMode(Mode.Expanded(worktreeKey));
+          },
+        });
         return;
       }
       case "ConfirmDown":

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -81,7 +81,7 @@ export function ConfirmModal({ mode, width, onConfirm, onCancel }: Props) {
   return (
     <Modal title={title} visible width={width} accentColor="red" dimAccent>
       <Box flexDirection="column" paddingX={1}>
-        <Text wrap="truncate">{toSingleLine(question)}</Text>
+        <Text wrap="wrap">{toSingleLine(question)}</Text>
         <Box gap={2} marginTop={1}>
           <Action label={confirmLabel} onClick={onConfirm} destructive />
           <Action label="esc:cancel" onClick={onCancel} />

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -1,0 +1,91 @@
+import { Box, Text } from "ink";
+import type { Mode } from "../types";
+import { Modal } from "./Modal";
+import { MouseClickable } from "./MouseClickable";
+
+export type ConfirmMode = Extract<
+  Mode,
+  {
+    type: "ConfirmKill" | "ConfirmDown" | "ConfirmClose" | "ConfirmCloseForce";
+  }
+>;
+
+interface Props {
+  mode: ConfirmMode;
+  width?: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function copyFor(mode: ConfirmMode): {
+  title: string;
+  question: string;
+  confirmLabel: string;
+} {
+  switch (mode.type) {
+    case "ConfirmKill":
+      return {
+        title: "Kill Pane",
+        question: `Kill pane ${mode.label}?`,
+        confirmLabel: "enter:confirm",
+      };
+    case "ConfirmDown":
+      return {
+        title: "Stop Session",
+        question: `Kill session for ${mode.branch}?`,
+        confirmLabel: "enter:confirm",
+      };
+    case "ConfirmClose":
+      return {
+        title: "Close Worktree",
+        question: `Close worktree ${mode.branch}?`,
+        confirmLabel: "enter:confirm",
+      };
+    case "ConfirmCloseForce":
+      return {
+        title: "Force Close Worktree",
+        question: `${mode.branch} has uncommitted changes`,
+        confirmLabel: "enter:force close",
+      };
+  }
+}
+
+function Action({
+  label,
+  onClick,
+  destructive = false,
+}: {
+  label: string;
+  onClick: () => void;
+  destructive?: boolean;
+}) {
+  return (
+    <MouseClickable onClick={onClick}>
+      {(isHovered) => (
+        <Text
+          color={destructive ? (isHovered ? "redBright" : "red") : undefined}
+          bold={isHovered}
+          dimColor={!destructive && !isHovered}
+        >
+          {label}
+        </Text>
+      )}
+    </MouseClickable>
+  );
+}
+
+export function ConfirmModal({ mode, width, onConfirm, onCancel }: Props) {
+  const { title, question, confirmLabel } = copyFor(mode);
+
+  return (
+    <Modal title={title} visible width={width} accentColor="red" dimAccent>
+      <Box flexDirection="column" paddingX={1}>
+        <Text>{question}</Text>
+        <Box gap={2} marginTop={1}>
+          <Action label={confirmLabel} onClick={onConfirm} destructive />
+          <Action label="esc:cancel" onClick={onCancel} />
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type { Mode } from "../types";
+import { toSingleLine } from "../utils/truncate";
 import { Modal } from "./Modal";
 import { MouseClickable } from "./MouseClickable";
 
@@ -80,7 +81,7 @@ export function ConfirmModal({ mode, width, onConfirm, onCancel }: Props) {
   return (
     <Modal title={title} visible width={width} accentColor="red" dimAccent>
       <Box flexDirection="column" paddingX={1}>
-        <Text>{question}</Text>
+        <Text wrap="truncate">{toSingleLine(question)}</Text>
         <Box gap={2} marginTop={1}>
           <Action label={confirmLabel} onClick={onConfirm} destructive />
           <Action label="esc:cancel" onClick={onCancel} />

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -32,7 +32,7 @@ function copyFor(mode: ConfirmMode): {
       };
     case "ConfirmDown":
       return {
-        title: "Stop Session",
+        title: "Kill Session",
         question: `Kill session for ${mode.branch}?`,
         confirmLabel: "enter:confirm",
       };

--- a/src/tui/components/Modal.tsx
+++ b/src/tui/components/Modal.tsx
@@ -1,3 +1,4 @@
+import type { TextProps } from "ink";
 import type { ReactNode } from "react";
 import { TitledBox } from "./TitledBox";
 
@@ -6,13 +7,28 @@ interface Props {
   children: ReactNode;
   visible: boolean;
   width?: number;
+  accentColor?: TextProps["color"];
+  dimAccent?: boolean;
 }
 
-export function Modal({ title, children, visible, width }: Props) {
+export function Modal({
+  title,
+  children,
+  visible,
+  width,
+  accentColor,
+  dimAccent,
+}: Props) {
   if (!visible) return null;
 
   return (
-    <TitledBox title={title} isFocused={true} width={width}>
+    <TitledBox
+      title={title}
+      isFocused={true}
+      width={width}
+      accentColor={accentColor}
+      dimAccent={dimAccent}
+    >
       {children}
     </TitledBox>
   );

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "ink";
+import { Box, Text, type TextProps } from "ink";
 import { Children, type ReactNode } from "react";
 
 interface Props {
@@ -7,6 +7,8 @@ interface Props {
   width?: number;
   children: ReactNode;
   isHovered?: boolean;
+  accentColor?: TextProps["color"];
+  dimAccent?: boolean;
 }
 
 const graphemeSegmenter = new Intl.Segmenter(undefined, {
@@ -60,6 +62,8 @@ export function TitledBox({
   width,
   children,
   isHovered = false,
+  accentColor = "cyan",
+  dimAccent = false,
 }: Props) {
   const boxWidth = Math.max(width ?? 40, 0);
   const isHighlighted = isFocused || isHovered;
@@ -71,9 +75,9 @@ export function TitledBox({
     ),
   );
   const lineProps = {
-    color: isHighlighted ? "cyan" : undefined,
-    bold: isHighlighted,
-    dimColor: !isHighlighted,
+    color: isHighlighted ? accentColor : undefined,
+    bold: isHighlighted && !dimAccent,
+    dimColor: !isHighlighted || dimAccent,
   } as const;
 
   return (
@@ -85,11 +89,11 @@ export function TitledBox({
         borderStyle="round"
         borderTop={false}
         borderBottom={false}
-        borderColor={isHighlighted ? "cyan" : undefined}
-        borderLeftColor={isHighlighted ? "cyan" : undefined}
-        borderRightColor={isHighlighted ? "cyan" : undefined}
-        borderLeftDimColor={!isHighlighted}
-        borderRightDimColor={!isHighlighted}
+        borderColor={isHighlighted ? accentColor : undefined}
+        borderLeftColor={isHighlighted ? accentColor : undefined}
+        borderRightColor={isHighlighted ? accentColor : undefined}
+        borderLeftDimColor={!isHighlighted || dimAccent}
+        borderRightDimColor={!isHighlighted || dimAccent}
       >
         {normalizedChildren}
       </Box>

--- a/src/tui/input/confirm-kill.ts
+++ b/src/tui/input/confirm-kill.ts
@@ -8,7 +8,14 @@ export interface ConfirmKillContext {
 }
 
 export async function executeConfirmKill(ctx: ConfirmKillContext) {
-  const killed = await ctx.killPane(ctx.paneId);
+  let killed: boolean;
+  try {
+    killed = await ctx.killPane(ctx.paneId);
+  } catch {
+    if (ctx.isCurrent()) ctx.showActionError("Failed to kill pane");
+    return;
+  }
+
   if (!ctx.isCurrent()) return;
 
   if (!killed) {

--- a/src/tui/input/confirm-kill.ts
+++ b/src/tui/input/confirm-kill.ts
@@ -1,0 +1,18 @@
+export interface ConfirmKillContext {
+  paneId: string;
+  killPane: (paneId: string) => Promise<boolean>;
+  refreshSessions: () => Promise<unknown>;
+  onSuccess: () => void;
+  showActionError: (message: string) => void;
+}
+
+export async function executeConfirmKill(ctx: ConfirmKillContext) {
+  const killed = await ctx.killPane(ctx.paneId);
+  if (!killed) {
+    ctx.showActionError("Failed to kill pane");
+    return;
+  }
+
+  ctx.onSuccess();
+  await ctx.refreshSessions();
+}

--- a/src/tui/input/confirm-kill.ts
+++ b/src/tui/input/confirm-kill.ts
@@ -2,12 +2,15 @@ export interface ConfirmKillContext {
   paneId: string;
   killPane: (paneId: string) => Promise<boolean>;
   refreshSessions: () => Promise<unknown>;
+  isCurrent: () => boolean;
   onSuccess: () => void;
   showActionError: (message: string) => void;
 }
 
 export async function executeConfirmKill(ctx: ConfirmKillContext) {
   const killed = await ctx.killPane(ctx.paneId);
+  if (!ctx.isCurrent()) return;
+
   if (!killed) {
     ctx.showActionError("Failed to kill pane");
     return;

--- a/tests/tui/confirm-modal.test.tsx
+++ b/tests/tui/confirm-modal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  ConfirmModal,
+  type ConfirmMode,
+} from "../../src/tui/components/ConfirmModal";
+import { Mode } from "../../src/tui/types";
+import { renderWithInput, sendKeys } from "./keypress-harness";
+
+const click = (col: number, row: number) => `\x1b[<0;${col};${row}M`;
+
+describe("ConfirmModal", () => {
+  test("renders confirmation copy inside the shared modal chrome", async () => {
+    const rendered = await renderWithInput(
+      <ConfirmModal
+        mode={
+          Mode.ConfirmKill("%1", "shell:1 vim", "proj/branch") as ConfirmMode
+        }
+        width={60}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    try {
+      expect(rendered.output()).toContain("╭ Kill Pane");
+      expect(rendered.output()).toContain("Kill pane shell:1 vim?");
+      expect(rendered.output()).toContain("enter:confirm  esc:cancel");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("makes the enter and escape shortcut labels clickable", async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const rendered = await renderWithInput(
+      <ConfirmModal
+        mode={
+          Mode.ConfirmDown(
+            "myapp-feature",
+            "feature",
+            "/tmp/myapp-feature",
+            "proj/feature",
+          ) as ConfirmMode
+        }
+        width={60}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, click(3, 4));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+      expect(onCancel).not.toHaveBeenCalled();
+
+      await sendKeys(rendered.stdin, click(18, 4));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/tests/tui/confirm-modal.test.tsx
+++ b/tests/tui/confirm-modal.test.tsx
@@ -79,9 +79,7 @@ describe("ConfirmModal", () => {
     );
 
     try {
-      expect(rendered.output().trimEnd().split("\n").length).toBeGreaterThan(
-        5,
-      );
+      expect(rendered.output().trimEnd().split("\n").length).toBeGreaterThan(5);
       expect(rendered.output()).toContain("xxxxxxxxxxxxxxxx");
       expect(rendered.output()).toContain("enter:confirm  esc:cancel");
     } finally {

--- a/tests/tui/confirm-modal.test.tsx
+++ b/tests/tui/confirm-modal.test.tsx
@@ -60,4 +60,29 @@ describe("ConfirmModal", () => {
       rendered.unmount();
     }
   });
+
+  test("keeps long confirmation copy to one terminal row", async () => {
+    const rendered = await renderWithInput(
+      <ConfirmModal
+        mode={
+          Mode.ConfirmDown(
+            "myapp-feature",
+            `feature/with-a-very-long-name-${"x".repeat(80)}`,
+            "/tmp/myapp-feature",
+            "proj/feature",
+          ) as ConfirmMode
+        }
+        width={40}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    try {
+      expect(rendered.output().trimEnd().split("\n")).toHaveLength(5);
+      expect(rendered.output()).toContain("enter:confirm  esc:cancel");
+    } finally {
+      rendered.unmount();
+    }
+  });
 });

--- a/tests/tui/confirm-modal.test.tsx
+++ b/tests/tui/confirm-modal.test.tsx
@@ -61,7 +61,7 @@ describe("ConfirmModal", () => {
     }
   });
 
-  test("keeps long confirmation copy to one terminal row", async () => {
+  test("wraps long confirmation copy without hiding the actions", async () => {
     const rendered = await renderWithInput(
       <ConfirmModal
         mode={
@@ -79,7 +79,10 @@ describe("ConfirmModal", () => {
     );
 
     try {
-      expect(rendered.output().trimEnd().split("\n")).toHaveLength(5);
+      expect(rendered.output().trimEnd().split("\n").length).toBeGreaterThan(
+        5,
+      );
+      expect(rendered.output()).toContain("xxxxxxxxxxxxxxxx");
       expect(rendered.output()).toContain("enter:confirm  esc:cancel");
     } finally {
       rendered.unmount();

--- a/tests/tui/input-confirm-kill.test.ts
+++ b/tests/tui/input-confirm-kill.test.ts
@@ -11,6 +11,7 @@ function makeContext(
     paneId: "%5",
     killPane: vi.fn().mockResolvedValue(true),
     refreshSessions: vi.fn().mockResolvedValue([]),
+    isCurrent: vi.fn(() => true),
     onSuccess: vi.fn(),
     showActionError: vi.fn(),
     ...overrides,
@@ -38,6 +39,18 @@ describe("executeConfirmKill", () => {
 
     expect(ctx.showActionError).toHaveBeenCalledWith("Failed to kill pane");
     expect(ctx.onSuccess).not.toHaveBeenCalled();
+    expect(ctx.refreshSessions).not.toHaveBeenCalled();
+  });
+
+  test("ignores a stale completion after the confirmation is cancelled", async () => {
+    const ctx = makeContext({
+      isCurrent: vi.fn(() => false),
+    });
+
+    await executeConfirmKill(ctx);
+
+    expect(ctx.onSuccess).not.toHaveBeenCalled();
+    expect(ctx.showActionError).not.toHaveBeenCalled();
     expect(ctx.refreshSessions).not.toHaveBeenCalled();
   });
 });

--- a/tests/tui/input-confirm-kill.test.ts
+++ b/tests/tui/input-confirm-kill.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  type ConfirmKillContext,
+  executeConfirmKill,
+} from "../../src/tui/input/confirm-kill";
+
+function makeContext(
+  overrides: Partial<ConfirmKillContext> = {},
+): ConfirmKillContext {
+  return {
+    paneId: "%5",
+    killPane: vi.fn().mockResolvedValue(true),
+    refreshSessions: vi.fn().mockResolvedValue([]),
+    onSuccess: vi.fn(),
+    showActionError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("executeConfirmKill", () => {
+  test("restores expanded state and refreshes sessions after a successful kill", async () => {
+    const ctx = makeContext();
+
+    await executeConfirmKill(ctx);
+
+    expect(ctx.killPane).toHaveBeenCalledWith("%5");
+    expect(ctx.onSuccess).toHaveBeenCalledOnce();
+    expect(ctx.refreshSessions).toHaveBeenCalledOnce();
+    expect(ctx.showActionError).not.toHaveBeenCalled();
+  });
+
+  test("reports failure without leaving confirmation or refreshing sessions", async () => {
+    const ctx = makeContext({
+      killPane: vi.fn().mockResolvedValue(false),
+    });
+
+    await executeConfirmKill(ctx);
+
+    expect(ctx.showActionError).toHaveBeenCalledWith("Failed to kill pane");
+    expect(ctx.onSuccess).not.toHaveBeenCalled();
+    expect(ctx.refreshSessions).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tui/input-confirm-kill.test.ts
+++ b/tests/tui/input-confirm-kill.test.ts
@@ -42,8 +42,21 @@ describe("executeConfirmKill", () => {
     expect(ctx.refreshSessions).not.toHaveBeenCalled();
   });
 
+  test("reports a rejected pane kill through the action error flow", async () => {
+    const ctx = makeContext({
+      killPane: vi.fn().mockRejectedValue(new Error("tmux failed")),
+    });
+
+    await executeConfirmKill(ctx);
+
+    expect(ctx.showActionError).toHaveBeenCalledWith("Failed to kill pane");
+    expect(ctx.onSuccess).not.toHaveBeenCalled();
+    expect(ctx.refreshSessions).not.toHaveBeenCalled();
+  });
+
   test("ignores a stale completion after the confirmation is cancelled", async () => {
     const ctx = makeContext({
+      killPane: vi.fn().mockRejectedValue(new Error("tmux failed")),
       isCurrent: vi.fn(() => false),
     });
 

--- a/tests/tui/input-confirm-kill.test.ts
+++ b/tests/tui/input-confirm-kill.test.ts
@@ -19,7 +19,7 @@ function makeContext(
 }
 
 describe("executeConfirmKill", () => {
-  test("restores expanded state and refreshes sessions after a successful kill", async () => {
+  test("calls onSuccess and refreshes sessions after a successful kill", async () => {
     const ctx = makeContext();
 
     await executeConfirmKill(ctx);
@@ -30,7 +30,7 @@ describe("executeConfirmKill", () => {
     expect(ctx.showActionError).not.toHaveBeenCalled();
   });
 
-  test("reports failure without leaving confirmation or refreshing sessions", async () => {
+  test("reports failure without calling onSuccess or refreshing sessions", async () => {
     const ctx = makeContext({
       killPane: vi.fn().mockResolvedValue(false),
     });


### PR DESCRIPTION
## Summary

- replace inline confirmation status prompts with reusable modal UI
- place confirmation modals directly below the `wct` header
- make confirm and cancel shortcut legends clickable while preserving Enter/Escape keyboard behavior
- use subdued reddish chrome with neutral content and clearer destructive-action emphasis
- keep tmux and action errors visible alongside confirmations

## Why

Confirmation prompts used different chrome from the open-worktree and add-project flows, and their shortcut legends were not interactive. The new component gives destructive actions a consistent modal treatment without overwhelming the content with red styling.

## Impact

Users get consistent confirmation UI, mouse-accessible actions, preserved keyboard navigation, and visible failure feedback when a confirmed operation cannot proceed.

## Validation

- added focused component coverage for confirmation copy and clickable actions
- repository-managed formatting, linting, and test hooks remain responsible for automated checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified confirmation modal for pane kill, move-down, and close actions.
  * Added enter/escape shortcuts plus clickable controls for confirm and cancel, including destructive styling.
* **UI Improvements**
  * Enhanced modal presentation with configurable accent colors and optional dimming.
  * Improved confirmation layout to fit within existing viewport budgeting, especially at narrow terminal widths.
* **Bug Fixes**
  * Standardized confirmation input handling and prevented stale/duplicate confirm submissions during async operations.
* **Tests**
  * Added/expanded Vitest coverage for modal rendering, keyboard/mouse interactions, wrapping behavior, and kill-attempt edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->