### PR TITLE
Make modal escape shortcuts clickable

### DIFF
--- a/src/tui/components/AddProjectModal.tsx
+++ b/src/tui/components/AddProjectModal.tsx
@@ -7,6 +7,7 @@ import { useGuardedInput } from "../hooks/useGuardedInput";
 import { runTuiSilentPromise } from "../runtime";
 import { isSubmitShortcut, SubmitButton } from "./form-controls";
 import { Modal } from "./Modal";
+import { ModalShortcut } from "./ModalShortcut";
 import { MouseClickable } from "./MouseClickable";
 import { expandTilde, PathInput } from "./PathInput";
 import { TitledBox } from "./TitledBox";
@@ -204,8 +205,9 @@ export function AddProjectModal({
         />
         <Box marginTop={1}>
           <Text dimColor>
-            {"tab:next  shift+tab:prev  →:complete  enter:confirm  esc:cancel"}
+            {"tab:next  shift+tab:prev  →:complete  enter:confirm  "}
           </Text>
+          <ModalShortcut label="esc:close" onClick={onCancel} />
         </Box>
       </Box>
     </Modal>

--- a/src/tui/components/ModalShortcut.tsx
+++ b/src/tui/components/ModalShortcut.tsx
@@ -1,0 +1,20 @@
+import { Text } from "ink";
+import { MouseClickable } from "./MouseClickable";
+
+interface Props {
+  label: string;
+  onClick: () => void;
+}
+
+/** Clickable modal shortcut legend with the shared hover treatment. */
+export function ModalShortcut({ label, onClick }: Props) {
+  return (
+    <MouseClickable onClick={onClick}>
+      {(isHovered) => (
+        <Text bold={isHovered} dimColor={!isHovered}>
+          {label}
+        </Text>
+      )}
+    </MouseClickable>
+  );
+}

--- a/src/tui/components/OpenModal.tsx
+++ b/src/tui/components/OpenModal.tsx
@@ -8,6 +8,7 @@ import { tuiRuntime } from "../runtime";
 import type { PRInfo } from "../types";
 import { isSubmitShortcut } from "./form-controls";
 import { Modal } from "./Modal";
+import { ModalShortcut } from "./ModalShortcut";
 import { MouseClickable } from "./MouseClickable";
 import { filterItems, type ListItem, ScrollableList } from "./ScrollableList";
 import { SessionOptionsSection } from "./SessionOptionsSection";
@@ -699,6 +700,7 @@ export function OpenModal({
     abortControllerRef.current?.abort();
     onCancel();
   };
+  const handleBack = () => setStep("selector");
 
   if (!visible) return null;
 
@@ -725,7 +727,7 @@ export function OpenModal({
           defaultBase={defaultBase}
           profileNames={profileNames}
           onSubmit={onSubmit}
-          onBack={() => setStep("selector")}
+          onBack={handleBack}
           width={innerWidth}
         />
       )}
@@ -736,7 +738,7 @@ export function OpenModal({
           isRefreshing={isRefreshing}
           onRefresh={() => onRefresh(abortControllerRef.current?.signal)}
           onSubmit={onSubmit}
-          onBack={() => setStep("selector")}
+          onBack={handleBack}
           width={innerWidth}
         />
       )}
@@ -745,16 +747,20 @@ export function OpenModal({
           repoPath={repoPath}
           profileNames={profileNames}
           onSubmit={onSubmit}
-          onBack={() => setStep("selector")}
+          onBack={handleBack}
           width={innerWidth}
         />
       )}
       <Box marginTop={1}>
         <Text dimColor>
           {step === "selector"
-            ? "↑↓:select  enter:confirm  esc:cancel"
-            : "tab:next  shift+tab:prev  esc:back"}
+            ? "↑↓:select  enter:confirm  "
+            : "tab:next  shift+tab:prev  "}
         </Text>
+        <ModalShortcut
+          label={step === "selector" ? "esc:close" : "esc:back"}
+          onClick={step === "selector" ? handleCancel : handleBack}
+        />
       </Box>
     </Modal>
   );

--- a/src/tui/components/ShortcutsModal.tsx
+++ b/src/tui/components/ShortcutsModal.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import { Modal } from "./Modal";
-import { MouseClickable } from "./MouseClickable";
+import { ModalShortcut } from "./ModalShortcut";
 
 interface Props {
   width?: number;
@@ -36,13 +36,7 @@ export function ShortcutsModal({ width, onHide }: Props) {
           </Box>
         ))}
         <Box marginTop={1}>
