### PR TITLE
Anchor confirmation modals to target rows

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -278,9 +278,6 @@ export function App() {
     viewportRows,
   );
 
-  // Capture the reading position once, before the anchored-modal effect below
-  // scrolls the viewport. Cancellation restores this exact tree viewport so a
-  // detail row that sits below the modal does not remain selected off-screen.
   useEffect(() => {
     const isConfirming = confirmationMode !== null;
     if (isConfirming && !wasConfirmingRef.current) {
@@ -426,10 +423,6 @@ export function App() {
     );
   }, [selectionRowIndex, viewportRows, selectionChanged]);
 
-  // Confirmation rows must be wholly visible so the prompt and both actions
-  // cannot open below the viewport. This runs after selection anchoring and
-  // wins only while a confirmation is present; wheel/tree input is inert in
-  // confirmation modes, so the modal remains on screen until it is resolved.
   useEffect(() => {
     if (!confirmationRange) return;
     setScrollOffset((prev) =>
@@ -441,9 +434,6 @@ export function App() {
     );
   }, [confirmationRange, rows.length, viewportRows]);
 
-  // A refresh can remove the worktree/pane being confirmed. Leave the stale
-  // confirmation immediately: without an anchor it cannot be rendered, and
-  // Enter must not remain capable of executing an action against stale data.
   useEffect(() => {
     if (!confirmationMode || confirmationAnchorItemIndex !== null) return;
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -3,7 +3,7 @@
 import { Box, type Key, render, Text, useApp, useWindowSize } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddProjectModal } from "./components/AddProjectModal";
-import { ConfirmModal } from "./components/ConfirmModal";
+import { confirmModalRowCount, isConfirmMode } from "./components/ConfirmModal";
 import { OpenModal } from "./components/OpenModal";
 import { ShortcutsModal } from "./components/ShortcutsModal";
 import { StatusBar, statusBarRowCount } from "./components/StatusBar";
@@ -39,12 +39,16 @@ import {
   buildTreeItems,
   buildTreeRows,
   clampScrollOffset,
+  confirmationRowRange,
   findOwningWorktreeIndex,
   firstRowForItem,
+  insertConfirmationRows,
   reconcileExpandedWorktreeKeys,
+  resolveConfirmationAnchorItemIndex,
   resolveRecoveredSelectionIndex,
   resolveStatusBarProps,
   resolveTreeReturnMode,
+  scrollRangeToKeepVisible,
   scrollToKeepVisible,
   treeItemId,
 } from "./tree-helpers";
@@ -109,6 +113,8 @@ export function App() {
   const modalReturnModeRef = useRef<Mode>(Mode.Navigate);
   const confirmPendingRef = useRef(false);
   const confirmKillAttemptRef = useRef(0);
+  const confirmReturnScrollOffsetRef = useRef(0);
+  const wasConfirmingRef = useRef(false);
   const lastMouseClickRef = useRef<MouseClickHistory | null>(null);
 
   // Reset selection when search query changes
@@ -204,7 +210,7 @@ export function App() {
 
   // The shared visual-row model drives both windowing here and the row-by-row
   // render in TreeView. Logical items are not 1:1 with terminal rows.
-  const rows = useMemo(
+  const baseRows = useMemo(
     () =>
       buildTreeRows({
         items: treeItems,
@@ -216,6 +222,29 @@ export function App() {
     [treeItems, filteredRepos, expandedWorktreeKeys, pendingActions, termCols],
   );
 
+  const confirmationMode = isConfirmMode(mode) ? mode : null;
+  const confirmationWidth = Math.min(termCols, 60);
+  const confirmationAnchorItemIndex = useMemo(
+    () => resolveConfirmationAnchorItemIndex(mode, treeItems, filteredRepos),
+    [mode, treeItems, filteredRepos],
+  );
+  const rows = useMemo(() => {
+    if (!confirmationMode || confirmationAnchorItemIndex === null) {
+      return baseRows;
+    }
+    return insertConfirmationRows(
+      baseRows,
+      confirmationAnchorItemIndex,
+      confirmModalRowCount(confirmationMode, confirmationWidth),
+    );
+  }, [
+    baseRows,
+    confirmationMode,
+    confirmationAnchorItemIndex,
+    confirmationWidth,
+  ]);
+  const confirmationRange = useMemo(() => confirmationRowRange(rows), [rows]);
+
   // Bottom chrome: optional tmux/action error line (mutually exclusive, so at
   // most one row) + the StatusBar's rows — counted by statusBarRowCount, the
   // helper co-located with StatusBar's render branches so the budget cannot
@@ -225,12 +254,12 @@ export function App() {
   // would under-count, and the overflowing layout would misalign mouse
   // hit-testing.
   //
-  // True modals replace the StatusBar but budget the SAME virtual row count
+  // Form modals replace the StatusBar but budget the SAME virtual row count
   // as the now-hidden default shortcut footer (zero, or one repo-error row):
   // viewportRows must not change when a modal opens, or the clamp/keep-visible
   // effects would rewrite a wheel-scrolled offset the user expects back on
-  // cancel. Confirmation modals render below the header; the other modals
-  // render below the tree. A modal being taller than the budgeted chrome is
+  // cancel. Confirmation modals are anchored inside the tree's visual-row
+  // model. A form modal being taller than the budgeted chrome is
   // absorbed by the tree box's overflowY="hidden" clipping (see the render
   // below), which keeps the modal fully on-screen without inflating the
   // viewport.
@@ -248,6 +277,17 @@ export function App() {
     rows.length,
     viewportRows,
   );
+
+  // Capture the reading position once, before the anchored-modal effect below
+  // scrolls the viewport. Cancellation restores this exact tree viewport so a
+  // detail row that sits below the modal does not remain selected off-screen.
+  useEffect(() => {
+    const isConfirming = confirmationMode !== null;
+    if (isConfirming && !wasConfirmingRef.current) {
+      confirmReturnScrollOffsetRef.current = effectiveScrollOffset;
+    }
+    wasConfirmingRef.current = isConfirming;
+  }, [confirmationMode, effectiveScrollOffset]);
 
   // Identity-based selection recovery: when the tree structure changes
   // (background refresh, async worktree add/remove), find the previously-
@@ -386,6 +426,46 @@ export function App() {
     );
   }, [selectionRowIndex, viewportRows, selectionChanged]);
 
+  // Confirmation rows must be wholly visible so the prompt and both actions
+  // cannot open below the viewport. This runs after selection anchoring and
+  // wins only while a confirmation is present; wheel/tree input is inert in
+  // confirmation modes, so the modal remains on screen until it is resolved.
+  useEffect(() => {
+    if (!confirmationRange) return;
+    setScrollOffset((prev) =>
+      clampScrollOffset(
+        scrollRangeToKeepVisible(confirmationRange, prev, viewportRows),
+        rows.length,
+        viewportRows,
+      ),
+    );
+  }, [confirmationRange, rows.length, viewportRows]);
+
+  // A refresh can remove the worktree/pane being confirmed. Leave the stale
+  // confirmation immediately: without an anchor it cannot be rendered, and
+  // Enter must not remain capable of executing an action against stale data.
+  useEffect(() => {
+    if (!confirmationMode || confirmationAnchorItemIndex !== null) return;
+
+    setScrollOffset(confirmReturnScrollOffsetRef.current);
+    switch (mode.type) {
+      case "ConfirmKill":
+        confirmKillAttemptRef.current += 1;
+        confirmPendingRef.current = false;
+        setMode(Mode.Expanded(mode.worktreeKey));
+        return;
+      case "ConfirmDown":
+        setSelectedIndex(confirmDownReturnSelectedIndexRef.current);
+        setMode(confirmDownReturnModeRef.current);
+        return;
+      case "ConfirmClose":
+      case "ConfirmCloseForce":
+        setSelectedIndex(confirmCloseReturnSelectedIndexRef.current);
+        setMode(confirmCloseReturnModeRef.current);
+        return;
+    }
+  }, [confirmationMode, confirmationAnchorItemIndex, mode]);
+
   // The trailing writes keeping the prev-* refs one commit behind for the
   // selectionChanged computation and the keep-visible effect above. The
   // visibility ref alone has a second writer (the searchQueryChanged branch
@@ -408,6 +488,10 @@ export function App() {
   const refreshAll = useCallback(async () => {
     await Promise.all([refreshRegistry(), refreshSessions(), discoverClient()]);
   }, [refreshRegistry, refreshSessions, discoverClient]);
+
+  const restoreConfirmationViewport = useCallback(() => {
+    setScrollOffset(confirmReturnScrollOffsetRef.current);
+  }, []);
 
   useRefresh(refreshAll);
 
@@ -461,6 +545,7 @@ export function App() {
     discoverClient,
     refreshSessions,
     refreshAll,
+    restoreConfirmationViewport,
     confirmDownReturnModeRef,
     confirmDownReturnSelectedIndexRef,
     confirmCloseReturnModeRef,
@@ -551,6 +636,7 @@ export function App() {
   }
 
   function cancelConfirm() {
+    setScrollOffset(confirmReturnScrollOffsetRef.current);
     switch (mode.type) {
       case "ConfirmKill":
         confirmKillAttemptRef.current += 1;
@@ -570,6 +656,10 @@ export function App() {
   }
 
   function submitConfirm() {
+    if (confirmationAnchorItemIndex === null) {
+      cancelConfirm();
+      return;
+    }
     switch (mode.type) {
       case "ConfirmKill": {
         if (confirmPendingRef.current) return;
@@ -585,6 +675,7 @@ export function App() {
           isCurrent: () => confirmKillAttemptRef.current === attempt,
           showActionError,
           onSuccess: () => {
+            restoreConfirmationViewport();
             if (parentIndex !== null) setSelectedIndex(parentIndex);
             setMode(Mode.Expanded(worktreeKey));
           },
@@ -806,29 +897,6 @@ export function App() {
             {ADD_PROJECT_BUTTON_LABEL}
           </Text>
         </Box>
-        {mode.type === "ConfirmKill" ||
-        mode.type === "ConfirmDown" ||
-        mode.type === "ConfirmClose" ||
-        mode.type === "ConfirmCloseForce" ? (
-          <Box flexDirection="column">
-            {tmuxError && !actionError ? (
-              <Text color="yellow" wrap="truncate">
-                {toSingleLine(tmuxError)}
-              </Text>
-            ) : null}
-            {actionError ? (
-              <Text color="red" wrap="truncate">
-                {toSingleLine(actionError)}
-              </Text>
-            ) : null}
-            <ConfirmModal
-              mode={mode}
-              width={Math.min(termCols, 60)}
-              onConfirm={submitConfirm}
-              onCancel={cancelConfirm}
-            />
-          </Box>
-        ) : null}
         <Text> </Text>
       </Box>
       {/* overflowY="hidden" + flexShrink is what lets a true modal exceed the
@@ -861,12 +929,22 @@ export function App() {
             errors={githubErrors}
             scrollOffset={effectiveScrollOffset}
             viewportRows={viewportRows}
+            confirmation={
+              confirmationMode
+                ? {
+                    mode: confirmationMode,
+                    width: confirmationWidth,
+                    onConfirm: submitConfirm,
+                    onCancel: cancelConfirm,
+                  }
+                : undefined
+            }
           />
         </Box>
       </Box>
       {/* flexShrink={0} pins the bottom area (form modal or status chrome) to
           its natural height so the tree box above is the only child Yoga
-          shrinks. Confirmations render below the header instead. */}
+          shrinks. Confirmations render inside the tree instead. */}
       <Box flexDirection="column" flexShrink={0}>
         {mode.type === "Shortcuts" ? (
           <ShortcutsModal
@@ -905,10 +983,7 @@ export function App() {
             onSubmit={modalActions.handleAddProject}
             onCancel={() => setMode(modalReturnModeRef.current)}
           />
-        ) : mode.type === "ConfirmKill" ||
-          mode.type === "ConfirmDown" ||
-          mode.type === "ConfirmClose" ||
-          mode.type === "ConfirmCloseForce" ? null : (
+        ) : (
           <Box flexDirection="column">
             {tmuxError && !actionError ? (
               <Text color="yellow" wrap="truncate">
@@ -920,13 +995,15 @@ export function App() {
                 {toSingleLine(actionError)}
               </Text>
             ) : null}
-            <StatusBar
-              {...statusBarProps}
-              searchQuery={searchQuery}
-              hasClient={tmuxClient !== null}
-              canCollapse={canCollapse}
-              repoError={repoError}
-            />
+            {!confirmationMode ? (
+              <StatusBar
+                {...statusBarProps}
+                searchQuery={searchQuery}
+                hasClient={tmuxClient !== null}
+                canCollapse={canCollapse}
+                repoError={repoError}
+              />
+            ) : null}
           </Box>
         )}
       </Box>

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -61,11 +61,6 @@ export function copyFor(mode: ConfirmMode): {
   }
 }
 
-/**
- * The titled border consumes two columns and the content's horizontal padding
- * consumes two more. Rendering these pre-wrapped lines with truncation keeps
- * the modal's measured height identical to `confirmModalRowCount`.
- */
 export function confirmationQuestionLines(
   mode: ConfirmMode,
   width: number,
@@ -74,7 +69,6 @@ export function confirmationQuestionLines(
 }
 
 export function confirmModalRowCount(mode: ConfirmMode, width: number): number {
-  // top border + question lines + margin + actions + bottom border
   return confirmationQuestionLines(mode, width).length + 4;
 }
 

--- a/src/tui/components/ConfirmModal.tsx
+++ b/src/tui/components/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import type { Mode } from "../types";
 import { toSingleLine } from "../utils/truncate";
+import { wrapText } from "../utils/wrap-text";
 import { Modal } from "./Modal";
 import { MouseClickable } from "./MouseClickable";
 
@@ -11,6 +12,15 @@ export type ConfirmMode = Extract<
   }
 >;
 
+export function isConfirmMode(mode: Mode): mode is ConfirmMode {
+  return (
+    mode.type === "ConfirmKill" ||
+    mode.type === "ConfirmDown" ||
+    mode.type === "ConfirmClose" ||
+    mode.type === "ConfirmCloseForce"
+  );
+}
+
 interface Props {
   mode: ConfirmMode;
   width?: number;
@@ -18,7 +28,7 @@ interface Props {
   onCancel: () => void;
 }
 
-function copyFor(mode: ConfirmMode): {
+export function copyFor(mode: ConfirmMode): {
   title: string;
   question: string;
   confirmLabel: string;
@@ -51,6 +61,23 @@ function copyFor(mode: ConfirmMode): {
   }
 }
 
+/**
+ * The titled border consumes two columns and the content's horizontal padding
+ * consumes two more. Rendering these pre-wrapped lines with truncation keeps
+ * the modal's measured height identical to `confirmModalRowCount`.
+ */
+export function confirmationQuestionLines(
+  mode: ConfirmMode,
+  width: number,
+): string[] {
+  return wrapText(copyFor(mode).question, Math.max(1, width - 4));
+}
+
+export function confirmModalRowCount(mode: ConfirmMode, width: number): number {
+  // top border + question lines + margin + actions + bottom border
+  return confirmationQuestionLines(mode, width).length + 4;
+}
+
 function Action({
   label,
   onClick,
@@ -64,6 +91,7 @@ function Action({
     <MouseClickable onClick={onClick}>
       {(isHovered) => (
         <Text
+          wrap="truncate"
           color={destructive ? (isHovered ? "redBright" : "red") : undefined}
           bold={isHovered}
           dimColor={!destructive && !isHovered}
@@ -76,12 +104,16 @@ function Action({
 }
 
 export function ConfirmModal({ mode, width, onConfirm, onCancel }: Props) {
-  const { title, question, confirmLabel } = copyFor(mode);
+  const modalWidth = width ?? 40;
+  const { title, confirmLabel } = copyFor(mode);
+  const questionLines = confirmationQuestionLines(mode, modalWidth);
 
   return (
     <Modal title={title} visible width={width} accentColor="red" dimAccent>
       <Box flexDirection="column" paddingX={1}>
-        <Text wrap="wrap">{toSingleLine(question)}</Text>
+        <Text wrap="truncate">
+          {questionLines.map(toSingleLine).join("\n")}
+        </Text>
         <Box gap={2} marginTop={1}>
           <Action label={confirmLabel} onClick={onConfirm} destructive />
           <Action label="esc:cancel" onClick={onCancel} />

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -89,17 +89,17 @@ function getHints(
  * and searchQuery/selectedPaneRow/hasClient only change text, never lines.
  *
  * Normal navigation has no shortcut footer; it only reserves a row when a
- * repository error is visible. True-modal modes use that same virtual count,
- * so opening a modal does not clamp or re-anchor the scroll position. The
- * modal's extra height is absorbed by the tree box's overflow clipping.
+ * repository error is visible. Form modals use that same virtual count, so
+ * opening one does not clamp or re-anchor the scroll position. Confirmation
+ * modals are part of the tree row model and therefore reserve no footer rows.
  */
 export function statusBarRowCount(mode: Mode, hasRepoError: boolean): number {
   switch (mode.type) {
-    // divider + confirm question + hint line
     case "ConfirmKill":
     case "ConfirmDown":
     case "ConfirmClose":
     case "ConfirmCloseForce":
+      return 0;
     // divider + query line + hint line
     case "Search":
       return 3;
@@ -146,21 +146,7 @@ export function StatusBar({
     mode.type === "ConfirmClose" ||
     mode.type === "ConfirmCloseForce"
   ) {
-    const [line1, line2] = getHints(
-      mode,
-      selectedPaneRow,
-      hasClient,
-      canCollapse,
-    );
-    return (
-      <Box flexDirection="column">
-        <ChromeLine dimColor>{divider}</ChromeLine>
-        <ChromeLine color="red" bold>
-          {line1}
-        </ChromeLine>
-        <ChromeLine dimColor>{line2}</ChromeLine>
-      </Box>
-    );
+    return null;
   }
 
   if (mode.type === "Search") {

--- a/src/tui/components/TreeView.tsx
+++ b/src/tui/components/TreeView.tsx
@@ -12,6 +12,7 @@ import {
   pendingKey,
   type TreeItem,
 } from "../types";
+import { ConfirmModal, type ConfirmMode } from "./ConfirmModal";
 import { DetailRow } from "./DetailRow";
 import { RepoEmptyRow } from "./RepoEmptyRow";
 import { RepoNode } from "./RepoNode";
@@ -41,6 +42,12 @@ interface Props {
   scrollOffset?: number;
   /** Number of visual rows to render. Defaults to rendering all rows. */
   viewportRows?: number;
+  confirmation?: {
+    mode: ConfirmMode;
+    width: number;
+    onConfirm: () => void;
+    onCancel: () => void;
+  };
 }
 
 export function getDetailRowKey(
@@ -69,6 +76,7 @@ export function TreeView({
   errors,
   scrollOffset = 0,
   viewportRows,
+  confirmation,
 }: Props) {
   const sessionMap = useMemo(
     () => new Map(sessions.map((s) => [s.name, s])),
@@ -100,6 +108,7 @@ export function TreeView({
       maxWidth,
       refreshingProjects,
       errors,
+      confirmation,
     });
     if (element) elements.push(element);
   }
@@ -120,10 +129,22 @@ interface RenderRowContext {
   maxWidth: number;
   refreshingProjects?: Set<string>;
   errors?: Map<string, string>;
+  confirmation?: Props["confirmation"];
 }
 
 function renderRow(row: TreeRow, ctx: RenderRowContext): React.ReactNode {
   switch (row.kind) {
+    case "confirmation":
+      if (row.partIndex !== 0 || !ctx.confirmation) return null;
+      return (
+        <ConfirmModal
+          key="confirmation"
+          mode={ctx.confirmation.mode}
+          width={ctx.confirmation.width}
+          onConfirm={ctx.confirmation.onConfirm}
+          onCancel={ctx.confirmation.onCancel}
+        />
+      );
     case "repo-empty":
       return <RepoEmptyRow key={`repo-empty-${row.repoIndex}`} />;
     case "phantom": {

--- a/src/tui/hooks/useSessionActions.ts
+++ b/src/tui/hooks/useSessionActions.ts
@@ -39,6 +39,7 @@ export interface SessionActionDeps {
   refreshSessions: (signal?: AbortSignal) => Promise<TmuxSessionInfo[]>;
 
   refreshAll: () => Promise<void>;
+  restoreConfirmationViewport: () => void;
 
   confirmDownReturnModeRef: MutableRefObject<Mode>;
   confirmDownReturnSelectedIndexRef: MutableRefObject<number>;
@@ -227,6 +228,7 @@ export function createExecuteDown(deps: SessionActionDeps) {
       return;
     }
 
+    deps.restoreConfirmationViewport();
     deps.setSelectedIndex(deps.confirmDownReturnSelectedIndexRef.current);
     deps.setMode(deps.confirmDownReturnModeRef.current);
 
@@ -315,6 +317,7 @@ export function createExecuteClose(deps: SessionActionDeps) {
       return;
     }
 
+    deps.restoreConfirmationViewport();
     deps.setSelectedIndex(deps.confirmCloseReturnSelectedIndexRef.current);
     deps.setMode(deps.confirmCloseReturnModeRef.current);
 

--- a/src/tui/pr-layout.ts
+++ b/src/tui/pr-layout.ts
@@ -16,7 +16,7 @@
 // wrap="truncate-end" as a backstop, so even a measurement disagreement could
 // only clip a glyph, never add a terminal row.
 
-import { displayWidth, graphemeWidths } from "./utils/display-width";
+import { wrapText } from "./utils/wrap-text";
 
 /** Leading indent columns of a PR detail line. */
 export const PR_INDENT = 5;
@@ -36,58 +36,6 @@ export function prLabelStart(hasIcon: boolean): number {
 }
 
 /**
- * Greedy word-wrap `text` into lines no wider than `width` display columns
- * (CJK/emoji glyphs count 2). A word wider than `width` is hard-broken on
- * grapheme boundaries — never splitting a surrogate pair or an emoji ZWJ
- * sequence. Always returns at least one (possibly empty) line.
- */
-function wrapWords(text: string, width: number): string[] {
-  if (width <= 0) return [text];
-  const lines: string[] = [];
-  let current = "";
-  let currentWidth = 0;
-  for (const word of text.split(" ")) {
-    let w = word;
-    let wordWidth = displayWidth(word);
-    if (wordWidth > width) {
-      // Hard-break: flush the current line, emit full-width pieces, and carry
-      // the final piece forward as this iteration's word.
-      if (current !== "") {
-        lines.push(current);
-        current = "";
-        currentWidth = 0;
-      }
-      let piece = "";
-      let pieceWidth = 0;
-      for (const [grapheme, graphemeW] of graphemeWidths(word)) {
-        if (piece !== "" && pieceWidth + graphemeW > width) {
-          lines.push(piece);
-          piece = "";
-          pieceWidth = 0;
-        }
-        piece += grapheme;
-        pieceWidth += graphemeW;
-      }
-      w = piece;
-      wordWidth = pieceWidth;
-    }
-    if (current === "") {
-      current = w;
-      currentWidth = wordWidth;
-    } else if (currentWidth + 1 + wordWidth <= width) {
-      current += ` ${w}`;
-      currentWidth += 1 + wordWidth;
-    } else {
-      lines.push(current);
-      current = w;
-      currentWidth = wordWidth;
-    }
-  }
-  lines.push(current);
-  return lines;
-}
-
-/**
  * Split a PR label into the terminal lines it occupies at `maxWidth`. Line 0 is
  * rendered after the indent/selector/icon; any further lines are continuation
  * lines indented by `prLabelStart` to align under line 0's label.
@@ -97,5 +45,5 @@ export function wrapPrLabel(
   maxWidth: number,
   hasIcon: boolean,
 ): string[] {
-  return wrapWords(label, Math.max(1, maxWidth - prLabelStart(hasIcon)));
+  return wrapText(label, Math.max(1, maxWidth - prLabelStart(hasIcon)));
 }

--- a/src/tui/tree-helpers.ts
+++ b/src/tui/tree-helpers.ts
@@ -68,7 +68,61 @@ export type TreeRow =
       pieceIndex: number;
       prLine: string;
     }
-  | { itemIndex: null; kind: "phantom"; repoIndex: number; branch: string };
+  | { itemIndex: null; kind: "phantom"; repoIndex: number; branch: string }
+  | { itemIndex: null; kind: "confirmation"; partIndex: number };
+
+export function insertConfirmationRows(
+  rows: TreeRow[],
+  anchorItemIndex: number,
+  rowCount: number,
+): TreeRow[] {
+  const anchorRowIndex = rows.findIndex(
+    (row) => row.itemIndex === anchorItemIndex,
+  );
+  if (anchorRowIndex === -1 || rowCount <= 0) return rows;
+
+  const confirmationRows: TreeRow[] = Array.from(
+    { length: rowCount },
+    (_, partIndex) => ({
+      itemIndex: null,
+      kind: "confirmation",
+      partIndex,
+    }),
+  );
+  return [
+    ...rows.slice(0, anchorRowIndex + 1),
+    ...confirmationRows,
+    ...rows.slice(anchorRowIndex + 1),
+  ];
+}
+
+export function confirmationRowRange(
+  rows: TreeRow[],
+): { start: number; end: number } | null {
+  const start = rows.findIndex(
+    (row) => row.kind === "confirmation" && row.partIndex === 0,
+  );
+  if (start === -1) return null;
+
+  let end = start;
+  while (rows[end + 1]?.kind === "confirmation") end += 1;
+  return { start, end };
+}
+
+export function scrollRangeToKeepVisible(
+  range: { start: number; end: number },
+  scrollOffset: number,
+  viewportRows: number,
+): number {
+  if (viewportRows <= 0) return scrollOffset;
+  const rangeRows = range.end - range.start + 1;
+  if (rangeRows > viewportRows) return range.start;
+  if (range.start < scrollOffset) return range.start;
+  if (range.end >= scrollOffset + viewportRows) {
+    return range.end - viewportRows + 1;
+  }
+  return scrollOffset;
+}
 
 interface ResolveSelectedPaneOptions {
   repos: RepoInfo[];
@@ -110,6 +164,47 @@ interface ResolveCloseSelectedWorktreeActionOptions {
   repos: RepoInfo[];
   items: TreeItem[];
   selectedIndex: number;
+}
+
+export function resolveConfirmationAnchorItemIndex(
+  mode: Mode,
+  items: TreeItem[],
+  repos: RepoInfo[],
+): number | null {
+  if (mode.type === "ConfirmKill") {
+    const paneIndex = items.findIndex((item) => {
+      if (item.type !== "detail" || item.detailKind !== "pane") return false;
+      if (item.meta.paneId !== mode.paneId) return false;
+      const repo = repos[item.repoIndex];
+      const worktree = repo?.worktrees[item.worktreeIndex];
+      return (
+        repo !== undefined &&
+        worktree !== undefined &&
+        pendingKey(repo.project, worktree.branch) === mode.worktreeKey
+      );
+    });
+    return paneIndex === -1 ? null : paneIndex;
+  }
+
+  if (
+    mode.type !== "ConfirmDown" &&
+    mode.type !== "ConfirmClose" &&
+    mode.type !== "ConfirmCloseForce"
+  ) {
+    return null;
+  }
+
+  const worktreeIndex = items.findIndex((item) => {
+    if (item.type !== "worktree") return false;
+    const repo = repos[item.repoIndex];
+    const worktree = repo?.worktrees[item.worktreeIndex];
+    return (
+      repo !== undefined &&
+      worktree !== undefined &&
+      pendingKey(repo.project, worktree.branch) === mode.worktreeKey
+    );
+  });
+  return worktreeIndex === -1 ? null : worktreeIndex;
 }
 
 type ExpandedRightArrowAction =

--- a/src/tui/utils/wrap-text.ts
+++ b/src/tui/utils/wrap-text.ts
@@ -1,9 +1,5 @@
 import { displayWidth, graphemeWidths } from "./display-width";
 
-/**
- * Greedy word-wrap `text` into lines no wider than `width` display columns.
- * Overlong words are hard-broken on grapheme boundaries.
- */
 export function wrapText(text: string, width: number): string[] {
   if (width <= 0) return [text];
   const lines: string[] = [];

--- a/src/tui/utils/wrap-text.ts
+++ b/src/tui/utils/wrap-text.ts
@@ -1,0 +1,52 @@
+import { displayWidth, graphemeWidths } from "./display-width";
+
+/**
+ * Greedy word-wrap `text` into lines no wider than `width` display columns.
+ * Overlong words are hard-broken on grapheme boundaries.
+ */
+export function wrapText(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const lines: string[] = [];
+  let current = "";
+  let currentWidth = 0;
+
+  for (const word of text.split(" ")) {
+    let nextWord = word;
+    let wordWidth = displayWidth(word);
+    if (wordWidth > width) {
+      if (current !== "") {
+        lines.push(current);
+        current = "";
+        currentWidth = 0;
+      }
+      let piece = "";
+      let pieceWidth = 0;
+      for (const [grapheme, graphemeWidth] of graphemeWidths(word)) {
+        if (piece !== "" && pieceWidth + graphemeWidth > width) {
+          lines.push(piece);
+          piece = "";
+          pieceWidth = 0;
+        }
+        piece += grapheme;
+        pieceWidth += graphemeWidth;
+      }
+      nextWord = piece;
+      wordWidth = pieceWidth;
+    }
+
+    if (current === "") {
+      current = nextWord;
+      currentWidth = wordWidth;
+    } else if (currentWidth + 1 + wordWidth <= width) {
+      current += ` ${nextWord}`;
+      currentWidth += 1 + wordWidth;
+    } else {
+      lines.push(current);
+      current = nextWord;
+      currentWidth = wordWidth;
+    }
+  }
+
+  lines.push(current);
+  return lines;
+}

--- a/tests/tui/app-harness.tsx
+++ b/tests/tui/app-harness.tsx
@@ -45,9 +45,6 @@ vi.mock("../../src/tui/runtime", () => ({
   runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
 }));
 
-// App-level tests need to drive a background refresh deterministically. The
-// useRefresh hook's filesystem/timer delivery is a separate concern; capture
-// the exact refreshAll callback App registers and invoke it directly.
 vi.mock("../../src/tui/hooks/useRefresh", () => ({
   useRefresh: (callback: () => void | Promise<void>) => {
     refreshHarness.callback = callback;

--- a/tests/tui/app-harness.tsx
+++ b/tests/tui/app-harness.tsx
@@ -36,9 +36,22 @@ const runtimeMock = vi.hoisted(() => ({
   runSync: vi.fn((effect: unknown) => effect),
 }));
 
+const refreshHarness = vi.hoisted(() => ({
+  callback: null as (() => void | Promise<void>) | null,
+}));
+
 vi.mock("../../src/tui/runtime", () => ({
   tuiRuntime: runtimeMock,
   runTuiSilentPromise: (effect: unknown) => runtimeMock.runPromise(effect),
+}));
+
+// App-level tests need to drive a background refresh deterministically. The
+// useRefresh hook's filesystem/timer delivery is a separate concern; capture
+// the exact refreshAll callback App registers and invoke it directly.
+vi.mock("../../src/tui/hooks/useRefresh", () => ({
+  useRefresh: (callback: () => void | Promise<void>) => {
+    refreshHarness.callback = callback;
+  },
 }));
 
 // Ink disables ANSI colors for this PassThrough-based harness, so the selected
@@ -172,6 +185,11 @@ export function resetHarnessFixtures(): void {
   githubFixtures.prsByRepoPath.clear();
   runtimeMock.runPromise.mockClear();
   runtimeMock.runSync.mockClear();
+  refreshHarness.callback = null;
+}
+
+export async function triggerRefresh(): Promise<void> {
+  await refreshHarness.callback?.();
 }
 
 export type TestStdout = NodeJS.WriteStream & { columns: number; rows: number };

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -7,7 +7,7 @@
 // Service mocks and the Ink render harness live in tests/tui/app-harness.tsx
 // (shared with tests/tui/app-review-fixes.test.tsx); see the mocking-strategy
 // note there.
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -25,6 +25,7 @@ import {
   sgrRowFor,
   sgrWheel,
   tick,
+  triggerRefresh,
   worktreeFixtures,
 } from "./app-harness";
 
@@ -282,20 +283,11 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         );
         expect(visibleBefore.length).toBeGreaterThan(0);
 
-        // Trigger a REAL background refresh through useRefresh's fs.watch
-        // path (not a simulated re-render): useRefresh watches
-        // `${HOME}/.wct/` for `.db`/`-wal` changes with a 150ms debounce and
-        // calls refreshAll -> refreshRegistry -> useRegistry's refresh(),
-        // which re-fetches from RegistryService/WorktreeService. Our mocks
-        // re-read their fixture maps fresh on every call and return brand-new
-        // arrays each time — exactly like the real services — so this is a
-        // content-identical, reference-different refresh, which is the exact
-        // condition useRegistry.ts triggers on (it has no equality bail-out
-        // before calling setRepos).
-        const wctDir = join(homeDir, ".wct");
-        mkdirSync(wctDir, { recursive: true });
-        writeFileSync(join(wctDir, "registry.db"), "trigger");
-        await new Promise((resolve) => setTimeout(resolve, 250)); // past the 150ms debounce
+        // Trigger the exact refreshAll callback App registered with
+        // useRefresh. The service mocks re-read their fixtures and return
+        // brand-new arrays, matching a real content-identical background
+        // refresh without relying on filesystem-watcher timing.
+        await triggerRefresh();
         await tick(10);
 
         const afterRefresh = rendered.lines();

--- a/tests/tui/app-mouse-wiring.test.tsx
+++ b/tests/tui/app-mouse-wiring.test.tsx
@@ -283,10 +283,6 @@ describe("App.tsx mouse wiring (bug 1 + bug 2 regressions, real App)", () => {
         );
         expect(visibleBefore.length).toBeGreaterThan(0);
 
-        // Trigger the exact refreshAll callback App registered with
-        // useRefresh. The service mocks re-read their fixtures and return
-        // brand-new arrays, matching a real content-identical background
-        // refresh without relying on filesystem-watcher timing.
         await triggerRefresh();
         await tick(10);
 

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -143,7 +143,6 @@ describe("App.tsx review fixes (real App)", () => {
     try {
       await tick(20);
 
-      // repo -> main -> feature/0 ... -> feature/15
       for (let i = 0; i < 17; i++) {
         await sendKeys(rendered.stdin, "\x1b[B", 1);
       }
@@ -160,8 +159,6 @@ describe("App.tsx review fixes (real App)", () => {
       expect(modalRow).toBe(branchRow + 1);
       expect(frame.some((line) => line.includes("enter:confirm"))).toBe(true);
 
-      // Background clicks, navigation, and quit shortcuts are inert while
-      // confirming; only the modal's own click targets remain active.
       const backgroundBranchRow = frame.findIndex(
         (line) => /feature\/\d+/.test(line) && !line.includes("feature/15"),
       );
@@ -226,7 +223,6 @@ describe("App.tsx review fixes (real App)", () => {
     const rendered = await renderApp(<App />, 12);
     try {
       await tick(20);
-      // repo -> main -> feature/0 -> feature/1 -> feature/2
       for (let i = 0; i < 4; i++) {
         await sendKeys(rendered.stdin, "\x1b[B", 1);
       }

--- a/tests/tui/app-review-fixes.test.tsx
+++ b/tests/tui/app-review-fixes.test.tsx
@@ -24,13 +24,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  githubFixtures,
   renderApp,
   resetHarnessFixtures,
   selectedLine,
   sendKeys,
   setTallWorktrees,
+  sgrPress,
   sgrWheel,
   tick,
+  triggerRefresh,
+  worktreeFixtures,
 } from "./app-harness";
 
 const { App } = await import("../../src/tui/App");
@@ -127,6 +131,123 @@ describe("App.tsx review fixes (real App)", () => {
       expect(topBorder).toBeGreaterThan(-1);
       expect(frame[topBorder]).toContain("╭");
       expect(bottomBorder).toBeGreaterThan(topBorder);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("anchors close confirmation below the branch and scrolls it into view", async () => {
+    setTallWorktrees(repoPath, 20);
+
+    const rendered = await renderApp(<App />, 10);
+    try {
+      await tick(20);
+
+      // repo -> main -> feature/0 ... -> feature/15
+      for (let i = 0; i < 17; i++) {
+        await sendKeys(rendered.stdin, "\x1b[B", 1);
+      }
+      expect(selectedLine(rendered.lines())).toContain("feature/15");
+
+      await sendKeys(rendered.stdin, "c");
+      const frame = rendered.lines();
+      const branchRow = frame.findIndex((line) => line.includes("feature/15"));
+      const modalRow = frame.findIndex((line) =>
+        line.includes("Close Worktree"),
+      );
+
+      expect(branchRow).toBeGreaterThan(-1);
+      expect(modalRow).toBe(branchRow + 1);
+      expect(frame.some((line) => line.includes("enter:confirm"))).toBe(true);
+
+      // Background clicks, navigation, and quit shortcuts are inert while
+      // confirming; only the modal's own click targets remain active.
+      const backgroundBranchRow = frame.findIndex(
+        (line) => /feature\/\d+/.test(line) && !line.includes("feature/15"),
+      );
+      expect(backgroundBranchRow).toBeGreaterThan(-1);
+      await sendKeys(rendered.stdin, sgrPress(3, backgroundBranchRow + 1));
+      await sendKeys(rendered.stdin, "q\x1b[B");
+      expect(selectedLine(rendered.lines())).toContain("feature/15");
+      expect(
+        rendered.lines().some((line) => line.includes("Close Worktree")),
+      ).toBe(true);
+
+      await sendKeys(rendered.stdin, "\x1b");
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(
+        rendered.lines().some((line) => line.includes("Close Worktree")),
+      ).toBe(false);
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("restores a selected detail row to the viewport after cancellation", async () => {
+    setTallWorktrees(repoPath, 20);
+    githubFixtures.prsByRepoPath.set(repoPath, [
+      {
+        number: 42,
+        title: "Selected detail",
+        state: "OPEN",
+        headRefName: "feature/15",
+        rollupState: "success",
+      },
+    ]);
+
+    const rendered = await renderApp(<App />, 8);
+    try {
+      await tick(20);
+      await sendKeys(rendered.stdin, "r");
+      for (let i = 0; i < 17; i++) {
+        await sendKeys(rendered.stdin, "\x1b[B", 1);
+      }
+      await sendKeys(rendered.stdin, "\x1b[C");
+      await sendKeys(rendered.stdin, "\x1b[B");
+      expect(selectedLine(rendered.lines())).toContain("PR #42");
+
+      await sendKeys(rendered.stdin, "c");
+      expect(
+        rendered.lines().some((line) => line.includes("Close Worktree")),
+      ).toBe(true);
+      expect(selectedLine(rendered.lines())).toBeUndefined();
+
+      await sendKeys(rendered.stdin, "\x1b");
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(selectedLine(rendered.lines())).toContain("PR #42");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("cancels confirmation when a refresh removes its anchor", async () => {
+    setTallWorktrees(repoPath, 5);
+
+    const rendered = await renderApp(<App />, 12);
+    try {
+      await tick(20);
+      // repo -> main -> feature/0 -> feature/1 -> feature/2
+      for (let i = 0; i < 4; i++) {
+        await sendKeys(rendered.stdin, "\x1b[B", 1);
+      }
+      expect(selectedLine(rendered.lines())).toContain("feature/2");
+      await sendKeys(rendered.stdin, "c");
+      expect(
+        rendered.lines().some((line) => line.includes("Close Worktree")),
+      ).toBe(true);
+
+      worktreeFixtures.byRepoPath.set(
+        repoPath,
+        (worktreeFixtures.byRepoPath.get(repoPath) ?? []).filter(
+          (worktree) => worktree.branch !== "feature/2",
+        ),
+      );
+      await triggerRefresh();
+      await tick(10);
+
+      expect(
+        rendered.lines().some((line) => line.includes("Close Worktree")),
+      ).toBe(false);
     } finally {
       rendered.unmount();
     }

--- a/tests/tui/build-tree-rows.test.ts
+++ b/tests/tui/build-tree-rows.test.ts
@@ -5,9 +5,13 @@ import {
   buildTreeItems,
   buildTreeRows,
   clampScrollOffset,
+  confirmationRowRange,
+  insertConfirmationRows,
+  resolveConfirmationAnchorItemIndex,
+  scrollRangeToKeepVisible,
   scrollToKeepVisible,
 } from "../../src/tui/tree-helpers";
-import { type PendingAction, pendingKey } from "../../src/tui/types";
+import { Mode, type PendingAction, pendingKey } from "../../src/tui/types";
 
 function repo(overrides: Partial<RepoInfo> & { id: string }): RepoInfo {
   return {
@@ -712,5 +716,63 @@ describe("scrollToKeepVisible", () => {
 
   test("returns the offset unchanged for a zero/negative viewport", () => {
     expect(scrollToKeepVisible(3, 2, 0)).toBe(2);
+  });
+});
+
+describe("anchored confirmation rows", () => {
+  const repos = [
+    repo({
+      id: "repo-1",
+      project: "alpha",
+      worktrees: [
+        {
+          branch: "feature/x",
+          path: "/tmp/alpha-x",
+          isMainWorktree: false,
+          changedFiles: 0,
+          sync: { ahead: 0, behind: 0 },
+        },
+      ],
+    }),
+  ];
+  const items = buildTreeItems({
+    repos,
+    expandedWorktreeKeys: new Set<string>(),
+    ...emptyOpts,
+  });
+
+  test("inserts the modal immediately below its worktree", () => {
+    const baseRows = buildTreeRows({
+      items,
+      repos,
+      pendingActions: new Map(),
+    });
+    const mode = Mode.ConfirmClose(
+      "alpha-x",
+      "feature/x",
+      "/tmp/alpha-x",
+      "alpha/feature/x",
+      "/tmp/alpha",
+      "alpha",
+      0,
+    );
+    const anchor = resolveConfirmationAnchorItemIndex(mode, items, repos);
+    expect(anchor).toBe(1);
+
+    const rows = insertConfirmationRows(baseRows, anchor ?? -1, 5);
+    expect(rows.map((row) => row.kind)).toEqual([
+      "repo",
+      "worktree",
+      "confirmation",
+      "confirmation",
+      "confirmation",
+      "confirmation",
+      "confirmation",
+    ]);
+    expect(confirmationRowRange(rows)).toEqual({ start: 2, end: 6 });
+  });
+
+  test("scrolls the entire modal into a viewport when it opens below it", () => {
+    expect(scrollRangeToKeepVisible({ start: 12, end: 16 }, 0, 8)).toBe(9);
   });
 });

--- a/tests/tui/confirm-modal.test.tsx
+++ b/tests/tui/confirm-modal.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   ConfirmModal,
   type ConfirmMode,
+  confirmModalRowCount,
 } from "../../src/tui/components/ConfirmModal";
 import { Mode } from "../../src/tui/types";
 import { renderWithInput, sendKeys } from "./keypress-harness";
@@ -82,6 +83,34 @@ describe("ConfirmModal", () => {
       expect(rendered.output().trimEnd().split("\n").length).toBeGreaterThan(5);
       expect(rendered.output()).toContain("xxxxxxxxxxxxxxxx");
       expect(rendered.output()).toContain("enter:confirm  esc:cancel");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("keeps row accounting exact when narrow actions cannot fit side by side", async () => {
+    const mode = Mode.ConfirmCloseForce(
+      "myapp-feature",
+      "feature",
+      "/tmp/myapp-feature",
+      "proj/feature",
+      "/tmp/myapp",
+      "proj",
+    ) as ConfirmMode;
+    const width = 20;
+    const rendered = await renderWithInput(
+      <ConfirmModal
+        mode={mode}
+        width={width}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    try {
+      expect(rendered.output().trimEnd().split("\n")).toHaveLength(
+        confirmModalRowCount(mode, width),
+      );
     } finally {
       rendered.unmount();
     }

--- a/tests/tui/session-actions.test.ts
+++ b/tests/tui/session-actions.test.ts
@@ -55,6 +55,7 @@ function makeDeps(
     discoverClient: vi.fn().mockResolvedValue({ type: "none" }),
     refreshSessions: vi.fn().mockResolvedValue([]),
     refreshAll: vi.fn().mockResolvedValue(undefined),
+    restoreConfirmationViewport: vi.fn(),
     confirmDownReturnModeRef: { current: Mode.Navigate },
     confirmDownReturnSelectedIndexRef: { current: 0 },
     confirmCloseReturnModeRef: { current: Mode.Navigate },
@@ -572,6 +573,7 @@ describe("createExecuteClose", () => {
     expect(tuiRuntime.runPromise).toHaveBeenCalledWith("mock-workspace-effect");
     expect(deps.setPendingActions).toHaveBeenCalled();
     expect(deps.refreshAll).toHaveBeenCalled();
+    expect(deps.restoreConfirmationViewport).toHaveBeenCalledOnce();
     expect(deps.showActionError).not.toHaveBeenCalled();
     expect(pendingActions.size).toBe(0);
     expect(setPendingActions).toHaveBeenCalledTimes(2);
@@ -704,6 +706,10 @@ describe("createExecuteClose", () => {
         "proj",
       ),
     );
+    expect(deps.restoreConfirmationViewport).toHaveBeenCalledOnce();
+    expect(
+      vi.mocked(deps.restoreConfirmationViewport).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(deps.setMode).mock.invocationCallOrder[0] ?? 0);
     expect(deps.refreshAll).toHaveBeenCalled();
     expect(pendingActions.size).toBe(0);
     expect(setPendingActions).toHaveBeenCalledTimes(2);
@@ -829,6 +835,10 @@ describe("createExecuteDown", () => {
     expect(workspaceDown).toHaveBeenCalledWith({ path: "/tmp/wt" });
     expect(tuiRuntime.runPromise).toHaveBeenCalledWith("mock-workspace-effect");
     expect(deps.refreshAll).toHaveBeenCalled();
+    expect(deps.restoreConfirmationViewport).toHaveBeenCalledOnce();
+    expect(
+      vi.mocked(deps.restoreConfirmationViewport).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(deps.setMode).mock.invocationCallOrder[0] ?? 0);
     expect(deps.showActionError).not.toHaveBeenCalled();
     expect(pendingActions.size).toBe(0);
     expect(setPendingActions).toHaveBeenCalledTimes(2);

--- a/tests/tui/status-bar.test.tsx
+++ b/tests/tui/status-bar.test.tsx
@@ -80,18 +80,17 @@ describe("StatusBar", () => {
     rendered.unmount();
   });
 
-  test("shows the kill confirmation prompt", async () => {
+  test("does not duplicate the anchored kill confirmation", async () => {
     const rendered = await renderStatusBar({
       mode: Mode.ConfirmKill("%1", "shell:1 vim", "proj/branch"),
     });
 
-    expect(rendered.output).toContain("Kill pane shell:1 vim?");
-    expect(rendered.output).toContain("enter:confirm  esc:cancel");
+    expect(rendered.lastFrame()).toBe("");
 
     rendered.unmount();
   });
 
-  test("shows the down confirmation prompt", async () => {
+  test("does not duplicate the anchored down confirmation", async () => {
     const rendered = await renderStatusBar({
       mode: Mode.ConfirmDown(
         "myapp-feature",
@@ -101,8 +100,7 @@ describe("StatusBar", () => {
       ),
     });
 
-    expect(rendered.output).toContain("Kill session for feature?");
-    expect(rendered.output).toContain("enter:confirm  esc:cancel");
+    expect(rendered.lastFrame()).toBe("");
 
     rendered.unmount();
   });


### PR DESCRIPTION
## Summary

- render confirmation modals directly beneath the worktree or pane they target
- include confirmation rows in tree windowing and scroll the full prompt into view
- isolate confirmation input so background tree controls remain inert
- restore the prior viewport when confirmation exits and cancel stale prompts when refresh removes their anchor
- keep modal row accounting exact for wrapped questions and narrow action labels

## Why

Confirmation prompts previously appeared at the top of the TUI, disconnected from the affected row. Moving them into the tree exposed viewport, refresh, and narrow-terminal edge cases that required confirmation-aware row modeling and explicit transition handling.

## Impact

Close, down, force-close, and pane-kill prompts now appear in context. The prompt remains visible, only its confirm/cancel controls are active, and returning from it preserves the user's reading position.

## Root causes addressed

- modal height and placement were outside the tree's shared visual-row model
- confirmation exits did not consistently restore the pre-modal scroll offset
- refreshed data could remove an anchor while leaving stale confirmation mode active
- narrow action labels could wrap beyond the row count budget

## Validation

- 61 focused TUI tests passed
- TypeScript typecheck passed
- Biome checks passed
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confirmation prompts now appear directly beside the relevant tree item.
  * Confirmation dialogs support wrapped text and improved narrow-screen layouts.
  * The interface keeps confirmations visible and restores the previous selection and viewport after completion or cancellation.

* **Bug Fixes**
  * Prevented duplicate confirmation prompts in the status bar.
  * Improved confirmation behavior when items disappear during refreshes.
  * Preserved viewport position during background refreshes and confirmation actions.
  * Improved pull request label wrapping for long text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->