### PR TITLE
Add project button to TUI header

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -22,8 +22,11 @@ import { executeConfirmKill } from "./input/confirm-kill";
 import type { ExpandedContext } from "./input/expanded";
 import { handleExpandedInput } from "./input/expanded";
 import {
+  ADD_PROJECT_BUTTON_LABEL,
   detectDoubleClick,
   HEADER_OFFSET,
+  isAddProjectButtonPress,
+  isAddProjectButtonTarget,
   type MouseClickHistory,
   type MouseEvent,
   mouseClickTargetId,
@@ -91,6 +94,8 @@ export function App() {
     new Set(),
   );
   const [searchQuery, setSearchQuery] = useState("");
+  const [isAddProjectButtonHovered, setIsAddProjectButtonHovered] =
+    useState(false);
   const { actionError, showActionError, clearActionError } = useActionError();
   const [pendingActions, setPendingActions] = useState<
     Map<string, PendingAction>
@@ -634,6 +639,18 @@ export function App() {
   }
 
   function handleMouse(event: MouseEvent) {
+    if (event.kind === "move" || event.kind === "press") {
+      setIsAddProjectButtonHovered(
+        isAddProjectButtonTarget(event, mode, termCols),
+      );
+    }
+
+    if (isAddProjectButtonPress(event, mode, termCols)) {
+      lastMouseClickRef.current = null;
+      modalActions.prepareAddProjectModal();
+      return;
+    }
+
     const action = resolveMouseAction(event, {
       mode,
       rows,
@@ -772,7 +789,12 @@ export function App() {
           otherwise the header/spacer lines get squeezed to zero height and
           later rows paint over them. */}
       <Box flexDirection="column" flexShrink={0}>
-        <Text bold>wct</Text>
+        <Box justifyContent="space-between">
+          <Text bold>wct</Text>
+          <Text bold color="cyan" inverse={isAddProjectButtonHovered}>
+            {ADD_PROJECT_BUTTON_LABEL}
+          </Text>
+        </Box>
         {mode.type === "ConfirmKill" ||
         mode.type === "ConfirmDown" ||
         mode.type === "ConfirmClose" ||

--- a/src/tui/input/mouse.ts
+++ b/src/tui/input/mouse.ts
@@ -8,6 +8,7 @@ import { type Mode, pendingKey, type TreeItem } from "../types";
  * this offset (and the 1-based → 0-based conversion).
  */
 export const HEADER_OFFSET = 2;
+export const ADD_PROJECT_BUTTON_LABEL = "[+Add]";
 
 /** SGR extended mouse event (DECSET ?1006). ESC is already stripped by Ink. */
 // biome-ignore lint/suspicious/noControlCharactersInRegex: the ESC (\x1b) byte is the literal start of an SGR mouse sequence and must be matched
@@ -66,6 +67,35 @@ export type MouseEvent =
       col: number;
       row: number;
     };
+
+export function isAddProjectButtonTarget(
+  event: MouseEvent,
+  mode: Mode,
+  terminalColumns: number,
+): boolean {
+  if (mode.type !== "Navigate" && mode.type !== "Expanded") return false;
+  if (event.kind === "wheel" || event.row !== 1) {
+    return false;
+  }
+
+  const firstButtonColumn = Math.max(
+    1,
+    terminalColumns - ADD_PROJECT_BUTTON_LABEL.length + 1,
+  );
+  return event.col >= firstButtonColumn && event.col <= terminalColumns;
+}
+
+export function isAddProjectButtonPress(
+  event: MouseEvent,
+  mode: Mode,
+  terminalColumns: number,
+): boolean {
+  return (
+    event.kind === "press" &&
+    event.button === "left" &&
+    isAddProjectButtonTarget(event, mode, terminalColumns)
+  );
+}
 
 export interface MouseClickHistory {
   targetId: string;

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -116,8 +116,10 @@ describe("App.tsx review fixes (real App)", () => {
       // The whole frame must fit the terminal (the overflowing tree clips
       // inside its own box instead of painting over the modal)...
       expect(frame.length).toBeLessThanOrEqual(14);
-      // ...the header must survive (the garbled layout corrupted it to " ct")...
-      expect(frame[0]).toBe("wct");
+      // ...the header must survive (the garbled layout corrupted it to " ct")
+      // and retain the right-aligned add-project control.
+      expect(frame[0]?.startsWith("wct")).toBe(true);
+      expect(frame[0]).toContain("[+Add]");
       // ...and the modal must be fully present: title on its top border and
       // an intact bottom border, in order.
       const topBorder = frame.findIndex((l) => l.includes("Select mode"));

--- a/tests/tui/input-mouse.test.ts
+++ b/tests/tui/input-mouse.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "vitest";
 import type { RepoInfo } from "../../src/tui/hooks/useRegistry";
 import {
+  ADD_PROJECT_BUTTON_LABEL,
   detectDoubleClick,
   HEADER_OFFSET,
+  isAddProjectButtonPress,
+  isAddProjectButtonTarget,
   isMouseSequence,
   isX10MousePrefix,
   type MouseActionContext,
@@ -18,6 +21,69 @@ import {
   type TreeRow,
 } from "../../src/tui/tree-helpers";
 import { Mode, type PaneInfo, pendingKey } from "../../src/tui/types";
+
+describe("add-project button mouse targeting", () => {
+  test("matches a left click on the right-aligned header button", () => {
+    const columns = 80;
+    const firstButtonColumn = columns - ADD_PROJECT_BUTTON_LABEL.length + 1;
+
+    expect(
+      isAddProjectButtonPress(
+        { kind: "press", button: "left", col: firstButtonColumn, row: 1 },
+        Mode.Navigate,
+        columns,
+      ),
+    ).toBe(true);
+    expect(
+      isAddProjectButtonPress(
+        { kind: "press", button: "left", col: columns, row: 1 },
+        Mode.Navigate,
+        columns,
+      ),
+    ).toBe(true);
+  });
+
+  test("identifies pointer movement over the button for hover styling", () => {
+    expect(
+      isAddProjectButtonTarget(
+        { kind: "move", col: 80, row: 1 },
+        Mode.Navigate,
+        80,
+      ),
+    ).toBe(true);
+    expect(
+      isAddProjectButtonTarget(
+        { kind: "move", col: 73, row: 1 },
+        Mode.Navigate,
+        80,
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects clicks outside the button and while another mode owns input", () => {
+    expect(
+      isAddProjectButtonPress(
+        { kind: "press", button: "left", col: 74, row: 1 },
+        Mode.Navigate,
+        80,
+      ),
+    ).toBe(false);
+    expect(
+      isAddProjectButtonPress(
+        { kind: "press", button: "left", col: 80, row: 2 },
+        Mode.Navigate,
+        80,
+      ),
+    ).toBe(false);
+    expect(
+      isAddProjectButtonPress(
+        { kind: "press", button: "left", col: 80, row: 1 },
+        Mode.AddProjectModal,
+        80,
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("isX10MousePrefix", () => {
   test("matches the legacy X10 report prefix, with or without leading ESC", () => {


### PR DESCRIPTION
## What changed

- add a right-aligned `[+Add]` control to the `wct` TUI title row
- open the existing Add Project modal when the control is clicked
- highlight the control when the mouse pointer hovers over it
- keep header hit-testing aligned with the rendered label width
- add mouse-targeting and real-App layout regression coverage

## Why

The Add Project workflow was available through the `a` shortcut, but it was not discoverable as an on-screen action. This adds a visible mouse-accessible entry point while reusing the existing modal flow.

## Validation

- full hook suite: 940 tests passed after updating the expected header label
- `tests/tui/app-review-fixes.test.tsx`: 8 tests passed
- `git diff --check`