-          <MouseClickable onClick={onHide}>
-            {(isHovered) => (
-              <Text bold={isHovered} dimColor={!isHovered}>
-                esc:hide
-              </Text>
-            )}
-          </MouseClickable>
+          <ModalShortcut label="esc:close" onClick={onHide} />
         </Box>
       </Box>
     </Modal>

--- a/src/tui/components/UpModal.tsx
+++ b/src/tui/components/UpModal.tsx
@@ -4,6 +4,7 @@ import { useGuardedInput } from "../hooks/useGuardedInput";
 import { useSessionOptionsState } from "../hooks/useSessionOptionsState";
 import { isSubmitShortcut } from "./form-controls";
 import { Modal } from "./Modal";
+import { ModalShortcut } from "./ModalShortcut";
 import { SessionOptionsSection } from "./SessionOptionsSection";
 import { resolveSessionOptionsSubmitState } from "./session-options";
 
@@ -113,7 +114,10 @@ export function UpModal({
           width={width ? width - 2 : undefined}
         />
         <Box height={1} />
-        <Text dimColor>{"tab:next  shift+tab:prev  esc:cancel"}</Text>
+        <Box>
+          <Text dimColor>{"tab:next  shift+tab:prev  "}</Text>
+          <ModalShortcut label="esc:close" onClick={onCancel} />
+        </Box>
       </Box>
     </Modal>
   );

--- a/tests/tui/modal-shortcut.test.tsx
+++ b/tests/tui/modal-shortcut.test.tsx
@@ -1,0 +1,34 @@
+import { Text } from "ink";
+import type React from "react";
+import { describe, expect, test, vi } from "vitest";
+import { ModalShortcut } from "../../src/tui/components/ModalShortcut";
+import { MouseClickable } from "../../src/tui/components/MouseClickable";
+
+describe("ModalShortcut", () => {
+  test("forwards clicks and highlights the legend on hover", () => {
+    const onClick = vi.fn();
+    const shortcut = ModalShortcut({ label: "esc:back", onClick });
+
+    expect(shortcut.type).toBe(MouseClickable);
+    shortcut.props.onClick();
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    const renderLegend = shortcut.props.children as (
+      isHovered: boolean,
+    ) => React.ReactElement;
+    const idle = renderLegend(false);
+    const hovered = renderLegend(true);
+
+    expect(idle.type).toBe(Text);
+    expect(idle.props).toMatchObject({
+      children: "esc:back",
+      bold: false,
+      dimColor: true,
+    });
+    expect(hovered.props).toMatchObject({
+      children: "esc:back",
+      bold: true,
+      dimColor: false,
+    });
+  });
+});

--- a/tests/tui/open-modal.test.tsx
+++ b/tests/tui/open-modal.test.tsx
@@ -483,4 +483,34 @@ describe("OpenModal", () => {
       rendered.unmount();
     }
   });
+
+  test("shows close at the selector and back in a nested form", async () => {
+    const rendered = await renderNode(
+      <OpenModal
+        visible
+        width={60}
+        defaultBase="main"
+        profileNames={[]}
+        repoProject="myproj"
+        repoPath="/repo"
+        prList={[]}
+        isRefreshing={false}
+        onRefresh={() => {}}
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    try {
+      expect(rendered.currentOutput()).toContain("esc:close");
+
+      rendered.stdin.write("\r");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(rendered.currentOutput()).toContain("esc:back");
+    } finally {
+      rendered.unmount();
+    }
+  });
 });


### PR DESCRIPTION
## What changed

- add a shared clickable modal shortcut legend with hover styling
- make `esc:close` clickable in the Open, Up, Add Project, and Shortcuts modals
- make `esc:back` clickable in nested Open Worktree forms
- route clicks through the same callbacks used by the Escape key
- add coverage for click forwarding, hover styling, and Open modal legend transitions

## Why

Modal shortcut legends looked actionable but only worked from the keyboard. Making them clickable gives mouse users consistent behavior while preserving the existing Escape-key paths.

## Validation

- reviewer found no actionable correctness regressions
- `git diff --check` passed
- tests and lint were not run manually because repository hooks own those checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent, interactive Escape shortcut controls across modal dialogs.
  * Escape actions now clearly indicate whether they close, hide, cancel, or return to the previous step.
  * Shortcut labels respond visually when hovered.

* **Bug Fixes**
  * Improved navigation clarity when moving between modal steps.

* **Tests**
  * Added coverage for shortcut interactions, hover styling, and modal navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->