### PR TITLE
Add selection position indicators

### DIFF
--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -70,7 +70,12 @@ function ModeSelector({
   );
 
   return (
-    <TitledBox title="Select mode" isFocused={true} width={width}>
+    <TitledBox
+      title="Select mode"
+      footer={`${selected + 1} of ${options.length}`}
+      isFocused={true}
+      width={width}
+    >
       {options.map((opt, i) => {
         const isSel = i === selected;
         return (
@@ -428,6 +433,7 @@ export function FromPRForm({
       <Box height={1} />
       <TitledBox
         title="Select PR"
+        footer={`${selectedPRIndex + 1} of ${displayItems.length}`}
         isFocused={currentField === "prList"}
         width={width}
       >
@@ -605,6 +611,11 @@ export function ExistingBranchForm({
       <Box height={1} />
       <TitledBox
         title="Select Branch"
+        footer={
+          filteredBranchItems.length > 0
+            ? `${selectedBranchIndex + 1} of ${filteredBranchItems.length}`
+            : "0 of 0"
+        }
         isFocused={currentField === "branchList"}
         width={width}
       >

--- a/src/tui/components/PathInput.tsx
+++ b/src/tui/components/PathInput.tsx
@@ -183,6 +183,11 @@ export function PathInput({
       {(isHovered) => (
         <TitledBox
           title={title}
+          footer={
+            showCompletions
+              ? `${selectedCompletionIndex + 1} of ${filtered.length}`
+              : undefined
+          }
           isFocused={isFocused}
           isHovered={isHovered}
           width={width}

--- a/src/tui/components/SessionOptionsSection.tsx
+++ b/src/tui/components/SessionOptionsSection.tsx
@@ -102,6 +102,11 @@ export function SessionOptionsSection({
       {profileNames.length > 0 ? (
         <TitledBox
           title={profileQuery ? `Profile filter: ${profileQuery}` : "Profile"}
+          footer={
+            filteredProfiles.length > 0
+              ? `${selectedProfileIndex + 1} of ${filteredProfiles.length}`
+              : "0 of 0"
+          }
           isFocused={focusedField === "profile"}
           width={width}
         >

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -3,6 +3,7 @@ import { Children, type ReactNode } from "react";
 
 interface Props {
   title: string;
+  footer?: string;
   isFocused: boolean;
   width?: number;
   children: ReactNode;
@@ -47,17 +48,24 @@ function topBorder(width: number, title: string) {
   return `╭ ${visibleTitle} ${"─".repeat(dashCount)}╮`;
 }
 
-function bottomBorder(width: number) {
+function bottomBorder(width: number, footer?: string) {
   if (width <= 0) return "";
   if (width === 1) return "╰";
   if (width === 2) return "╰╯";
   if (width === 3) return "╰─╯";
 
-  return `╰${"─".repeat(width - 2)}╯`;
+  if (!footer) return `╰${"─".repeat(width - 2)}╯`;
+
+  const footerWidth = width - 4;
+  const visibleFooter = truncateTitle(footer, footerWidth);
+  const dashCount = Math.max(footerWidth - visibleLength(visibleFooter), 0);
+
+  return `╰${"─".repeat(dashCount)} ${visibleFooter} ╯`;
 }
 
 export function TitledBox({
   title,
+  footer,
   isFocused,
   width,
   children,
@@ -97,7 +105,7 @@ export function TitledBox({
       >
         {normalizedChildren}
       </Box>
-      <Text {...lineProps}>{bottomBorder(boxWidth)}</Text>
+      <Text {...lineProps}>{bottomBorder(boxWidth, footer)}</Text>
     </Box>
   );
 }

--- a/src/tui/components/TitledBox.tsx
+++ b/src/tui/components/TitledBox.tsx
@@ -24,11 +24,11 @@ function visibleLength(value: string) {
   return getGraphemes(value).length;
 }
 
-function truncateTitle(title: string, width: number) {
+function truncateText(value: string, width: number) {
   if (width <= 0) return "";
 
-  const graphemes = getGraphemes(title);
-  if (graphemes.length <= width) return title;
+  const graphemes = getGraphemes(value);
+  if (graphemes.length <= width) return value;
 
   if (width === 1) return "…";
 
@@ -42,7 +42,7 @@ function topBorder(width: number, title: string) {
   if (width === 3) return "╭─╮";
 
   const titleWidth = width - 4;
-  const visibleTitle = truncateTitle(title, titleWidth);
+  const visibleTitle = truncateText(title, titleWidth);
   const dashCount = Math.max(titleWidth - visibleLength(visibleTitle), 0);
 
   return `╭ ${visibleTitle} ${"─".repeat(dashCount)}╮`;
@@ -57,7 +57,7 @@ function bottomBorder(width: number, footer?: string) {
   if (!footer) return `╰${"─".repeat(width - 2)}╯`;
 
   const footerWidth = width - 4;
-  const visibleFooter = truncateTitle(footer, footerWidth);
+  const visibleFooter = truncateText(footer, footerWidth);
   const dashCount = Math.max(footerWidth - visibleLength(visibleFooter), 0);
 
   return `╰${"─".repeat(dashCount)} ${visibleFooter} ╯`;

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -132,6 +132,24 @@ describe("App.tsx review fixes (real App)", () => {
     }
   });
 
+  test("the open mode footer advances with keyboard selection", async () => {
+    setTallWorktrees(repoPath, 3);
+
+    const rendered = await renderApp(<App />, 24);
+    try {
+      await tick(20);
+      await sendKeys(rendered.stdin, "o");
+
+      expect(rendered.output()).toContain("1 of 3");
+
+      await sendKeys(rendered.stdin, "\x1b[B");
+
+      expect(rendered.output()).toContain("2 of 3");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
   test("Ctrl+C disables mouse reporting BEFORE raw mode is turned off, then exits", async () => {
     setTallWorktrees(repoPath, 3);
 

--- a/tests/tui/open-modal.test.tsx
+++ b/tests/tui/open-modal.test.tsx
@@ -28,8 +28,10 @@ function createStdoutStdin() {
   stdout.columns = 100;
   stdout.rows = 32;
   const stdin = new PassThrough() as unknown as TestStdin;
-  stdin.isTTY = false;
+  stdin.isTTY = true;
   stdin.setRawMode = () => stdin;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
   return { stdout, stdin };
 }
 
@@ -72,6 +74,8 @@ async function renderNode(node: React.ReactElement) {
 
   return {
     output: stripAnsi(chunks.join("")),
+    currentOutput: () => stripAnsi(chunks.join("")),
+    stdin,
     unmount() {
       instance.unmount();
     },
@@ -172,6 +176,47 @@ describe("OpenModal form variants", () => {
 
     try {
       expect(rendered.output).toContain("↻ Refresh PRs");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("from PR form updates the position footer for filtered options", async () => {
+    const rendered = await renderNode(
+      <FromPRForm
+        prList={[
+          {
+            number: 1,
+            title: "First PR",
+            state: "OPEN",
+            headRefName: "feat-1",
+            rollupState: null,
+          },
+          {
+            number: 2,
+            title: "Second PR",
+            state: "OPEN",
+            headRefName: "feat-2",
+            rollupState: null,
+          },
+        ]}
+        profileNames={[]}
+        isRefreshing={false}
+        onRefresh={() => {}}
+        onSubmit={() => {}}
+        onBack={() => {}}
+        width={80}
+      />,
+    );
+
+    try {
+      expect(rendered.output).toContain("1 of 3");
+
+      rendered.stdin.write("2");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(rendered.currentOutput()).toContain("1 of 2");
     } finally {
       rendered.unmount();
     }

--- a/tests/tui/titled-box.test.tsx
+++ b/tests/tui/titled-box.test.tsx
@@ -158,6 +158,56 @@ describe("TitledBox", () => {
     }
   });
 
+  test("renders a footer right-aligned in the bottom border", async () => {
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
+
+    try {
+      rendered = await renderTitledBox({
+        title: "Branches",
+        footer: "3 of 208",
+        isFocused: true,
+        width: 28,
+        children: "content",
+      });
+
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
+      const bottomBorder = lines[lines.length - 1];
+
+      expect(bottomBorder).toBe("╰──────────────── 3 of 208 ╯");
+      expect(bottomBorder?.length).toBe(28);
+    } finally {
+      rendered?.unmount();
+    }
+  });
+
+  test("truncates a footer when the box is too narrow", async () => {
+    let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
+
+    try {
+      rendered = await renderTitledBox({
+        title: "Items",
+        footer: "123 of 456",
+        isFocused: true,
+        width: 8,
+        children: "x",
+      });
+
+      const lines = rendered.output
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .filter((line) => line.length > 0);
+      const bottomBorder = lines[lines.length - 1];
+
+      expect(bottomBorder).toBe("╰ 123… ╯");
+      expect(bottomBorder?.length).toBe(8);
+    } finally {
+      rendered?.unmount();
+    }
+  });
+
   test("truncates the title with an ellipsis when the box is too narrow", async () => {
     let rendered: Awaited<ReturnType<typeof renderTitledBox>> | undefined;
 


### PR DESCRIPTION
## Summary

- add lazygit-style `N of M` position indicators to TUI option selectors
- render the indicator inside the bottom-right border with width-aware truncation
- show filtered counts for branch, profile, PR, mode, and path-completion selections

## Why

Long or filtered option lists did not show the selected item’s position or the total number of available choices. The footer gives users immediate context while navigating lists.

## Validation

- added focused rendering coverage for footer alignment and narrow-width truncation
- verified the staged diff with `git diff --check`
- tests and lint were not run manually because repository hooks own those checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination-style position indicators to modal steps and selection menus (e.g., “1 of N”), including updated counts after filtering.
  * Added optional footer text support in titled panels, with right-aligned display and automatic truncation in narrow layouts.
* **Tests**
  * Added/updated regression tests to verify footer alignment, truncation behavior, and that footer position updates correctly during keyboard navigation and filter changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->