### PR TITLE
Hide TUI shortcuts behind help modal

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddProjectModal } from "./components/AddProjectModal";
 import { ConfirmModal } from "./components/ConfirmModal";
 import { OpenModal } from "./components/OpenModal";
+import { ShortcutsModal } from "./components/ShortcutsModal";
 import { StatusBar, statusBarRowCount } from "./components/StatusBar";
 import { TreeView } from "./components/TreeView";
 import { UpModal } from "./components/UpModal";
@@ -107,6 +108,7 @@ export function App() {
   const upModalReturnModeRef = useRef<Mode>(Mode.Navigate);
   const upModalReturnSelectedIndexRef = useRef<number>(0);
   const searchReturnModeRef = useRef<Mode>(Mode.Navigate);
+  const shortcutsReturnModeRef = useRef<Mode>(Mode.Navigate);
   const modalReturnModeRef = useRef<Mode>(Mode.Navigate);
   const confirmPendingRef = useRef(false);
   const confirmKillAttemptRef = useRef(0);
@@ -226,7 +228,8 @@ export function App() {
   // would under-count, and the overflowing layout would misalign mouse
   // hit-testing.
   //
-  // True modals replace the StatusBar but budget the SAME virtual row count:
+  // True modals replace the StatusBar but budget the SAME virtual row count
+  // as the now-hidden default shortcut footer (zero, or one repo-error row):
   // viewportRows must not change when a modal opens, or the clamp/keep-visible
   // effects would rewrite a wheel-scrolled offset the user expects back on
   // cancel. Confirmation modals render below the header; the other modals
@@ -752,11 +755,23 @@ export function App() {
         return;
       }
 
+      if (
+        input === "?" &&
+        (mode.type === "Navigate" || mode.type === "Expanded")
+      ) {
+        shortcutsReturnModeRef.current = mode;
+        setMode(Mode.Shortcuts);
+        return;
+      }
+
       switch (mode.type) {
         case "Navigate":
           return handleNavigateInput(navCtx, input, key);
         case "Search":
           return handleSearchInput(input, key);
+        case "Shortcuts":
+          if (key.escape) setMode(shortcutsReturnModeRef.current);
+          return;
         case "OpenModal":
         case "UpModal":
         case "AddProjectModal":
@@ -857,7 +872,12 @@ export function App() {
           its natural height so the tree box above is the only child Yoga
           shrinks. Confirmations render below the header instead. */}
       <Box flexDirection="column" flexShrink={0}>
-        {mode.type === "OpenModal" ? (
+        {mode.type === "Shortcuts" ? (
+          <ShortcutsModal
+            width={Math.min(termCols, 60)}
+            onHide={() => setMode(shortcutsReturnModeRef.current)}
+          />
+        ) : mode.type === "OpenModal" ? (
           <OpenModal
             visible
             width={Math.min(termCols, 60)}

--- a/src/tui/components/ShortcutsModal.tsx
+++ b/src/tui/components/ShortcutsModal.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import { Modal } from "./Modal";
+import { MouseClickable } from "./MouseClickable";
+
+interface Props {
+  width?: number;
+  onHide: () => void;
+}
+
+const SHORTCUTS = [
+  ["↑ / ↓", "navigate"],
+  ["← / →", "collapse / show details"],
+  ["space", "switch or activate"],
+  ["o", "open worktree"],
+  ["u", "start session"],
+  ["d", "stop session"],
+  ["c", "close worktree"],
+  ["a", "add project"],
+  ["/", "search"],
+  ["r", "refresh pull requests"],
+  ["z", "zoom selected pane"],
+  ["x", "kill selected pane"],
+  ["q", "quit"],
+] as const;
+
+export function ShortcutsModal({ width, onHide }: Props) {
+  return (
+    <Modal title="Shortcuts" visible width={width}>
+      <Box flexDirection="column" paddingX={1}>
+        {SHORTCUTS.map(([key, description]) => (
+          <Box key={key}>
+            <Box width={10}>
+              <Text color="cyan">{key}</Text>
+            </Box>
+            <Text>{description}</Text>
+          </Box>
+        ))}
+        <Box marginTop={1}>
+          <MouseClickable onClick={onHide}>
+            {(isHovered) => (
+              <Text bold={isHovered} dimColor={!isHovered}>
+                esc:hide
+              </Text>
+            )}
+          </MouseClickable>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -37,6 +37,7 @@ function getHints(
       ];
     case "Search":
       return ["type to filter", "esc:cancel  enter:done"];
+    case "Shortcuts":
     case "OpenModal":
       return ["", ""];
     case "Expanded":
@@ -87,12 +88,10 @@ function getHints(
  * (and the divider is width-repeated), so width never changes the row count,
  * and searchQuery/selectedPaneRow/hasClient only change text, never lines.
  *
- * True-modal modes (OpenModal/UpModal/AddProjectModal) do not render
- * StatusBar at all — the modal replaces the bottom chrome — but they return
- * the default-branch count anyway: App budgets the tree viewport with this
- * VIRTUAL count so opening a modal does not change viewportRows (which would
- * clamp/re-anchor the scroll state); the modal's extra height is absorbed by
- * the tree box's overflow clipping instead.
+ * Normal navigation has no shortcut footer; it only reserves a row when a
+ * repository error is visible. True-modal modes use that same virtual count,
+ * so opening a modal does not clamp or re-anchor the scroll position. The
+ * modal's extra height is absorbed by the tree box's overflow clipping.
  */
 export function statusBarRowCount(mode: Mode, hasRepoError: boolean): number {
   switch (mode.type) {
@@ -104,9 +103,17 @@ export function statusBarRowCount(mode: Mode, hasRepoError: boolean): number {
     // divider + query line + hint line
     case "Search":
       return 3;
-    // divider + optional repoError + two hint lines
+    // Shortcut and form modals replace the footer. Their virtual count matches
+    // the normal tree footer so opening one does not disturb scroll position.
+    case "Shortcuts":
+    case "OpenModal":
+    case "UpModal":
+    case "AddProjectModal":
+      return hasRepoError ? 1 : 0;
+    // The normal tree only reserves room for an error; shortcuts live in the
+    // on-demand shortcuts modal.
     default:
-      return 3 + (hasRepoError ? 1 : 0);
+      return hasRepoError ? 1 : 0;
   }
 }
 
@@ -166,6 +173,12 @@ export function StatusBar({
         </ChromeLine>
       </Box>
     );
+  }
+
+  if (mode.type === "Navigate" || mode.type === "Expanded") {
+    return repoError ? (
+      <ChromeLine color="yellow">⚠ {toSingleLine(repoError)}</ChromeLine>
+    ) : null;
   }
 
   const [line1, line2] = getHints(

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -6,6 +6,7 @@ import type { SessionIdeDefaults } from "./hooks/useSessionOptionsState";
 export type Mode =
   | { type: "Navigate" }
   | { type: "Search" }
+  | { type: "Shortcuts" }
   | { type: "OpenModal" }
   | { type: "AddProjectModal" }
   | {
@@ -52,6 +53,7 @@ export type Mode =
 export const Mode = {
   Navigate: { type: "Navigate" } as Mode,
   Search: { type: "Search" } as Mode,
+  Shortcuts: { type: "Shortcuts" } as Mode,
   OpenModal: { type: "OpenModal" } as Mode,
   AddProjectModal: { type: "AddProjectModal" } as Mode,
   UpModal: (

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -683,7 +683,7 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
   });
 
   describe("Bug: narrow terminals must not wrap bottom chrome (PR #104 r3520956519)", () => {
-    test("the frame stays within terminal rows when a hint line exceeds the width", async () => {
+    test("the frame stays within terminal rows when an error exceeds the width", async () => {
       registryItems.items = [
         { id: "repo-1", repo_path: repoPath, project: "alpha" },
       ];
@@ -692,13 +692,11 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         ...Array.from({ length: 20 }, (_, i) => worktree(`feature/${i}`)),
       ]);
 
-      // 45 columns: BOTH the Navigate hint line (46 chars without a tmux
-      // client) and the tmux-error line ("No tmux client found — …", 49
-      // chars, always shown in this clientless test env) no longer fit.
-      // Without truncation Ink wraps each onto a second row, the 14-row
-      // budget (2 header + 8 viewport + 4 chrome: tmux error, divider, 2
-      // hints) under-counts, and the overflowing layout clips rows and
-      // misaligns mouse hit-testing.
+      // At 45 columns the tmux-error line ("No tmux client found — …", 49
+      // chars, always shown in this clientless test env) does not fit. Without
+      // truncation Ink wraps it onto a second row, the 14-row budget (2 header
+      // + 11 viewport + 1 error) under-counts, and the overflowing layout
+      // clips rows and misaligns mouse hit-testing.
       const rendered = await renderApp(<App />, 14, 45);
       try {
         await tick(20);
@@ -713,10 +711,10 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         }
         expect(frame.length).toBeLessThanOrEqual(14);
         // The full budgeted layout must actually be present: the last of the
-        // 8 viewport rows (repo, main, feature/0..5) and the second hint
-        // line's tail must both have survived.
-        expect(frame.some((l) => l.includes("feature/5"))).toBe(true);
-        expect(frame[frame.length - 1]).toContain("q:quit");
+        // 11 viewport rows (repo, main, feature/0..8) and the single error
+        // line must both have survived.
+        expect(frame.some((l) => l.includes("feature/8"))).toBe(true);
+        expect(frame[frame.length - 1]).toContain("No tmux client found");
       } finally {
         rendered.unmount();
       }

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -155,6 +155,27 @@ describe("App.tsx review fixes (real App)", () => {
     expect(disableIndex).toBeLessThan(rawModeOffIndex);
   });
 
+  test("q quits while the shortcuts modal is open", async () => {
+    setTallWorktrees(repoPath, 3);
+
+    const rendered = await renderApp(<App />, 24);
+    await tick(20);
+
+    await sendKeys(rendered.stdin, "?");
+    expect(rendered.output()).toContain("Shortcuts");
+    expect(rendered.output()).toContain("quit");
+
+    await sendKeys(rendered.stdin, "q");
+    await rendered.instance.waitUntilExit();
+
+    expect(
+      rendered.events.some(
+        (event) =>
+          event.kind === "write" && event.data.includes(MOUSE_DISABLE),
+      ),
+    ).toBe(true);
+  });
+
   test("legacy X10 mouse bytes are swallowed instead of typed into the Search query", async () => {
     setTallWorktrees(repoPath, 5);
 

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -170,8 +170,7 @@ describe("App.tsx review fixes (real App)", () => {
 
     expect(
       rendered.events.some(
-        (event) =>
-          event.kind === "write" && event.data.includes(MOUSE_DISABLE),
+        (event) => event.kind === "write" && event.data.includes(MOUSE_DISABLE),
       ),
     ).toBe(true);
   });

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -53,46 +53,30 @@ async function renderStatusBar(
 }
 
 describe("StatusBar", () => {
-  test("shows pane hints for expanded pane rows", async () => {
+  test("hides shortcut hints in Expanded mode", async () => {
     const rendered = await renderStatusBar({
       mode: Mode.Expanded("proj/branch"),
       selectedPaneRow: true,
       canCollapse: true,
     });
 
-    expect(rendered.output).toContain(
-      "↑↓:navigate  ←:collapse  space:jump  z:zoom  x:kill",
-    );
-    expect(rendered.output).toContain("/:search  q:quit");
+    expect(rendered.output).not.toContain("↑↓:navigate");
+    expect(rendered.output).not.toContain("space:jump");
+    expect(rendered.lastFrame()).toBe("");
 
     rendered.unmount();
   });
 
-  test("shows generic expanded hints for non-pane rows", async () => {
+  test("hides shortcut hints in Navigate mode", async () => {
     const rendered = await renderStatusBar({
-      mode: Mode.Expanded("proj/branch"),
-      selectedPaneRow: false,
-      canCollapse: true,
+      mode: Mode.Navigate,
+      hasClient: true,
     });
 
-    expect(rendered.output).toContain(
-      "↑↓:navigate  ←:collapse  space:action  o:open  a:add",
-    );
-    expect(rendered.output).toContain(
-      "u:up  d:down  c:close  /:search  q:quit",
-    );
+    expect(rendered.output).not.toContain("↑↓:navigate");
+    expect(rendered.output).not.toContain("q:quit");
+    expect(rendered.lastFrame()).toBe("");
 
-    rendered.unmount();
-  });
-
-  test("hides collapse when the selected row has no expanded owner", async () => {
-    const rendered = await renderStatusBar({
-      mode: Mode.Expanded("proj/branch"),
-      selectedPaneRow: false,
-      canCollapse: false,
-    });
-
-    expect(rendered.output).not.toContain("←:collapse");
     rendered.unmount();
   });
 
@@ -123,72 +107,19 @@ describe("StatusBar", () => {
     rendered.unmount();
   });
 
-  test("hides tmux-mutating hints in Navigate mode when no client", async () => {
-    const rendered = await renderStatusBar({
-      mode: Mode.Navigate,
-      hasClient: false,
-    });
-
-    expect(rendered.output).toContain("↑↓:navigate");
-    expect(rendered.output).toContain("o:open");
-    expect(rendered.output).toContain("a:add");
-    expect(rendered.output).not.toContain("space:switch");
-    expect(rendered.output).toContain("u:up");
-    expect(rendered.output).not.toContain("d:down");
-    expect(rendered.output).toContain("c:close");
-
-    rendered.unmount();
-  });
-
-  test("hides tmux-mutating hints in Expanded mode when no client", async () => {
-    const rendered = await renderStatusBar({
-      mode: Mode.Expanded("proj/branch"),
-      selectedPaneRow: false,
-      hasClient: false,
-    });
-
-    expect(rendered.output).toContain("↑↓:navigate");
-    expect(rendered.output).toContain("o:open");
-    expect(rendered.output).toContain("a:add");
-    expect(rendered.output).not.toContain("space:action");
-    expect(rendered.output).toContain("u:up");
-    expect(rendered.output).not.toContain("d:down");
-    expect(rendered.output).toContain("c:close");
-
-    rendered.unmount();
-  });
-
-  test("hides pane hints in Expanded pane row when no client", async () => {
-    const rendered = await renderStatusBar({
-      mode: Mode.Expanded("proj/branch"),
-      selectedPaneRow: true,
-      hasClient: false,
-    });
-
-    expect(rendered.output).toContain("↑↓:navigate");
-    expect(rendered.output).not.toContain("space:jump");
-    expect(rendered.output).not.toContain("z:zoom");
-    expect(rendered.output).not.toContain("x:kill");
-
-    rendered.unmount();
-  });
-
   // App.tsx budgets bottomChromeRows assuming every StatusBar line occupies
   // exactly one terminal row — a hint or error line wrapping in a narrow
   // terminal would silently overflow the viewport and misalign mouse
   // hit-testing, so these pin the truncate behaviour at widths where the
   // hint text is longer than the terminal.
   describe("narrow terminals (one row per chrome line)", () => {
-    test("Navigate hints truncate instead of wrapping", async () => {
-      // With a client, line1 is ~60 chars — well past 40 columns.
+    test("Navigate renders no footer without an error", async () => {
       const rendered = await renderStatusBar(
         { mode: Mode.Navigate, hasClient: true },
         40,
       );
 
-      // divider + 2 hint lines, regardless of hint text length.
-      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(3);
-      expect(rendered.output).toContain("↑↓:navigate");
+      expect(rendered.lastFrame()).toBe("");
 
       rendered.unmount();
     });
@@ -204,8 +135,7 @@ describe("StatusBar", () => {
         40,
       );
 
-      // divider + repoError + 2 hint lines.
-      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(4);
+      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(1);
       expect(rendered.output).toContain("⚠ gh: HTTP 502");
 
       rendered.unmount();
@@ -224,7 +154,7 @@ describe("StatusBar", () => {
         80,
       );
 
-      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(4);
+      expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(1);
       expect(rendered.output).toContain(
         "⚠ gh: HTTP 502 advice: try again later",
       );
@@ -269,9 +199,9 @@ describe("StatusBar", () => {
           repoError,
         });
 
-        expect(rendered.lastFrame().trimEnd().split("\n")).toHaveLength(
-          statusBarRowCount(mode, Boolean(repoError)),
-        );
+        const frame = rendered.lastFrame().trimEnd();
+        const renderedRows = frame ? frame.split("\n").length : 0;
+        expect(renderedRows).toBe(statusBarRowCount(mode, Boolean(repoError)));
 
         rendered.unmount();
       });


### PR DESCRIPTION
## Summary

- hide the always-visible shortcut legend so the tree can use the full terminal height
- open the shortcuts in the standard modal with `?` and close it with Escape or the `esc:hide` action
- preserve repository error visibility and make the advertised `q:quit` shortcut work from the modal
- update viewport and interaction regression coverage

## Why

The persistent two-line legend consumed valuable tree space even after users knew the shortcuts. Making it on-demand keeps help accessible while improving the default TUI layout.

## Validation

- `bun --bun node_modules/.bin/vitest run tests/tui/app-review-fixes.test.tsx tests/tui/app-mouse-wiring.test.tsx tests/tui/status-bar.test.tsx --reporter=agent`
- 38 tests passed