### PR TITLE
Add scrollbars and mouse actions to autocomplete lists

### DIFF
--- a/src/tui/components/MouseClickable.tsx
+++ b/src/tui/components/MouseClickable.tsx
@@ -1,16 +1,24 @@
 import { Box, type DOMElement, measureElement } from "ink";
 import { type ReactNode, useRef, useState } from "react";
 import { useGuardedInput } from "../hooks/useGuardedInput";
+import { DOUBLE_CLICK_INTERVAL_MS } from "../input/mouse";
 
 interface Props {
   children: ReactNode | ((isHovered: boolean) => ReactNode);
   onClick: () => void;
+  onDoubleClick?: () => void;
   isActive?: boolean;
 }
 
 /** Hit-test a left mouse press against the rendered bounds of its children. */
-export function MouseClickable({ children, onClick, isActive = true }: Props) {
+export function MouseClickable({
+  children,
+  onClick,
+  onDoubleClick,
+  isActive = true,
+}: Props) {
   const ref = useRef<DOMElement>(null);
+  const lastClickAtRef = useRef<number | null>(null);
   const [isHovered, setIsHovered] = useState(false);
 
   useGuardedInput(() => {}, {
@@ -34,8 +42,25 @@ export function MouseClickable({ children, onClick, isActive = true }: Props) {
         col >= x && col < x + width && row >= y && row < y + height;
       if (event.kind === "move") {
         setIsHovered(isInside);
-      } else if (event.button === "left" && isInside) {
+      } else if (event.button === "left" && !isInside) {
+        // Every clickable sees the same mouse stream. An intervening press on
+        // another target breaks this target's double-click sequence.
+        lastClickAtRef.current = null;
+      } else if (event.button === "left") {
         onClick();
+        if (onDoubleClick) {
+          const now = Date.now();
+          const lastClickAt = lastClickAtRef.current;
+          if (
+            lastClickAt !== null &&
+            now - lastClickAt <= DOUBLE_CLICK_INTERVAL_MS
+          ) {
+            lastClickAtRef.current = null;
+            onDoubleClick();
+          } else {
+            lastClickAtRef.current = now;
+          }
+        }
       }
     },
   });

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -441,11 +441,16 @@ export function FromPRForm({
           items={displayItems}
           selectedIndex={selectedPRIndex}
           filterQuery={filterQuery}
-          maxVisible={8}
+          maxVisible={5}
           isFocused={currentField === "prList"}
           onSelect={(index) => {
             setFocusIndex(fields.indexOf("prList"));
             setSelectedPRIndex(index);
+          }}
+          onDoubleSelect={(index) => {
+            if (index === refreshRowIndex && isRefreshRowSelectable) {
+              onRefresh();
+            }
           }}
         />
       </TitledBox>
@@ -623,7 +628,7 @@ export function ExistingBranchForm({
           items={branchItems}
           selectedIndex={selectedBranchIndex}
           filterQuery={filterQuery}
-          maxVisible={10}
+          maxVisible={5}
           isFocused={currentField === "branchList"}
           onSelect={(index) => {
             setFocusIndex(fields.indexOf("branchList"));

--- a/src/tui/components/PathInput.tsx
+++ b/src/tui/components/PathInput.tsx
@@ -1,11 +1,18 @@
 import { Effect, FileSystem } from "effect";
-import { Text } from "ink";
+import { Box, Text } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useBlink } from "../hooks/useBlink";
 import { useGuardedInput } from "../hooks/useGuardedInput";
 import { runTuiSilentPromise } from "../runtime";
 import { MouseClickable } from "./MouseClickable";
-import { getVisibleWindow, type ListItem } from "./ScrollableList";
+import {
+  clampListScrollOffset,
+  getListPaddingCount,
+  type ListItem,
+  ListPadding,
+  Scrollbar,
+  scrollToRevealListItem,
+} from "./ScrollableList";
 import { TitledBox } from "./TitledBox";
 
 /** Expand leading ~/ or bare ~ to $HOME. Does not expand ~user syntax. */
@@ -32,6 +39,21 @@ export function getParentAndPrefix(input: string): {
   };
 }
 
+/** Apply a selected directory completion while preserving a leading tilde. */
+export function completePathValue(
+  value: string,
+  selectedValue: string,
+): string {
+  const expanded = expandTilde(value);
+  const { parent } = getParentAndPrefix(expanded);
+  const newExpanded = `${parent + selectedValue}/`;
+  const home = process.env.HOME ?? "/tmp";
+  return value.startsWith("~") &&
+    (newExpanded === home || newExpanded.startsWith(`${home}/`))
+    ? `~${newExpanded.slice(home.length)}`
+    : newExpanded;
+}
+
 interface PathInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -52,8 +74,10 @@ export function PathInput({
   const cursorVisible = useBlink();
   const [completions, setCompletions] = useState<ListItem[]>([]);
   const [selectedCompletionIndex, setSelectedCompletionIndex] = useState(0);
+  const [completionScrollOffset, setCompletionScrollOffset] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef<{ cancelled: boolean } | null>(null);
+  const maxVisible = 5;
 
   // Debounced directory listing
   const loadCompletions = useCallback((inputValue: string) => {
@@ -84,10 +108,12 @@ export function PathInput({
         if (token.cancelled) return;
         setCompletions(entries.map((d) => ({ label: d, value: d })));
         setSelectedCompletionIndex(0);
+        setCompletionScrollOffset(0);
       } catch {
         if (token.cancelled) return;
         setCompletions([]);
         setSelectedCompletionIndex(0);
+        setCompletionScrollOffset(0);
       }
     }, 100);
   }, []);
@@ -109,6 +135,15 @@ export function PathInput({
       )
     : completions;
 
+  const completePath = useCallback(
+    (selected: ListItem | undefined) => {
+      if (!selected) return;
+      onChange(completePathValue(value, selected.value));
+      setSelectedCompletionIndex(0);
+    },
+    [onChange, value],
+  );
+
   // Clamp selection when filtered list shrinks
   useEffect(() => {
     if (selectedCompletionIndex >= filtered.length && filtered.length > 0) {
@@ -116,6 +151,23 @@ export function PathInput({
     } else if (filtered.length === 0 && selectedCompletionIndex !== 0) {
       setSelectedCompletionIndex(0);
     }
+  }, [filtered.length, selectedCompletionIndex]);
+
+  const effectiveCompletionScrollOffset = clampListScrollOffset(
+    completionScrollOffset,
+    filtered.length,
+    maxVisible,
+  );
+
+  useEffect(() => {
+    setCompletionScrollOffset((offset) =>
+      scrollToRevealListItem(
+        offset,
+        selectedCompletionIndex,
+        filtered.length,
+        maxVisible,
+      ),
+    );
   }, [filtered.length, selectedCompletionIndex]);
 
   useGuardedInput(
@@ -133,21 +185,7 @@ export function PathInput({
         return;
       }
       if (key.rightArrow && filtered.length > 0) {
-        // Accept completion
-        const selected = filtered[selectedCompletionIndex];
-        if (selected) {
-          const { parent } = getParentAndPrefix(expanded);
-          // Reconstruct with tilde if original used it and path is under HOME
-          const newExpanded = `${parent + selected.value}/`;
-          const home = process.env.HOME ?? "/tmp";
-          const newValue =
-            value.startsWith("~") &&
-            (newExpanded === home || newExpanded.startsWith(`${home}/`))
-              ? `~${newExpanded.slice(home.length)}`
-              : newExpanded;
-          onChange(newValue);
-          setSelectedCompletionIndex(0);
-        }
+        completePath(filtered[selectedCompletionIndex]);
         return;
       }
       if (key.backspace) {
@@ -166,17 +204,30 @@ export function PathInput({
         onChange(value + input);
       }
     },
-    { isActive: isFocused },
+    {
+      isActive: isFocused,
+      onMouseEvent: (event) => {
+        if (event.kind !== "wheel") return;
+        setCompletionScrollOffset((offset) =>
+          clampListScrollOffset(
+            offset + event.dir,
+            filtered.length,
+            maxVisible,
+          ),
+        );
+      },
+    },
   );
 
   const title = isGitRepo ? "Path ✓" : "Path";
   const displayValue = value || (!isFocused || !cursorVisible ? " " : "");
   const showCompletions = isFocused && filtered.length > 0;
-  const maxVisible = 8;
-  const window = showCompletions
-    ? getVisibleWindow(filtered.length, selectedCompletionIndex, maxVisible)
-    : null;
-  const visible = window ? filtered.slice(window.start, window.end) : [];
+  const visible = showCompletions
+    ? filtered.slice(
+        effectiveCompletionScrollOffset,
+        effectiveCompletionScrollOffset + maxVisible,
+      )
+    : [];
 
   return (
     <MouseClickable onClick={() => onFocus?.()}>
@@ -196,18 +247,18 @@ export function PathInput({
             {displayValue}
             {isFocused ? (cursorVisible ? "▎" : " ") : ""}
           </Text>
-          {showCompletions && window && (
-            <>
-              {window.hasAbove && <Text dimColor> ▲</Text>}
-              {visible.map((item, i) => {
-                const actualIndex = window.start + i;
-                const isSelected = actualIndex === selectedCompletionIndex;
-                return (
-                  <MouseClickable
-                    key={item.value}
-                    onClick={() => setSelectedCompletionIndex(actualIndex)}
-                  >
-                    {(isHovered) => (
+          {showCompletions &&
+            visible.map((item, i) => {
+              const actualIndex = effectiveCompletionScrollOffset + i;
+              const isSelected = actualIndex === selectedCompletionIndex;
+              return (
+                <MouseClickable
+                  key={item.value}
+                  onClick={() => setSelectedCompletionIndex(actualIndex)}
+                  onDoubleClick={() => completePath(item)}
+                >
+                  {(isHovered) => (
+                    <Box position="relative" width="100%">
                       <Text
                         color={isSelected || isHovered ? "cyan" : undefined}
                         dimColor={!isSelected && !isHovered}
@@ -216,13 +267,21 @@ export function PathInput({
                         {isSelected ? "▸ " : "  "}
                         {item.label}/
                       </Text>
-                    )}
-                  </MouseClickable>
-                );
-              })}
-              {window.hasBelow && <Text dimColor> ▼</Text>}
-            </>
-          )}
+                      <Box flexGrow={1} />
+                      <Scrollbar
+                        row={i}
+                        totalItems={filtered.length}
+                        visibleItems={visible.length}
+                        windowStart={effectiveCompletionScrollOffset}
+                      />
+                    </Box>
+                  )}
+                </MouseClickable>
+              );
+            })}
+          <ListPadding
+            count={getListPaddingCount(visible.length, maxVisible)}
+          />
         </TitledBox>
       )}
     </MouseClickable>

--- a/src/tui/components/PathInput.tsx
+++ b/src/tui/components/PathInput.tsx
@@ -18,7 +18,7 @@ import { TitledBox } from "./TitledBox";
 /** Expand leading ~/ or bare ~ to $HOME. Does not expand ~user syntax. */
 export function expandTilde(path: string): string {
   if (path === "~" || path.startsWith("~/")) {
-    const home = process.env.HOME ?? "/tmp";
+    const home = Bun.env.HOME ?? "/tmp";
     return home + path.slice(1);
   }
   return path;
@@ -47,7 +47,7 @@ export function completePathValue(
   const expanded = expandTilde(value);
   const { parent } = getParentAndPrefix(expanded);
   const newExpanded = `${parent + selectedValue}/`;
-  const home = process.env.HOME ?? "/tmp";
+  const home = Bun.env.HOME ?? "/tmp";
   return value.startsWith("~") &&
     (newExpanded === home || newExpanded.startsWith(`${home}/`))
     ? `~${newExpanded.slice(home.length)}`

--- a/src/tui/components/ScrollableList.tsx
+++ b/src/tui/components/ScrollableList.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from "ink";
+import { useEffect, useRef, useState } from "react";
 import { useBlink } from "../hooks/useBlink";
+import { useGuardedInput } from "../hooks/useGuardedInput";
 import { MouseClickable } from "./MouseClickable";
 
 export interface ListItem {
@@ -43,6 +45,85 @@ export function getVisibleWindow(
   };
 }
 
+export function clampListScrollOffset(
+  offset: number,
+  totalItems: number,
+  maxVisible: number,
+): number {
+  return Math.max(0, Math.min(offset, Math.max(0, totalItems - maxVisible)));
+}
+
+export function getListPaddingCount(
+  renderedRows: number,
+  maxVisible: number,
+): number {
+  return Math.max(0, maxVisible - renderedRows);
+}
+
+export function ListPadding({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return <Box height={count} />;
+}
+
+/** Move a viewport only as far as needed to reveal the selected item. */
+export function scrollToRevealListItem(
+  offset: number,
+  selectedIndex: number,
+  totalItems: number,
+  maxVisible: number,
+): number {
+  const clamped = clampListScrollOffset(offset, totalItems, maxVisible);
+  if (selectedIndex < clamped) return Math.max(0, selectedIndex);
+  if (selectedIndex >= clamped + maxVisible) {
+    return clampListScrollOffset(
+      selectedIndex - maxVisible + 1,
+      totalItems,
+      maxVisible,
+    );
+  }
+  return clamped;
+}
+
+/** Compute the start-inclusive/end-exclusive rows of a proportional thumb. */
+export function getScrollbarThumb(
+  totalItems: number,
+  visibleItems: number,
+  windowStart: number,
+): { start: number; end: number } | null {
+  if (totalItems <= visibleItems || visibleItems <= 0) return null;
+
+  const size = Math.max(
+    1,
+    Math.round((visibleItems / totalItems) * visibleItems),
+  );
+  const maxThumbStart = visibleItems - size;
+  const maxWindowStart = totalItems - visibleItems;
+  const start = Math.round((windowStart / maxWindowStart) * maxThumbStart);
+  return { start, end: start + size };
+}
+
+export function Scrollbar({
+  row,
+  totalItems,
+  visibleItems,
+  windowStart,
+}: {
+  row: number;
+  totalItems: number;
+  visibleItems: number;
+  windowStart: number;
+}) {
+  const thumb = getScrollbarThumb(totalItems, visibleItems, windowStart);
+  if (!thumb) return null;
+  const isThumb = row >= thumb.start && row < thumb.end;
+  if (!isThumb) return null;
+  return (
+    <Box position="absolute" right={-1}>
+      <Text color="cyan">█</Text>
+    </Box>
+  );
+}
+
 interface Props {
   items: ListItem[];
   selectedIndex: number;
@@ -50,73 +131,132 @@ interface Props {
   maxVisible?: number;
   isFocused: boolean;
   onSelect?: (index: number) => void;
+  onDoubleSelect?: (index: number) => void;
 }
 
 export function ScrollableList({
   items,
   selectedIndex,
   filterQuery,
-  maxVisible = 10,
+  maxVisible = 5,
   isFocused,
   onSelect,
+  onDoubleSelect,
 }: Props) {
   const cursorVisible = useBlink();
   const filtered = filterItems(items, filterQuery);
-  const { start, end, hasAbove, hasBelow } = getVisibleWindow(
-    filtered.length,
-    selectedIndex,
-    maxVisible,
+  const filterStateKey = JSON.stringify([
+    filterQuery,
+    filtered.map((item) => item.value),
+  ]);
+  const previousFilterStateKeyRef = useRef(filterStateKey);
+  const showFilter = isFocused && filterQuery.length > 0;
+  const visibleCapacity = Math.max(0, maxVisible - (showFilter ? 1 : 0));
+  const [scrollOffset, setScrollOffset] = useState(
+    () =>
+      getVisibleWindow(filtered.length, selectedIndex, visibleCapacity).start,
   );
-  const visible = filtered.slice(start, end);
+  const effectiveScrollOffset = clampListScrollOffset(
+    scrollOffset,
+    filtered.length,
+    visibleCapacity,
+  );
+  const visible = filtered.slice(
+    effectiveScrollOffset,
+    effectiveScrollOffset + visibleCapacity,
+  );
+
+  useEffect(() => {
+    const filterContentsChanged =
+      previousFilterStateKeyRef.current !== filterStateKey;
+    previousFilterStateKeyRef.current = filterStateKey;
+    setScrollOffset((offset) =>
+      scrollToRevealListItem(
+        filterContentsChanged ? 0 : offset,
+        selectedIndex,
+        filtered.length,
+        visibleCapacity,
+      ),
+    );
+  }, [filtered.length, filterStateKey, selectedIndex, visibleCapacity]);
+
+  useGuardedInput(() => {}, {
+    isActive: isFocused && Boolean(onSelect || onDoubleSelect),
+    onMouseEvent: (event) => {
+      if (event.kind !== "wheel") return;
+      setScrollOffset((offset) =>
+        clampListScrollOffset(
+          offset + event.dir,
+          filtered.length,
+          visibleCapacity,
+        ),
+      );
+    },
+  });
 
   return (
     <Box flexDirection="column">
-      {hasAbove && <Text dimColor> ▲</Text>}
-      {visible.map((item, i) => {
-        const actualIndex = start + i;
-        const isSelected = actualIndex === selectedIndex;
-        return (
-          <MouseClickable
-            key={item.value}
-            onClick={() => onSelect?.(actualIndex)}
-            isActive={Boolean(onSelect)}
-          >
-            {(isHovered) => (
-              <Box>
-                <Text
-                  color={
-                    (isSelected && isFocused) || isHovered ? "cyan" : undefined
-                  }
-                >
-                  {isSelected ? "▸ " : "  "}
-                </Text>
-                <Text
-                  bold={isSelected || isHovered}
-                  dimColor={!isSelected && !isHovered}
-                  wrap="truncate"
-                >
-                  {item.label}
-                </Text>
-                {item.description && (
-                  <Text dimColor wrap="truncate">
-                    {" "}
-                    {item.description}
-                  </Text>
-                )}
-              </Box>
-            )}
-          </MouseClickable>
-        );
-      })}
-      {hasBelow && <Text dimColor> ▼</Text>}
-      {filtered.length === 0 && <Text dimColor> No matches</Text>}
-      {isFocused && filterQuery && (
+      {showFilter && (
         <Text dimColor>
           {" "}
           filter: {filterQuery}
           {cursorVisible ? "▎" : " "}
         </Text>
       )}
+      {visible.map((item, i) => {
+        const actualIndex = effectiveScrollOffset + i;
+        const isSelected = actualIndex === selectedIndex;
+        return (
+          <MouseClickable
+            key={item.value}
+            onClick={() => onSelect?.(actualIndex)}
+            onDoubleClick={() => onDoubleSelect?.(actualIndex)}
+            isActive={Boolean(onSelect || onDoubleSelect)}
+          >
+            {(isHovered) => (
+              <Box position="relative" width="100%">
+                <Box flexGrow={1}>
+                  <Text
+                    color={
+                      (isSelected && isFocused) || isHovered
+                        ? "cyan"
+                        : undefined
+                    }
+                  >
+                    {isSelected ? "▸ " : "  "}
+                  </Text>
+                  <Text
+                    bold={isSelected || isHovered}
+                    dimColor={!isSelected && !isHovered}
+                    wrap="truncate"
+                  >
+                    {item.label}
+                  </Text>
+                  {item.description && (
+                    <Text dimColor wrap="truncate">
+                      {" "}
+                      {item.description}
+                    </Text>
+                  )}
+                </Box>
+                <Scrollbar
+                  row={i}
+                  totalItems={filtered.length}
+                  visibleItems={visible.length}
+                  windowStart={effectiveScrollOffset}
+                />
+              </Box>
+            )}
+          </MouseClickable>
+        );
+      })}
+      {filtered.length === 0 && <Text dimColor> No matches</Text>}
+      <ListPadding
+        count={getListPaddingCount(
+          (showFilter ? 1 : 0) + (filtered.length === 0 ? 1 : visible.length),
+          maxVisible,
+        )}
+      />
     </Box>
   );
 }

--- a/src/tui/components/SessionOptionsSection.tsx
+++ b/src/tui/components/SessionOptionsSection.tsx
@@ -115,7 +115,7 @@ export function SessionOptionsSection({
             selectedIndex={selectedProfileIndex}
             filterQuery={profileQuery}
             isFocused={focusedField === "profile"}
-            maxVisible={6}
+            maxVisible={5}
             onSelect={(index) => {
               onFocusField("profile");
               setSelectedProfileIndex(index);

--- a/tests/tui/modal-mouse-guard.test.tsx
+++ b/tests/tui/modal-mouse-guard.test.tsx
@@ -191,8 +191,8 @@ describe("modal mouse controls", () => {
 
     try {
       await sendKeys(rendered.stdin, "feature-x");
-      // Submit text follows the profile box, spacer, and Auto-switch toggle.
-      await sendKeys(rendered.stdin, click(5, 16));
+      // The five-row profile box is followed by a spacer and Auto-switch.
+      await sendKeys(rendered.stdin, click(5, 19));
 
       expect(onSubmitMock).toHaveBeenCalledTimes(1);
       expect(onSubmitMock).toHaveBeenCalledWith(
@@ -209,7 +209,7 @@ describe("modal mouse controls", () => {
 
     try {
       await sendKeys(rendered.stdin, "feature-x");
-      const submitClick = click(5, 16);
+      const submitClick = click(5, 19);
       await sendKeys(rendered.stdin, `${submitClick}${submitClick}`);
 
       expect(onSubmitMock).toHaveBeenCalledTimes(1);
@@ -224,7 +224,7 @@ describe("modal mouse controls", () => {
 
     try {
       await sendKeys(rendered.stdin, "feature-x");
-      await sendKeys(rendered.stdin, click(5, 14));
+      await sendKeys(rendered.stdin, click(5, 17));
 
       expect(onSubmitMock).not.toHaveBeenCalled();
     } finally {
@@ -237,7 +237,7 @@ describe("modal mouse controls", () => {
     const rendered = await renderNewBranchForm(onSubmitMock);
 
     try {
-      await sendKeys(rendered.stdin, click(5, 16));
+      await sendKeys(rendered.stdin, click(5, 19));
       expect(onSubmitMock).not.toHaveBeenCalled();
     } finally {
       rendered.unmount();

--- a/tests/tui/mouse-clickable.test.tsx
+++ b/tests/tui/mouse-clickable.test.tsx
@@ -64,4 +64,49 @@ describe("MouseClickable", () => {
       rendered.unmount();
     }
   });
+
+  test("invokes the double-click action after two quick clicks", async () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    const rendered = await renderWithInput(
+      <MouseClickable onClick={onClick} onDoubleClick={onDoubleClick}>
+        <Text>target</Text>
+      </MouseClickable>,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, click(1, 1));
+      expect(onDoubleClick).not.toHaveBeenCalled();
+
+      await sendKeys(rendered.stdin, click(1, 1));
+      expect(onClick).toHaveBeenCalledTimes(2);
+      expect(onDoubleClick).toHaveBeenCalledTimes(1);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("does not treat clicks separated by another target as a double-click", async () => {
+    const firstDoubleClick = vi.fn();
+    const rendered = await renderWithInput(
+      <Box flexDirection="column">
+        <MouseClickable onClick={() => {}} onDoubleClick={firstDoubleClick}>
+          <Text>first</Text>
+        </MouseClickable>
+        <MouseClickable onClick={() => {}}>
+          <Text>second</Text>
+        </MouseClickable>
+      </Box>,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, click(1, 1));
+      await sendKeys(rendered.stdin, click(1, 2));
+      await sendKeys(rendered.stdin, click(1, 1));
+
+      expect(firstDoubleClick).not.toHaveBeenCalled();
+    } finally {
+      rendered.unmount();
+    }
+  });
 });

--- a/tests/tui/open-modal.test.tsx
+++ b/tests/tui/open-modal.test.tsx
@@ -181,6 +181,41 @@ describe("OpenModal form variants", () => {
     }
   });
 
+  test("double-clicking the Refresh row triggers refresh once", async () => {
+    const onRefresh = vi.fn();
+    const rendered = await renderNode(
+      <FromPRForm
+        prList={[
+          {
+            number: 1,
+            title: "First PR",
+            state: "OPEN",
+            headRefName: "feat-1",
+            rollupState: null,
+          },
+        ]}
+        profileNames={[]}
+        isRefreshing={false}
+        onRefresh={onRefresh}
+        onSubmit={() => {}}
+        onBack={() => {}}
+        width={80}
+      />,
+    );
+
+    try {
+      const refreshClick = "\x1b[<0;5;5M";
+      rendered.stdin.write(refreshClick);
+      rendered.stdin.write(refreshClick);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
   test("from PR form updates the position footer for filtered options", async () => {
     const rendered = await renderNode(
       <FromPRForm

--- a/tests/tui/path-input.test.tsx
+++ b/tests/tui/path-input.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  completePathValue,
   expandTilde,
   getParentAndPrefix,
 } from "../../src/tui/components/PathInput";
@@ -55,5 +56,17 @@ describe("expandTilde", () => {
 
   test("returns path unchanged if no tilde", () => {
     expect(expandTilde("/usr/local")).toBe("/usr/local");
+  });
+});
+
+describe("completePathValue", () => {
+  test("completes a directory and appends a slash", () => {
+    expect(completePathValue("/Users/dmtr/co", "code")).toBe(
+      "/Users/dmtr/code/",
+    );
+  });
+
+  test("preserves a leading tilde", () => {
+    expect(completePathValue("~/co", "code")).toBe("~/code/");
   });
 });

--- a/tests/tui/scrollable-list-mouse.test.tsx
+++ b/tests/tui/scrollable-list-mouse.test.tsx
@@ -1,0 +1,168 @@
+import { Box } from "ink";
+import { useState } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { ScrollableList } from "../../src/tui/components/ScrollableList";
+import { TitledBox } from "../../src/tui/components/TitledBox";
+import { useGuardedInput } from "../../src/tui/hooks/useGuardedInput";
+import { renderWithInput, sendKeys } from "./keypress-harness";
+
+const wheelDown = "\x1b[<65;1;1M";
+const click = (col: number, row: number) => `\x1b[<0;${col};${row}M`;
+const sameCountFilterItems = [
+  "a0",
+  "a1",
+  "a2",
+  "a3",
+  "a4",
+  "a5",
+  "b0",
+  "b1",
+  "b2",
+  "b3",
+  "b4",
+  "b5",
+].map((value) => ({ label: value, value }));
+
+function SameCountFilterList({
+  onSelect,
+}: {
+  onSelect: (index: number) => void;
+}) {
+  const [filterQuery, setFilterQuery] = useState("a");
+  useGuardedInput((input) => {
+    if (input === "b") setFilterQuery("b");
+  });
+  return (
+    <ScrollableList
+      items={sameCountFilterItems}
+      selectedIndex={0}
+      filterQuery={filterQuery}
+      isFocused
+      onSelect={onSelect}
+    />
+  );
+}
+
+describe("ScrollableList mouse input", () => {
+  test("shows five options by default and overlays the thumb on the border", async () => {
+    const items = Array.from({ length: 6 }, (_, index) => ({
+      label: `item ${index}`,
+      value: String(index),
+    }));
+    const rendered = await renderWithInput(
+      <TitledBox title="Items" isFocused width={24}>
+        <ScrollableList
+          items={items}
+          selectedIndex={0}
+          filterQuery=""
+          isFocused
+          onSelect={() => {}}
+        />
+      </TitledBox>,
+    );
+
+    try {
+      expect(rendered.output()).toContain("item 4");
+      expect(rendered.output()).not.toContain("item 5");
+      expect(rendered.output()).toMatch(/item 0 +█/);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("uses the first of five rows for an active filter", async () => {
+    const items = Array.from({ length: 6 }, (_, index) => ({
+      label: `item ${index}`,
+      value: String(index),
+    }));
+    const rendered = await renderWithInput(
+      <ScrollableList
+        items={items}
+        selectedIndex={0}
+        filterQuery="item"
+        isFocused
+        onSelect={() => {}}
+      />,
+    );
+
+    try {
+      const output = rendered.output();
+      expect(output.indexOf("filter: item")).toBeLessThan(
+        output.indexOf("item 0"),
+      );
+      expect(output).toContain("item 3");
+      expect(output).not.toContain("item 4");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("scrolls the focused viewport without changing selection", async () => {
+    const onSelect = vi.fn();
+    const items = Array.from({ length: 10 }, (_, index) => ({
+      label: `item ${index}`,
+      value: String(index),
+    }));
+    const rendered = await renderWithInput(
+      <Box width={30}>
+        <ScrollableList
+          items={items}
+          selectedIndex={2}
+          filterQuery=""
+          maxVisible={4}
+          isFocused
+          onSelect={onSelect}
+        />
+      </Box>,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, wheelDown);
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(rendered.output()).toContain("item 4");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("re-reveals selection when filter contents change at the same count", async () => {
+    const onSelect = vi.fn();
+    const rendered = await renderWithInput(
+      <SameCountFilterList onSelect={onSelect} />,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, wheelDown);
+      await sendKeys(rendered.stdin, wheelDown);
+      await sendKeys(rendered.stdin, "b");
+      await sendKeys(rendered.stdin, click(1, 2));
+
+      expect(onSelect).toHaveBeenCalledWith(0);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("ignores wheel input while unfocused", async () => {
+    const onSelect = vi.fn();
+    const rendered = await renderWithInput(
+      <ScrollableList
+        items={[
+          { label: "one", value: "one" },
+          { label: "two", value: "two" },
+        ]}
+        selectedIndex={0}
+        filterQuery=""
+        isFocused={false}
+        onSelect={onSelect}
+      />,
+    );
+
+    try {
+      await sendKeys(rendered.stdin, wheelDown);
+      expect(onSelect).not.toHaveBeenCalled();
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/tests/tui/scrollable-list-mouse.test.tsx
+++ b/tests/tui/scrollable-list-mouse.test.tsx
@@ -144,23 +144,23 @@ describe("ScrollableList mouse input", () => {
   });
 
   test("ignores wheel input while unfocused", async () => {
-    const onSelect = vi.fn();
     const rendered = await renderWithInput(
       <ScrollableList
-        items={[
-          { label: "one", value: "one" },
-          { label: "two", value: "two" },
-        ]}
+        items={Array.from({ length: 6 }, (_, index) => ({
+          label: `item ${index}`,
+          value: String(index),
+        }))}
         selectedIndex={0}
         filterQuery=""
         isFocused={false}
-        onSelect={onSelect}
+        onSelect={() => {}}
       />,
     );
 
     try {
+      const initiallyVisible = rendered.output().match(/item \d+/g);
       await sendKeys(rendered.stdin, wheelDown);
-      expect(onSelect).not.toHaveBeenCalled();
+      expect(rendered.output().match(/item \d+/g)).toEqual(initiallyVisible);
     } finally {
       rendered.unmount();
     }

--- a/tests/tui/scrollable-list.test.ts
+++ b/tests/tui/scrollable-list.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
 import {
+  clampListScrollOffset,
   filterItems,
+  getListPaddingCount,
+  getScrollbarThumb,
   getVisibleWindow,
+  scrollToRevealListItem,
 } from "../../src/tui/components/ScrollableList";
 
 describe("filterItems", () => {
@@ -66,5 +70,42 @@ describe("getVisibleWindow", () => {
       hasAbove: true,
       hasBelow: false,
     });
+  });
+});
+
+describe("getScrollbarThumb", () => {
+  test("hides the scrollbar when every item fits", () => {
+    expect(getScrollbarThumb(8, 8, 0)).toBeNull();
+    expect(getScrollbarThumb(3, 8, 0)).toBeNull();
+  });
+
+  test("places the thumb at the start and end of an overflowing list", () => {
+    expect(getScrollbarThumb(20, 8, 0)).toEqual({ start: 0, end: 3 });
+    expect(getScrollbarThumb(20, 8, 12)).toEqual({ start: 5, end: 8 });
+  });
+
+  test("keeps a usable one-row thumb for very long lists", () => {
+    expect(getScrollbarThumb(209, 8, 100)).toEqual({ start: 3, end: 4 });
+  });
+});
+
+describe("list scroll offsets", () => {
+  test("clamps offsets to the scrollable range", () => {
+    expect(clampListScrollOffset(-1, 20, 8)).toBe(0);
+    expect(clampListScrollOffset(99, 20, 8)).toBe(12);
+  });
+
+  test("reveals keyboard and click selections with minimal movement", () => {
+    expect(scrollToRevealListItem(4, 3, 20, 8)).toBe(3);
+    expect(scrollToRevealListItem(4, 12, 20, 8)).toBe(5);
+    expect(scrollToRevealListItem(4, 8, 20, 8)).toBe(4);
+  });
+});
+
+describe("getListPaddingCount", () => {
+  test("reserves five option rows for short and empty lists", () => {
+    expect(getListPaddingCount(0, 5)).toBe(5);
+    expect(getListPaddingCount(1, 5)).toBe(4);
+    expect(getListPaddingCount(5, 5)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- keep select and path autocomplete layouts at a stable five-row height
- add independent mouse-wheel viewport scrolling with a proportional thumb overlaid on the right border
- move active select filters into the first visible row without changing component height
- support click selection, path completion on double-click, and PR refresh on double-click
- preserve selection while scrolling and re-reveal it when filtered contents change
- make double-click detection require consecutive clicks on the same target

## Why

Long option lists previously relied on triangle indicators, changed modal height as their contents changed, and lacked consistent mouse interactions. The new behavior keeps layouts stable while making overflow, navigation, completion, and refresh actions discoverable and usable with the mouse.

## Validation

- Biome checks passed through the repository hooks
- Vitest suite passed through the repository hooks
- added regression coverage for scrollbar sizing and placement, fixed-height padding, wheel scrolling, same-count filter changes, click targeting, double-click sequencing, path completion, and PR refresh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added double-click interactions for clickable controls and selectable lists.
  - Double-clicking the refresh option now refreshes available pull requests.
  - Added scrollbars, mouse-wheel scrolling, and automatic selection visibility for lists.
  - Improved path completion, including preservation of `~` home-directory notation.

- **Bug Fixes**
  - Prevented double-clicks from carrying across different clickable targets.
  - Updated modal interactions for revised list layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->