### PR TITLE
Upgrade Effect packages to beta.102

### DIFF
--- a/EFFECT_V4.md
+++ b/EFFECT_V4.md
@@ -262,10 +262,9 @@ type Reason<E> = Fail<E> | Die | Interrupt;
 
 `FiberRef` is removed. Use `ServiceMap.Reference` instead.
 
-| v3                            | v4                              |
-| ----------------------------- | ------------------------------- |
-| `FiberRef.currentLogLevel`    | `References.CurrentLogLevel`    |
-| `FiberRef.currentConcurrency` | `References.CurrentConcurrency` |
+| v3                         | v4                           |
+| -------------------------- | ---------------------------- |
+| `FiberRef.currentLogLevel` | `References.CurrentLogLevel` |
 
 ```ts
 // ❌ v3

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "tab-cli",
       "dependencies": {
-        "@effect/platform-bun": "4.0.0-beta.98",
-        "effect": "4.0.0-beta.98",
+        "@effect/platform-bun": "4.0.0-beta.102",
+        "effect": "4.0.0-beta.102",
         "ink": "7.1.1",
         "react": "^19.2.8",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
-        "@effect/vitest": "4.0.0-beta.98",
+        "@effect/vitest": "4.0.0-beta.102",
         "@types/bun": "1.3.14",
         "@types/react": "^19.2.17",
         "bun-types": "1.3.14",
@@ -46,11 +46,11 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.98", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.98" }, "peerDependencies": { "effect": "^4.0.0-beta.98" } }, "sha512-QorRKhvwHDPwvE8lH5lE0r0dI2z+zj12VUN4h7hfoIunKUiXSoSOMZqF3w13W30RpV6ivsvJywUycaa/18yMPA=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.98", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.98" } }, "sha512-iySXaffnCJX1sNAIp79ghhIeui9E5qwUQyqd1VLPkB9UNO4vdpd9B5fTEXwe7S/GusL4jsk9vSvX38XJgRFG1w=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.98", "", { "peerDependencies": { "effect": "^4.0.0-beta.98", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-uXRPuN8Y6v43/OVmQwKOd/VFDh+dipaxGKdWPr1bdnM+4bl8NZlYYRJi5omgXLFZ6ZbleduXKcmLM3NeePe69w=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -212,7 +212,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "effect": ["effect@4.0.0-beta.98", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-oz+bsG5h+6RNrw4t5GMfQrk/xBS8ROoqkYsuvRhBr5O7mCOrpvH/hbw+QrDzvKIpX4HJClwm86F94c87W0sJxg=="],
+    "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 

--- a/docs/research/effect-beta-102-upgrade.md
+++ b/docs/research/effect-beta-102-upgrade.md
@@ -1,0 +1,46 @@
+# Effect 4.0.0-beta.102 upgrade notes
+
+## Scope and conclusion
+
+The upgrade baseline is `4.0.0-beta.98` for `effect`, `@effect/platform-bun`, and `@effect/vitest`; the lockfile also resolves `@effect/platform-node-shared` at beta.98 ([wct manifest at the baseline revision](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/package.json#L20-L38)). This note covers the four core releases from [beta.99](https://github.com/Effect-TS/effect/releases/tag/effect%404.0.0-beta.99) through [beta.102](https://github.com/Effect-TS/effect/releases/tag/effect%404.0.0-beta.102).
+
+The upgrade is low-risk for wct. One beta.102 CLI change requires a source update: the new `CliError.UnexpectedArgument` variant must be handled by wct's JSON error mapping. The other documented breaking changes affect APIs that wct does not import. `@effect/platform-bun` has one beta.102 cluster-specific change plus dependency updates, while `@effect/vitest` has a `Record.assignProperty` change plus dependency updates ([platform-bun release](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fplatform-bun%404.0.0-beta.102), [vitest release](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fvitest%404.0.0-beta.102)).
+
+## Breaking and behavior changes relevant to wct
+
+### CLI now rejects leftover positional arguments
+
+Beta.102 adds `CliError.UnexpectedArgument` and rejects positional operands left after command parsing, including values beyond an `Argument.variadic` maximum ([upstream change](https://github.com/Effect-TS/effect/commit/c917bb94a4c1c4e0a24372a8ebb8a5ca232e36b5)). Because wct switches over the CLI error union in a function declared to return a non-optional result, the new variant causes a type-check failure until it is mapped. It belongs with `UnrecognizedOption`, `MissingArgument`, and `InvalidValue` under wct's `invalid_options` JSON code ([baseline error mapping](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/src/index.ts#L22-L43)).
+
+The runtime behavior is also desirable: commands with no positional parameters no longer silently accept extra operands. Wct's unbounded `close` variadic remains unaffected ([baseline argument definition](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/src/cli/root-command.ts#L19-L25)).
+
+### A new built-in `--wizard` flag changes CLI surface area
+
+Beta.99 reintroduces interactive CLI wizard mode through the built-in `--wizard` flag and `Command.wizard`; it also adds the scoped `CliConfig` service so applications can choose their built-in global flags ([wizard change](https://github.com/Effect-TS/effect/commit/80b539f8aba68f478c75c35c2b4140c4ffc4fada), [configuration change](https://github.com/Effect-TS/effect/commit/8ce4795ccbaebca4292757db568c005a992546a4)). Wct generates its own completion scripts, whose global option lists contain help, version, completions, and log-level but not wizard ([baseline completion source](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/src/cli/completions.ts#L123-L136)).
+
+This needs an explicit product choice, not just a version change:
+
+- If wizard mode is useful, keep the default built-ins and add `--wizard` to all custom completion generators and any JSON-output action detection that should not be suppressed.
+- If wct wants to preserve its previous CLI surface, provide `CliConfig.layer({ builtIns: [GlobalFlag.Help, GlobalFlag.Version, GlobalFlag.Completions, GlobalFlag.LogLevel] })` around the command runner. This is the cleaner near-term choice because the custom completions otherwise advertise an incomplete global-flag set.
+
+The upgrade implements the second option: wct explicitly retains its prior
+built-in flags, so `--wizard` is not exposed accidentally and the accepted
+flags remain aligned with the custom completion generators.
+
+### Other beta.102 removals do not affect current source
+
+Beta.102 removes `Effect.withConcurrency`, `References.CurrentConcurrency`, and the `"inherit"` concurrency option; removes experimental `SchemaUtils`; makes `Schema.Date` itself reject invalid dates while removing `Schema.DateValid` and related guards; removes `Schema.asClass` in favor of directly extending schemas; and substantially replaces the low-level `SchemaRepresentation` persistence/reviver API ([beta.102 release notes](https://github.com/Effect-TS/effect/releases/tag/effect%404.0.0-beta.102)). Wct imports none of those APIs, so no application migration is required. `EFFECT_V4.md` still names `References.CurrentConcurrency`, however, and should be corrected when that local migration reference is next maintained ([baseline reference](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/EFFECT_V4.md#L268)).
+
+The prior beta.98 `CliError.UnknownSubcommand._tag` typo remains present in beta.102 (`"UnknownSubcomand"`). Wct's class-based `instanceof CliError.UnknownSubcommand` check therefore remains necessary; do not replace it with a `_tag` match ([beta.102 source](https://github.com/Effect-TS/effect/blob/effect%404.0.0-beta.102/packages/effect/src/unstable/cli/CliError.ts#L408-L413), [wct compatibility check](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/src/index.ts#L29-L31)).
+
+## New and fixed functionality worth using
+
+- Beta.100 fixes duplicated `Expected: Expected ...` text in CLI invalid-value diagnostics. Wct receives this automatically through its existing Effect CLI definitions ([upstream fix](https://github.com/Effect-TS/effect/commit/875e618c3764a7b817ac863d0af86924449528f2)).
+- Beta.102 adds `Schema.Natural` for non-negative safe integers and tightens invalid numeric/date decoding across built-in schemas ([upstream change](https://github.com/Effect-TS/effect/commit/0e50ec7dbb94390666f292cf9120719bf30a7246)). Wct's config schema has only an optional numeric `version` today; `Schema.Natural` would be appropriate if that field is intended to accept only non-negative integer schema versions, but adopting it changes accepted configuration and should be a deliberate validation decision rather than part of the dependency bump.
+- Beta.102 adds `Symbol.asyncDispose` to `ManagedRuntime`, enabling `await using` ([upstream change](https://github.com/Effect-TS/effect/commit/cea1d9c92601e69ebda040af8a1d860d604d885c)). Wct's TUI runtime is intentionally process-scoped and currently has no disposal path, so adopting `await using` would conflict with that lifecycle design rather than simplify it ([baseline TUI runtime](https://github.com/dmtr-p/wct/blob/d525b6b4d58d96f3fb79d4b3514b83ed2e91a92d/src/tui/runtime.ts#L24-L35)).
+- Beta.102 adds `Record.assignProperty`, including safe handling for dynamic keys such as `__proto__`, and makes `Record.fromIterableBy` usable data-last ([safe assignment](https://github.com/Effect-TS/effect/commit/5101e92c9c149c153423f43dd7a94f6194653c06), [data-last constructor](https://github.com/Effect-TS/effect/commit/69663534d626003eb10a5e55ab1f13e0379fead1)). Current wct code does not build Effect `Record` values incrementally, so there is no immediate adoption site.
+- Beta.101 contains runtime interruption, traversal cleanup, stack-frame, and synchronous-runner performance fixes with no API migration ([beta.101 release](https://github.com/Effect-TS/effect/releases/tag/effect%404.0.0-beta.101)). Wct benefits transitively.
+
+## Recommendation
+
+Upgrade all resolved Effect packages together to beta.102, add `UnexpectedArgument` to the JSON invalid-options mapping, retain the class-based unknown-subcommand check, and explicitly preserve the previous built-in flag set with `CliConfig`. No other application refactor is warranted for this upgrade.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "@effect/vitest": "4.0.0-beta.98",
+    "@effect/vitest": "4.0.0-beta.102",
     "@types/bun": "1.3.14",
     "@types/react": "^19.2.17",
     "bun-types": "1.3.14",
@@ -31,8 +31,8 @@
     "typescript": "7.0.2"
   },
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.98",
-    "effect": "4.0.0-beta.98",
+    "@effect/platform-bun": "4.0.0-beta.102",
+    "effect": "4.0.0-beta.102",
     "ink": "7.1.1",
     "react": "^19.2.8"
   }

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1,4 +1,5 @@
 export * as Argument from "effect/unstable/cli/Argument";
+export * as CliConfig from "effect/unstable/cli/CliConfig";
 export * as CliError from "effect/unstable/cli/CliError";
 export * as CliOutput from "effect/unstable/cli/CliOutput";
 export * as Command from "effect/unstable/cli/Command";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,13 @@ import {
 } from "./cli/completions";
 import { JsonFlag } from "./cli/json-flag";
 import { rootCommand } from "./cli/root-command";
-import { CliError, CliOutput, Command } from "./effect/cli";
+import {
+  CliConfig,
+  CliError,
+  CliOutput,
+  Command,
+  GlobalFlag,
+} from "./effect/cli";
 import { BunRuntime, provideBunServices } from "./effect/runtime";
 import { provideWctServices } from "./effect/services";
 import { commandError, toWctError } from "./errors";
@@ -18,6 +24,14 @@ const helpRequested = args.includes("--help") || args.includes("-h");
 const jsonRequested = args.includes("--json");
 const builtInActionRequested =
   args.includes("--version") || args.includes("--completions");
+const cliConfigLayer = CliConfig.layer({
+  builtIns: [
+    GlobalFlag.Help,
+    GlobalFlag.Version,
+    GlobalFlag.Completions,
+    GlobalFlag.LogLevel,
+  ],
+});
 
 function toJsonModeWctError(
   error: unknown,
@@ -35,6 +49,7 @@ function toJsonModeWctError(
     case "DuplicateOption":
     case "MissingOption":
     case "MissingArgument":
+    case "UnexpectedArgument":
     case "InvalidValue":
       return commandError("invalid_options", error.message, error);
     case "UserError":
@@ -56,9 +71,13 @@ if (customCompletionShell) {
   process.exit(0);
 }
 
+const commandProgram = Command.run(rootCommand, { version: VERSION }).pipe(
+  Effect.provide(cliConfigLayer),
+);
+
 const program = provideBunServices(
   provideWctServices(
-    Effect.catch(Command.run(rootCommand, { version: VERSION }), (error) => {
+    Effect.catch(commandProgram, (error) => {
       return Effect.gen(function* () {
         let json = false;
 


### PR DESCRIPTION
## Summary

- upgrade `effect`, `@effect/platform-bun`, and `@effect/vitest` from beta.98 to beta.102
- handle the new `CliError.UnexpectedArgument` variant in JSON error output
- explicitly retain wct's existing built-in CLI flags instead of exposing the new `--wizard` flag implicitly
- update the compact Effect v4 reference and add cited beta.102 upgrade research

## Why

Effect beta.102 adds strict rejection of leftover positional arguments, which extends the CLI error union and caused wct's exhaustive JSON error mapper to stop compiling. Beta.99 also adds `--wizard` to the default built-in flag set; configuring `CliConfig` keeps the accepted flags aligned with wct's custom completion generators.

Users get stricter invalid-argument handling without an unexpected change to the documented CLI surface.

## Validation

- `bun run typecheck`
- `bun run src/index.ts --version`
- `bun run src/index.ts --help`
- `bun run src/index.ts list unexpected --json`
- confirmed `bun run src/index.ts --wizard` is rejected

Tests and lint were not run manually, per the repository's agent instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved built-in CLI options for help, version, completions, and log-level controls.
  * Added public CLI configuration support for improved command customization.

* **Bug Fixes**
  * Unexpected command-line arguments now report consistently as invalid options in JSON output.

* **Documentation**
  * Added upgrade guidance for recent Effect releases, including CLI behavior and compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->